### PR TITLE
chore: use ingest.neatlogs.com endpoint

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -188,7 +188,7 @@ Pass keys to `instrumentations` in `neatlogs.init()`. Install extras when noted.
 
 ```bash
 NEATLOGS_API_KEY=your-api-key
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com   # optional — this is the default
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com   # optional — this is the default
 ```
 
 Get your API key from the [NeatLogs dashboard](https://app.neatlogs.com). Full `init()` options: [reference](https://docs.neatlogs.com/reference/init-reference).

--- a/examples/sdk_examples/51_milvus_vector_search.py
+++ b/examples/sdk_examples/51_milvus_vector_search.py
@@ -71,7 +71,7 @@ DOCUMENTS = [
 # ---------------------------------------------------------------------------
 neatlogs.init(
     api_key=os.getenv("NEATLOGS_API_KEY"),
-    endpoint=os.getenv("NEATLOGS_ENDPOINT", "http://staging-cloud.neatlogs.com/api/data/v4/batch"),
+    endpoint=os.getenv("NEATLOGS_ENDPOINT", "https://ingest.neatlogs.com/api/data/v4/batch"),
     workflow_name="milvus-vector-search",
     tags=[
         "sdk-examples",

--- a/examples/sdk_examples/anthropic_multiagent/.env.example
+++ b/examples/sdk_examples/anthropic_multiagent/.env.example
@@ -1,5 +1,5 @@
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 AWS_ACCESS_KEY_ID=your_aws_access_key_id
 AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key

--- a/examples/sdk_examples/detection_demo/.env.example
+++ b/examples/sdk_examples/detection_demo/.env.example
@@ -1,6 +1,6 @@
 # NeatLogs (required)
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 # Azure OpenAI (required when USE_AZURE=true)
 AZURE_OPENAI_API_KEY=your_azure_openai_api_key_here

--- a/examples/sdk_examples/google_genai_multiagent/.env.example
+++ b/examples/sdk_examples/google_genai_multiagent/.env.example
@@ -1,4 +1,4 @@
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 GOOGLE_API_KEY=your_google_api_key_here

--- a/examples/sdk_examples/langchain_react/.env.example
+++ b/examples/sdk_examples/langchain_react/.env.example
@@ -1,5 +1,5 @@
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 AWS_ACCESS_KEY_ID=your_aws_access_key_id
 AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key

--- a/examples/sdk_examples/langgraph_multiagent/.env.example
+++ b/examples/sdk_examples/langgraph_multiagent/.env.example
@@ -1,5 +1,5 @@
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 AZURE_OPENAI_API_KEY=your_azure_openai_api_key

--- a/examples/sdk_examples/langgraph_research_assistant/.env.example
+++ b/examples/sdk_examples/langgraph_research_assistant/.env.example
@@ -1,5 +1,5 @@
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 AZURE_OPENAI_API_KEY=your_azure_openai_api_key

--- a/examples/sdk_examples/marketing_strategy_demo/.env.example
+++ b/examples/sdk_examples/marketing_strategy_demo/.env.example
@@ -1,5 +1,5 @@
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 AZURE_OPENAI_API_KEY=your_azure_openai_api_key

--- a/examples/sdk_examples/neatlogs_support_bot/.env.example
+++ b/examples/sdk_examples/neatlogs_support_bot/.env.example
@@ -1,5 +1,5 @@
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 AZURE_OPENAI_API_KEY=your_azure_openai_api_key

--- a/examples/sdk_examples/openai_multiagent/.env.example
+++ b/examples/sdk_examples/openai_multiagent/.env.example
@@ -1,5 +1,5 @@
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 AZURE_OPENAI_API_KEY=your_azure_openai_api_key

--- a/examples/sdk_examples/reasoning_model_workflow/.env.example
+++ b/examples/sdk_examples/reasoning_model_workflow/.env.example
@@ -1,5 +1,5 @@
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 AZURE_OPENAI_API_KEY=your_azure_openai_api_key

--- a/examples/sdk_examples/support_copilot_demo/.env.example
+++ b/examples/sdk_examples/support_copilot_demo/.env.example
@@ -1,6 +1,6 @@
 # NeatLogs (required)
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 # Azure OpenAI (required)
 AZURE_OPENAI_API_KEY=your_azure_openai_api_key_here

--- a/examples/sdk_examples/support_copilot_demo_triaged/.env.example
+++ b/examples/sdk_examples/support_copilot_demo_triaged/.env.example
@@ -1,6 +1,6 @@
 # NeatLogs (required)
 NEATLOGS_API_KEY=your_neatlogs_api_key_here
-NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com
+NEATLOGS_ENDPOINT=https://ingest.neatlogs.com
 
 # Azure OpenAI (required)
 AZURE_OPENAI_API_KEY=your_azure_openai_api_key_here

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -91,7 +91,7 @@ def _span_limits_for_capture_everything() -> SpanLimits:
 
 def init(
     api_key: Optional[str] = None,
-    endpoint: str = "https://staging-cloud.neatlogs.com",
+    endpoint: str = "https://ingest.neatlogs.com",
     workflow_name: Optional[str] = None,
     session_id: Optional[str] = None,
     auto_session: bool = False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.poetry]
 name = "neatlogs"
-version = "1.3.6"
+version = "1.3.7"
 description = "A Python package for extracting and managing LLM logs to build a collaborative workspace"
 readme = "README.MD"
 license = "MIT"
@@ -139,7 +139,7 @@ milvus = ["pymilvus", "milvus-lite"]
 
 [project]
 name = "neatlogs"
-version = "1.3.6"
+version = "1.3.7"
 description = "A Python package for extracting and managing LLM logs to build a collaborative workspace"
 readme = "README.MD"
 license = {text = "MIT"}

--- a/skills/neatlogs/SKILL.md
+++ b/skills/neatlogs/SKILL.md
@@ -170,7 +170,7 @@ For non-FastAPI servers, hook `neatlogs.flush()` + `neatlogs.shutdown()` into th
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `api_key` | `str` | `None` | API key (or set `NEATLOGS_API_KEY` env var). If neither is set, spans are created locally but **silently not exported** — no error is raised |
-| `endpoint` | `str` | `"https://staging-cloud.neatlogs.com"` | Backend base URL. Trace export is normalized to `{base_url}/v1/traces` |
+| `endpoint` | `str` | `"https://ingest.neatlogs.com"` | Backend base URL. Trace export is normalized to `{base_url}/v1/traces` |
 | `workflow_name` | `str` | `None` | Name for this workflow / application |
 | `instrumentations` | `list[str]` | `None` | Libraries to auto-instrument (e.g. `["openai", "langchain"]`) |
 | `tags` | `list[str]` | `None` | Tags for filtering in dashboard |

--- a/tests/manual/test_async_flush.py
+++ b/tests/manual/test_async_flush.py
@@ -27,7 +27,7 @@ import neatlogs
 async def main():
     neatlogs.init(
         api_key=None,  # reads NEATLOGS_API_KEY from env
-        endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://staging-cloud.neatlogs.com"),
+        endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://ingest.neatlogs.com"),
         workflow_name="test-async-flush",
     )
 

--- a/tests/manual/test_async_trace.py
+++ b/tests/manual/test_async_trace.py
@@ -29,7 +29,7 @@ from neatlogs import SystemPromptTemplate, UserPromptTemplate
 async def main():
     neatlogs.init(
         api_key=None,  # reads NEATLOGS_API_KEY from env
-        endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://staging-cloud.neatlogs.com"),
+        endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://ingest.neatlogs.com"),
         workflow_name="test-async-trace",
     )
 

--- a/tests/manual/test_http_zero_span_repro.py
+++ b/tests/manual/test_http_zero_span_repro.py
@@ -23,7 +23,7 @@ Run:
     NEATLOGS_API_KEY=<your-key> python tests/manual/test_http_zero_span_repro.py
 
 Optional:
-    NEATLOGS_ENDPOINT=https://staging-cloud.neatlogs.com python tests/manual/test_http_zero_span_repro.py
+    NEATLOGS_ENDPOINT=https://ingest.neatlogs.com python tests/manual/test_http_zero_span_repro.py
 
 Dashboard checks:
     - If a row appears for the standalone outgoing HTTP request, the backend/UI is
@@ -47,7 +47,7 @@ def non_ai_outgoing_http_only() -> int:
 def main() -> None:
     neatlogs.init(
         api_key=None,  # reads NEATLOGS_API_KEY from env
-        endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://staging-cloud.neatlogs.com"),
+        endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://ingest.neatlogs.com"),
         workflow_name="zero-span-non-ai-http-repro",
         instrumentations=[],
     )

--- a/tests/manual/test_litellm.py
+++ b/tests/manual/test_litellm.py
@@ -33,7 +33,7 @@ from neatlogs import SystemPromptTemplate, UserPromptTemplate
 
 neatlogs.init(
     api_key=None,  # reads NEATLOGS_API_KEY from env
-    endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://staging-cloud.neatlogs.com"),
+    endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://ingest.neatlogs.com"),
     workflow_name="test-litellm",
     instrumentations=["litellm"],
 )

--- a/tests/manual/test_manual_llm_span.py
+++ b/tests/manual/test_manual_llm_span.py
@@ -33,7 +33,7 @@ import neatlogs
 def main():
     neatlogs.init(
         api_key=None,  # reads NEATLOGS_API_KEY from env
-        endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://staging-cloud.neatlogs.com"),
+        endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://ingest.neatlogs.com"),
         workflow_name="test-manual-llm-span",
     )
 

--- a/tests/manual/test_pii_masking.py
+++ b/tests/manual/test_pii_masking.py
@@ -40,7 +40,7 @@ def redact_pii(span):
 def main():
     neatlogs.init(
         api_key=None,  # reads NEATLOGS_API_KEY from env
-        endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://staging-cloud.neatlogs.com"),
+        endpoint=os.environ.get("NEATLOGS_ENDPOINT", "https://ingest.neatlogs.com"),
         workflow_name="test-pii-masking",
         mask=redact_pii,
     )


### PR DESCRIPTION
## Summary
- Changes the Python SDK default endpoint to `https://ingest.neatlogs.com`.
- Bumps the Python package version from `1.3.6` to `1.3.7`.
- Updates README, skill docs, examples, and manual tests to use the new ingest host.
- Preserves existing API paths such as `/api/data/v4/batch` where examples already included them.

## Test Plan
- Verified no tracked file in this repo contains `staging-cloud`.
- Verified no tracked file uses `http://ingest.neatlogs.com`.
- Ran `git diff --check`.
- Verified `[tool.poetry]` and `[project]` versions in `pyproject.toml` both equal `1.3.7`.
- Ran `python3 -m compileall neatlogs/init.py examples/sdk_examples/51_milvus_vector_search.py tests/manual/test_async_flush.py tests/manual/test_async_trace.py tests/manual/test_http_zero_span_repro.py tests/manual/test_litellm.py tests/manual/test_manual_llm_span.py tests/manual/test_pii_masking.py`.

## Release Notes
- After merge, publish `neatlogs==1.3.7` to PyPI from the canonical release branch.
- `uv run pytest tests/unit/test_package_version.py` currently cannot resolve the repo environment because optional extras `crewai` and `hermes` are mutually unsatisfiable under the current dependency graph; the version invariant was checked directly from `pyproject.toml`.
