### PR TITLE
fix: log filter forward emit order and code line capture on Python 3.13

### DIFF
--- a/neatlogs/core/log_exporter.py
+++ b/neatlogs/core/log_exporter.py
@@ -96,10 +96,10 @@ class NeatlogsLogFilter(LogRecordProcessor):
 
     def _forward_emit(self, log_data: "LogData") -> None:
         """Forward to downstream processor (emit vs on_emit varies by OTel SDK version)."""
-        if hasattr(self._downstream, "emit"):
-            self._downstream.emit(log_data)
-        elif hasattr(self._downstream, "on_emit"):
+        if hasattr(self._downstream, "on_emit"):
             self._downstream.on_emit(log_data)
+        elif hasattr(self._downstream, "emit"):
+            self._downstream.emit(log_data)
 
     def emit(self, log_data: "LogData") -> None:
         lr = log_data.log_record

--- a/neatlogs/core/log_exporter.py
+++ b/neatlogs/core/log_exporter.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 from opentelemetry.sdk._logs import LogRecordProcessor
 
 if TYPE_CHECKING:
-    from opentelemetry.sdk._logs import LogData, LoggerProvider
+    from opentelemetry.sdk._logs import LogData
 
 # Python 3.10+ exposes stdlib module names directly; fall back to empty set on older versions.
 _STDLIB_MODULE_NAMES: frozenset = getattr(sys, "stdlib_module_names", frozenset())

--- a/neatlogs/decorators/_base.py
+++ b/neatlogs/decorators/_base.py
@@ -56,7 +56,9 @@ def _capture_code_attrs(func: Callable[..., Any]) -> Dict[str, Any]:
         _, lineno = inspect.getsourcelines(target)
         attrs["code.line.number"] = lineno
     except (TypeError, OSError):
-        pass
+        code = getattr(target, "__code__", None)
+        if code is not None:
+            attrs["code.line.number"] = code.co_firstlineno
     module = getattr(target, "__module__", None)
     if module:
         attrs["code.namespace"] = module

--- a/tests/unit/test_code_params_capture.py
+++ b/tests/unit/test_code_params_capture.py
@@ -30,6 +30,14 @@ def _install(tracer_provider):
     trace.set_tracer_provider(tracer_provider)
 
 
+def _expected_line_number(func):
+    target = inspect.unwrap(func)
+    try:
+        return inspect.getsourcelines(target)[1]
+    except (TypeError, OSError):
+        return target.__code__.co_firstlineno
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -76,9 +84,7 @@ def test_sync_decorator_sets_code_line_number(tracer_provider, in_memory_span_ex
     def my_agent():
         pass
 
-    expected_lineno = inspect.getsourcelines(
-        my_agent.__wrapped__ if hasattr(my_agent, "__wrapped__") else my_agent
-    )[1]
+    expected_lineno = _expected_line_number(my_agent)
 
     my_agent()
 
@@ -209,7 +215,7 @@ def test_stacked_decorator_reports_inner_function_location(
     def inner_tool():
         pass
 
-    expected_lineno = inspect.getsourcelines(inspect.unwrap(inner_tool))[1]
+    expected_lineno = _expected_line_number(inner_tool)
 
     inner_tool()
 


### PR DESCRIPTION
Fixes #26. Prefer on_emit in NeatlogsLogFilter._forward_emit. Fall back to co_firstlineno for code.line.number when getsourcelines fails on Python 3.13. pytest tests/unit: 43 passed.