### PR TITLE
feat: add get_session_stats() function for session analytics

### DIFF
--- a/neatlogs/__init__.py
+++ b/neatlogs/__init__.py
@@ -11,10 +11,10 @@ from .instrumentation.manager import setup_import_monitor
 import logging
 import atexit
 import threading
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 __version__ = "1.1.8"
-__all__ = ['init', 'get_tracker', 'add_tags', 'get_langchain_callback_handler']
+__all__ = ['init', 'get_tracker', 'add_tags', 'get_session_stats', 'get_langchain_callback_handler']
 
 # --- Global Tracker Instance and Initialization ---
 
@@ -116,6 +116,50 @@ def add_tags(tags: List[str]):
             "Tracker not initialized. Call neatlogs.init() first.")
 
     tracker.add_tags(tags)
+
+
+def get_session_stats() -> Dict:
+    """
+    Get statistics for all LLM calls in the current session.
+
+
+    Returns statistics including total calls, tokens, cost, and breakdowns
+    by provider and model.
+
+    Returns:
+        dict: Session statistics with keys:
+            - total_calls: Number of LLM calls
+            - total_tokens_input: Total input tokens
+            - total_tokens_output: Total output tokens
+            - total_tokens: Combined total tokens
+            - total_cost: Total cost in USD
+            - average_response_time: Average response time in seconds
+            - provider_breakdown: Stats per provider
+            - model_breakdown: Stats per model
+            - status_breakdown: Count by status (SUCCESS/FAILURE)
+
+    Example:
+        >>> import neatlogs
+        >>> neatlogs.init(api_key="key")
+        >>> # ... make some LLM calls ...
+        >>> stats = neatlogs.get_session_stats()
+        >>> print(f"Total calls: {stats['total_calls']}")
+        >>> print(f"Total cost: ${stats['total_cost']:.4f}")
+    """
+    tracker = get_tracker()
+    if not tracker:
+        return {
+            "total_calls": 0,
+            "total_tokens_input": 0,
+            "total_tokens_output": 0,
+            "total_tokens": 0,
+            "total_cost": 0.0,
+            "average_response_time": 0.0,
+            "provider_breakdown": {},
+            "model_breakdown": {},
+            "status_breakdown": {},
+        }
+    return tracker.get_session_stats()
 
 
 # --- Automatic Instrumentation Setup ---

--- a/neatlogs/core.py
+++ b/neatlogs/core.py
@@ -321,6 +321,79 @@ class LLMTracker:
                 "Neatlogs: Creating background thread to send call_data to server")
             self._send_data_to_server(call_data)
 
+    def get_session_stats(self) -> Dict:
+        """
+        Get statistics for all completed LLM calls in this session.
+
+        Returns:
+            Dict: Statistics including total_calls, tokens, cost, and breakdowns
+        """
+        with self._lock:
+            if not self._completed_calls:
+                return {
+                    "total_calls": 0,
+                    "total_tokens_input": 0,
+                    "total_tokens_output": 0,
+                    "total_tokens": 0,
+                    "total_cost": 0.0,
+                    "average_response_time": 0.0,
+                    "provider_breakdown": {},
+                    "model_breakdown": {},
+                    "status_breakdown": {},
+                }
+
+            total_calls = len(self._completed_calls)
+            total_prompt_tokens = sum(c.prompt_tokens for c in self._completed_calls)
+            total_completion_tokens = sum(c.completion_tokens for c in self._completed_calls)
+            total_tokens = total_prompt_tokens + total_completion_tokens
+            total_cost = sum(c.cost for c in self._completed_calls)
+
+            response_times = [
+                c.duration for c in self._completed_calls if c.duration > 0
+            ]
+            avg_response_time = sum(response_times) / len(response_times) if response_times else 0.0
+
+            provider_breakdown = {}
+            for c in self._completed_calls:
+                provider = c.provider or "unknown"
+                if provider not in provider_breakdown:
+                    provider_breakdown[provider] = {
+                        "calls": 0, "cost": 0.0, "tokens": 0
+                    }
+                provider_breakdown[provider]["calls"] += 1
+                provider_breakdown[provider]["cost"] += c.cost
+                provider_breakdown[provider]["tokens"] += c.total_tokens
+
+            model_breakdown = {}
+            for c in self._completed_calls:
+                model = c.model or "unknown"
+                if model not in model_breakdown:
+                    model_breakdown[model] = {
+                        "calls": 0, "cost": 0.0, "tokens": 0
+                    }
+                model_breakdown[model]["calls"] += 1
+                model_breakdown[model]["cost"] += c.cost
+                model_breakdown[model]["tokens"] += c.total_tokens
+
+            status_breakdown = {}
+            for c in self._completed_calls:
+                status = c.status or "unknown"
+                if status not in status_breakdown:
+                    status_breakdown[status] = 0
+                status_breakdown[status] += 1
+
+            return {
+                "total_calls": total_calls,
+                "total_tokens_input": total_prompt_tokens,
+                "total_tokens_output": total_completion_tokens,
+                "total_tokens": total_tokens,
+                "total_cost": round(total_cost, 6),
+                "average_response_time": round(avg_response_time, 3),
+                "provider_breakdown": provider_breakdown,
+                "model_breakdown": model_breakdown,
+                "status_breakdown": status_breakdown,
+            }
+
     def add_tags(self, tags: List[str]):
         """Add tags to the tracker."""
         with self._lock:


### PR DESCRIPTION
- Add get_session_stats() method to LLMTracker class in core.py
- Returns total_calls, token counts (input/output/total), total_cost
- Includes provider_breakdown and model_breakdown statistics
- Calculates average_response_time for completed calls
- Export new function in __init__.py public API