### PR TITLE
fix: resolve runtime crashes in CrewAI handler, streaming cost calculation, and missing requests dependency

### DIFF
--- a/neatlogs/core.py
+++ b/neatlogs/core.py
@@ -22,6 +22,9 @@ _current_framework_ctx = contextvars.ContextVar(
 # Context variable for parent span
 current_span_id_context = contextvars.ContextVar('current_span_id', default=None)
 
+# Context variable for agent name (used by CrewAI)
+_current_agent_name_ctx = contextvars.ContextVar('current_agent_name', default=None)
+
 
 # Context variable to suppress low-level patching
 _suppress_patching_ctx = contextvars.ContextVar(
@@ -41,6 +44,16 @@ def get_current_framework() -> Optional[str]:
 def clear_current_framework():
     """Clear the current framework context."""
     _current_framework_ctx.set(None)
+
+
+def set_current_agent_name(name: str):
+    """Set the current agent name for CrewAI tracking."""
+    _current_agent_name_ctx.set(name)
+
+
+def clear_current_agent_name():
+    """Clear the current agent name."""
+    _current_agent_name_ctx.set(None)
 
 
 def suppress_patching():

--- a/neatlogs/event_handlers/anthropic.py
+++ b/neatlogs/event_handlers/anthropic.py
@@ -14,6 +14,7 @@ from ..semconv import (
     LLMAttributes, MessageAttributes, LLMRequestTypeValues, LLMEvents,
     format_tools_for_attribute, extract_tool_calls_data
 )
+from ..token_counting import estimate_cost
 
 
 class AnthropicHandler(BaseEventHandler):
@@ -216,7 +217,7 @@ class AnthropicHandler(BaseEventHandler):
             span.prompt_tokens = response_data.get('prompt_tokens', 0)
             span.completion_tokens = response_data.get('completion_tokens', 0)
             span.total_tokens = response_data.get('total_tokens', 0)
-            span.cost = self.estimate_cost(
+            span.cost = estimate_cost(
                 span.model, span.prompt_tokens, span.completion_tokens)
 
         self.handle_call_end(span, final_message, success=True)

--- a/neatlogs/event_handlers/google_genai.py
+++ b/neatlogs/event_handlers/google_genai.py
@@ -9,6 +9,7 @@ Enhanced with comprehensive tracking including streaming support.
 import logging
 from typing import Dict, List, Any, Optional
 from .base import BaseEventHandler
+from ..token_counting import estimate_cost
 
 
 class GoogleGenAIHandler(BaseEventHandler):
@@ -215,7 +216,7 @@ class GoogleGenAIHandler(BaseEventHandler):
                 "completion_tokens", len(span.completion.split())
             )
             span.total_tokens = response_data.get("total_tokens", 0)
-            span.cost = self.estimate_cost(
+            span.cost = estimate_cost(
                 span.model, span.prompt_tokens, span.completion_tokens
             )
 

--- a/neatlogs/event_handlers/litellm.py
+++ b/neatlogs/event_handlers/litellm.py
@@ -10,6 +10,7 @@ Enhanced with comprehensive tracking including streaming support.
 import logging
 from typing import Dict, List, Any, Optional
 from .base import BaseEventHandler
+from ..token_counting import estimate_cost
 
 
 class LiteLLMHandler(BaseEventHandler):
@@ -157,7 +158,7 @@ class LiteLLMHandler(BaseEventHandler):
             span.prompt_tokens = response_data.get('prompt_tokens', 0)
             span.completion_tokens = response_data.get('completion_tokens', 0)
             span.total_tokens = response_data.get('total_tokens', 0)
-            span.cost = self.estimate_cost(
+            span.cost = estimate_cost(
                 span.model, span.prompt_tokens, span.completion_tokens)
 
         self.handle_call_end(span, final_chunk, success=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 requires-python = ">=3.8"
-dependencies = []
+dependencies = ["requests"]
 
 [project.urls]
 Homepage = "https://github.com/NeatLogs/neatlogs"


### PR DESCRIPTION

## Summary

I went through the codebase and found 3 bugs that will crash the library at runtime. These are not edge cases, they hit you the moment you try to use CrewAI integration or stream with Anthropic/Google/LiteLLM. All three fixes are small and independent of each other, but I've clubbed them together since they're all crash fixes.

---

## Bug 1: CrewAI handler crashes on import itself

**The issue:**
`crewai.py` (line 11) imports `set_current_agent_name` and `clear_current_agent_name` from `core.py`, but these functions were never actually defined there. So the moment someone does `from neatlogs.event_handlers.crewai import CrewAIHandler`, it throws an `ImportError` and the handler is basically unusable.

The error:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/neatlogs/neatlogs/event_handlers/crewai.py", line 11, in <module>
    from ..core import LLMSpan, current_span_id_context, set_current_agent_name, clear_current_agent_name
ImportError: cannot import name 'set_current_agent_name' from 'neatlogs.core'
```

**What I did:**
Added the missing pieces in `neatlogs/core.py`:
- A new context variable `_current_agent_name_ctx` to track the active agent name
- `set_current_agent_name(name)` to set it
- `clear_current_agent_name()` to clear it

No changes were needed in `crewai.py` because the imports there were already correct, the functions just needed to exist on the other side.

---

## Bug 2: Streaming handlers crash when calculating cost

**The issue:**
In `AnthropicHandler`, `GoogleGenAIHandler`, and `LiteLLMHandler`, the `finalize_stream_span()` method calls `self.estimate_cost(...)`. But `estimate_cost` is not a method on `BaseEventHandler` or any of these classes. It's a standalone function in `token_counting.py`. So whenever a stream finishes and tries to calculate cost, it blows up with `AttributeError`.

`base.py` already uses it correctly as a standalone function call `estimate_cost(...)` (line ~117). These three handlers just got it wrong.

**What I did:**
In all 3 files:
- Changed `self.estimate_cost(` to `estimate_cost(`
- Added `from ..token_counting import estimate_cost` at the top

Files changed:
- `neatlogs/event_handlers/anthropic.py`
- `neatlogs/event_handlers/google_genai.py`
- `neatlogs/event_handlers/litellm.py`

---

## Bug 3: `requests` not declared as a dependency

**The issue:**
`core.py` does `import requests` and uses `requests.post(...)` to send telemetry data to the server. But `pyproject.toml` has `dependencies = []`, completely empty. So if someone does a fresh `pip install neatlogs`, it installs fine but crashes at runtime when it tries to send any data. Most developers won't notice this locally because `requests` is usually already installed, but in a clean environment it will definitely fail.

**What I did:**
Changed `dependencies = []` to `dependencies = ["requests"]` in `pyproject.toml`.

---

## How I tested

- `from neatlogs.event_handlers.crewai import CrewAIHandler` imports without errors now
- No `self.estimate_cost` references remain in the codebase
- `requests` is listed in `pyproject.toml` dependencies
- All handlers import successfully: `CrewAIHandler`, `AnthropicHandler`, `GoogleGenAIHandler`, `LiteLLMHandler`, `OpenAIHandler`, `AzureOpenAIHandler`

---

## Note

The `LangChainHandler` import still fails due to a missing `langchain_core` dependency, that's a pre-existing issue and not related to this PR.
