### PR TITLE
Support instrumentation presets in init

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -140,6 +140,18 @@ API reference: [docs.neatlogs.com](https://docs.neatlogs.com)
 
 Pass keys to `instrumentations` in `neatlogs.init()`. Install extras when noted.
 
+You can also pass preset tags when you want NeatLogs to instrument a whole category:
+
+```python
+neatlogs.init(
+    api_key="your-api-key",
+    workflow_name="my-agent",
+    instrumentations=["llm", "agent"],
+)
+```
+
+Preset tags: `llm`, `embedding`, `retrieval`, `agent`, `tool`, `http`, and `framework`.
+
 ### LLM providers
 
 | Provider | Key | Install |

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -31,6 +31,7 @@ from ._wrap_utils import _normalize_traces_endpoint
 from .core.logger import get_logger
 from .core.span_processor import NeatlogsSpanProcessor
 from .instrumentation.manager import InstrumentationManager
+from .instrumentation.registry import INSTRUMENTATION_REGISTRY
 from .version import __version__
 
 logger = get_logger()
@@ -159,6 +160,20 @@ def _span_limits_for_capture_everything() -> SpanLimits:
     return SpanLimits(max_span_attributes=_DEFAULT_MAX_SPAN_ATTRIBUTES)
 
 
+def _resolve_instrumentations(instrumentations: List[str]) -> tuple[List[str], List[str]]:
+    instrumentation_tags = []
+    libraries = []
+    known_tags = INSTRUMENTATION_REGISTRY["tags"]
+
+    for entry in instrumentations:
+        if entry in known_tags:
+            instrumentation_tags.append(entry)
+        else:
+            libraries.append(entry)
+
+    return instrumentation_tags, libraries
+
+
 def init(
     api_key: Optional[str] = None,
     endpoint: str = "https://ingest.neatlogs.com",
@@ -198,7 +213,7 @@ def init(
                  wrapper-only code via ``with neatlogs.identify(session_id=...,
                  end_user_id=...)``.
         tags: Global tags for all traces (list of strings only, e.g., ['production', 'api-v2'])
-        instrumentations: Specific libraries to instrument
+        instrumentations: Specific libraries or preset tags to instrument
         sample_rate: Trace sampling rate (0.0-1.0)
         batch_size: Max spans per batch
         flush_interval: Seconds between batch flushes
@@ -612,7 +627,8 @@ def init(
     manager.instrument_http()
 
     if instrumentations:
-        manager.instrument(libraries=instrumentations)
+        instrumentation_tags, libraries = _resolve_instrumentations(instrumentations)
+        manager.instrument(tags=instrumentation_tags, libraries=libraries)
         if debug:
             logger.debug(f"Instrumented libraries: {manager.instrumented}")
 

--- a/tests/unit/test_instrumentation_presets.py
+++ b/tests/unit/test_instrumentation_presets.py
@@ -1,0 +1,17 @@
+from neatlogs.init import _resolve_instrumentations
+
+
+def test_resolve_instrumentations_keeps_explicit_libraries():
+    assert _resolve_instrumentations(["openai"]) == ([], ["openai"])
+
+
+def test_resolve_instrumentations_extracts_preset_tags():
+    assert _resolve_instrumentations(["llm", "agent"]) == (["llm", "agent"], [])
+
+
+def test_resolve_instrumentations_splits_mixed_entries():
+    assert _resolve_instrumentations(["llm", "openai"]) == (["llm"], ["openai"])
+
+
+def test_resolve_instrumentations_keeps_unknown_entries_as_libraries():
+    assert _resolve_instrumentations(["custom_sdk"]) == ([], ["custom_sdk"])


### PR DESCRIPTION
## Summary

Fixes #21.

This PR lets `neatlogs.init(instrumentations=["llm", "agent"])` use the registry tags that already exist in the instrumentation manager.

The resolver now splits `instrumentations` into preset tags and explicit library names. Known tags go through the tag path, while library keys and unknown values keep the existing library behavior.

Also included:
- README docs for the supported preset tags
- focused resolver tests for tag-only, library-only, mixed, and unknown inputs

## Testing

- `uv run --no-project --python 3.13 --with pytest --with opentelemetry-api --with opentelemetry-sdk --with opentelemetry-exporter-otlp-proto-http --with opentelemetry-instrumentation-threading --with opentelemetry-instrumentation-logging --with opentelemetry-instrumentation-requests --with opentelemetry-instrumentation-httpx --with opentelemetry-instrumentation-urllib3 --with opentelemetry-instrumentation-aiohttp-client python -m pytest tests/unit/test_instrumentation_presets.py -q`
- `uv run --no-project --python 3.13 --with black --with isort python -m black --check neatlogs/init.py tests/unit/test_instrumentation_presets.py`
- `uv run --no-project --python 3.13 --with isort python -m isort --check-only neatlogs/init.py tests/unit/test_instrumentation_presets.py`

`tests/unit` still has an unrelated failure in `tests/unit/test_log_filter.py::test_filter_passes_normal_record` with the latest OpenTelemetry SDK. I left that out of this PR so the change stays focused on presets.
