### PR TITLE
fix: Anthropic wrapper fail-open when telemetry setup fails

### DIFF
--- a/neatlogs/anthropic.py
+++ b/neatlogs/anthropic.py
@@ -665,12 +665,24 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
             async def patched_parse(*args, **kwargs):
                 if is_suppressed():
                     return await orig_parse(*args, **kwargs)
-                span = _start_message_span(kwargs, "anthropic.messages.parse", structured=True)
-                start = time.perf_counter()
+                span = None
+                try:
+                    span = _start_message_span(kwargs, "anthropic.messages.parse", structured=True)
+                    start = time.perf_counter()
+                except Exception:
+                    if span is not None:
+                        try:
+                            span.end()
+                        except Exception:
+                            pass
+                    return await orig_parse(*args, **kwargs)
                 try:
                     resp = await orig_parse(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e)
+                    try:
+                        _err(span, e)
+                    except Exception:
+                        pass
                     raise
                 _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
                 return resp
@@ -680,12 +692,24 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
             def patched_parse(*args, **kwargs):
                 if is_suppressed():
                     return orig_parse(*args, **kwargs)
-                span = _start_message_span(kwargs, "anthropic.messages.parse", structured=True)
-                start = time.perf_counter()
+                span = None
+                try:
+                    span = _start_message_span(kwargs, "anthropic.messages.parse", structured=True)
+                    start = time.perf_counter()
+                except Exception:
+                    if span is not None:
+                        try:
+                            span.end()
+                        except Exception:
+                            pass
+                    return orig_parse(*args, **kwargs)
                 try:
                     resp = orig_parse(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e)
+                    try:
+                        _err(span, e)
+                    except Exception:
+                        pass
                     raise
                 _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
                 return resp
@@ -703,19 +727,31 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
             async def patched_count(*args, **kwargs):
                 if is_suppressed():
                     return await orig_count(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="anthropic.messages.count_tokens",
-                    attributes={
-                        "neatlogs.span.kind": "llm",
-                        "neatlogs.llm.provider": "anthropic",
-                        "neatlogs.llm.task": "count_tokens",
-                        "neatlogs.llm.model_name": kwargs.get("model", ""),
-                    },
-                )
+                span = None
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="anthropic.messages.count_tokens",
+                        attributes={
+                            "neatlogs.span.kind": "llm",
+                            "neatlogs.llm.provider": "anthropic",
+                            "neatlogs.llm.task": "count_tokens",
+                            "neatlogs.llm.model_name": kwargs.get("model", ""),
+                        },
+                    )
+                except Exception:
+                    if span is not None:
+                        try:
+                            span.end()
+                        except Exception:
+                            pass
+                    return await orig_count(*args, **kwargs)
                 try:
                     resp = await orig_count(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e)
+                    try:
+                        _err(span, e)
+                    except Exception:
+                        pass
                     raise
                 _finalize_count_tokens(span, resp)
                 return resp
@@ -725,19 +761,31 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
             def patched_count(*args, **kwargs):
                 if is_suppressed():
                     return orig_count(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="anthropic.messages.count_tokens",
-                    attributes={
-                        "neatlogs.span.kind": "llm",
-                        "neatlogs.llm.provider": "anthropic",
-                        "neatlogs.llm.task": "count_tokens",
-                        "neatlogs.llm.model_name": kwargs.get("model", ""),
-                    },
-                )
+                span = None
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="anthropic.messages.count_tokens",
+                        attributes={
+                            "neatlogs.span.kind": "llm",
+                            "neatlogs.llm.provider": "anthropic",
+                            "neatlogs.llm.task": "count_tokens",
+                            "neatlogs.llm.model_name": kwargs.get("model", ""),
+                        },
+                    )
+                except Exception:
+                    if span is not None:
+                        try:
+                            span.end()
+                        except Exception:
+                            pass
+                    return orig_count(*args, **kwargs)
                 try:
                     resp = orig_count(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e)
+                    try:
+                        _err(span, e)
+                    except Exception:
+                        pass
                     raise
                 _finalize_count_tokens(span, resp)
                 return resp

--- a/neatlogs/anthropic.py
+++ b/neatlogs/anthropic.py
@@ -77,16 +77,6 @@ def wrap_async_anthropic_client(client: Any) -> Any:
     return client
 
 
-def _resource(client: Any, *path):
-    """Safely walk a nested resource path."""
-    obj = client
-    for p in path:
-        obj = getattr(obj, p, None)
-        if obj is None:
-            return None
-    return obj
-
-
 def _safe(fn, resource, **kw):
     """Call a patch fn only if the resource exists; never raise."""
     if resource is None:

--- a/neatlogs/anthropic.py
+++ b/neatlogs/anthropic.py
@@ -118,6 +118,7 @@ def _patch_messages(messages: Any) -> None:
         if is_suppressed():
             return orig_create(*args, **kwargs)
 
+        span = None
         try:
             model = kwargs.get("model", "")
             input_messages = kwargs.get("messages", [])
@@ -140,12 +141,20 @@ def _patch_messages(messages: Any) -> None:
 
             start = time.perf_counter()
         except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
             return orig_create(*args, **kwargs)
 
         try:
             response = orig_create(*args, **kwargs)
         except Exception as e:
-            _record_error(span, e)
+            try:
+                _record_error(span, e)
+            except Exception:
+                pass
             raise
 
         if is_stream:
@@ -158,10 +167,12 @@ def _patch_messages(messages: Any) -> None:
     messages.create = patched_create
 
     if orig_stream:
+
         def patched_stream(*args, **kwargs):
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
 
+            span = None
             try:
                 model = kwargs.get("model", "")
                 input_messages = kwargs.get("messages", [])
@@ -180,11 +191,23 @@ def _patch_messages(messages: Any) -> None:
                 )
 
                 _set_input_attributes(span, input_messages, system, kwargs)
-
-                stream_mgr = orig_stream(*args, **kwargs)
-                return _SyncStreamManagerWrapper(stream_mgr, span)
             except Exception:
+                if span is not None:
+                    try:
+                        span.end()
+                    except Exception:
+                        pass
                 return orig_stream(*args, **kwargs)
+
+            try:
+                stream_mgr = orig_stream(*args, **kwargs)
+            except Exception:
+                try:
+                    span.end()
+                except Exception:
+                    pass
+                raise
+            return _SyncStreamManagerWrapper(stream_mgr, span)
 
         messages.stream = patched_stream
 
@@ -202,6 +225,7 @@ def _patch_async_messages(messages: Any) -> None:
         if is_suppressed():
             return await orig_create(*args, **kwargs)
 
+        span = None
         try:
             model = kwargs.get("model", "")
             input_messages = kwargs.get("messages", [])
@@ -224,12 +248,20 @@ def _patch_async_messages(messages: Any) -> None:
 
             start = time.perf_counter()
         except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
             return await orig_create(*args, **kwargs)
 
         try:
             response = await orig_create(*args, **kwargs)
         except Exception as e:
-            _record_error(span, e)
+            try:
+                _record_error(span, e)
+            except Exception:
+                pass
             raise
 
         if is_stream:
@@ -242,10 +274,12 @@ def _patch_async_messages(messages: Any) -> None:
     messages.create = patched_create
 
     if orig_stream:
+
         def patched_stream(*args, **kwargs):
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
 
+            span = None
             try:
                 model = kwargs.get("model", "")
                 input_messages = kwargs.get("messages", [])
@@ -264,11 +298,23 @@ def _patch_async_messages(messages: Any) -> None:
                 )
 
                 _set_input_attributes(span, input_messages, system, kwargs)
-
-                stream_mgr = orig_stream(*args, **kwargs)
-                return _AsyncStreamManagerWrapper(stream_mgr, span)
             except Exception:
+                if span is not None:
+                    try:
+                        span.end()
+                    except Exception:
+                        pass
                 return orig_stream(*args, **kwargs)
+
+            try:
+                stream_mgr = orig_stream(*args, **kwargs)
+            except Exception:
+                try:
+                    span.end()
+                except Exception:
+                    pass
+                raise
+            return _AsyncStreamManagerWrapper(stream_mgr, span)
 
         messages.stream = patched_stream
 
@@ -760,14 +806,26 @@ def _patch_legacy_completions(completions: Any, is_async: bool) -> None:
         async def patched(*args, **kwargs):
             if is_suppressed():
                 return await orig(*args, **kwargs)
-            span = get_provider_tracer().start_span(
-                name="anthropic.completions.create", attributes=_attrs(kwargs)
-            )
-            start = time.perf_counter()
+            span = None
+            try:
+                span = get_provider_tracer().start_span(
+                    name="anthropic.completions.create", attributes=_attrs(kwargs)
+                )
+                start = time.perf_counter()
+            except Exception:
+                if span is not None:
+                    try:
+                        span.end()
+                    except Exception:
+                        pass
+                return await orig(*args, **kwargs)
             try:
                 resp = await orig(*args, **kwargs)
             except Exception as e:
-                _err(span, e)
+                try:
+                    _err(span, e)
+                except Exception:
+                    pass
                 raise
             _finalize(span, resp, (time.perf_counter() - start) * 1000)
             return resp
@@ -777,14 +835,26 @@ def _patch_legacy_completions(completions: Any, is_async: bool) -> None:
         def patched(*args, **kwargs):
             if is_suppressed():
                 return orig(*args, **kwargs)
-            span = get_provider_tracer().start_span(
-                name="anthropic.completions.create", attributes=_attrs(kwargs)
-            )
-            start = time.perf_counter()
+            span = None
+            try:
+                span = get_provider_tracer().start_span(
+                    name="anthropic.completions.create", attributes=_attrs(kwargs)
+                )
+                start = time.perf_counter()
+            except Exception:
+                if span is not None:
+                    try:
+                        span.end()
+                    except Exception:
+                        pass
+                return orig(*args, **kwargs)
             try:
                 resp = orig(*args, **kwargs)
             except Exception as e:
-                _err(span, e)
+                try:
+                    _err(span, e)
+                except Exception:
+                    pass
                 raise
             _finalize(span, resp, (time.perf_counter() - start) * 1000)
             return resp

--- a/neatlogs/anthropic.py
+++ b/neatlogs/anthropic.py
@@ -684,7 +684,10 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
                     except Exception:
                         pass
                     raise
-                _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+                _finish_ok(
+                    span,
+                    lambda: _finalize_response(span, resp, (time.perf_counter() - start) * 1000),
+                )
                 return resp
 
         else:
@@ -711,7 +714,10 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
                     except Exception:
                         pass
                     raise
-                _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+                _finish_ok(
+                    span,
+                    lambda: _finalize_response(span, resp, (time.perf_counter() - start) * 1000),
+                )
                 return resp
 
         messages.parse = patched_parse
@@ -753,7 +759,7 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
                     except Exception:
                         pass
                     raise
-                _finalize_count_tokens(span, resp)
+                _finish_ok(span, lambda: _finalize_count_tokens(span, resp))
                 return resp
 
         else:
@@ -787,7 +793,7 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
                     except Exception:
                         pass
                     raise
-                _finalize_count_tokens(span, resp)
+                _finish_ok(span, lambda: _finalize_count_tokens(span, resp))
                 return resp
 
         messages.count_tokens = patched_count

--- a/neatlogs/anthropic.py
+++ b/neatlogs/anthropic.py
@@ -97,6 +97,26 @@ def _safe(fn, resource, **kw):
         pass
 
 
+def _record_error(span: Any, error: Exception) -> None:
+    try:
+        span.set_status(StatusCode.ERROR, str(error))
+        span.record_exception(error)
+        span.end()
+    except Exception:
+        pass
+
+
+def _finish_ok(span: Any, finalize) -> None:
+    try:
+        finalize()
+    except Exception:
+        try:
+            span.set_status(StatusCode.OK)
+            span.end()
+        except Exception:
+            pass
+
+
 def _patch_messages(messages: Any) -> None:
     if getattr(messages, "_neatlogs_patched", False):
         return
@@ -108,53 +128,11 @@ def _patch_messages(messages: Any) -> None:
         if is_suppressed():
             return orig_create(*args, **kwargs)
 
-        model = kwargs.get("model", "")
-        input_messages = kwargs.get("messages", [])
-        system = kwargs.get("system")
-        is_stream = kwargs.get("stream", False)
-
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="anthropic.messages.create",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "anthropic",
-                "neatlogs.llm.system": "anthropic",
-                "neatlogs.llm.model_name": model,
-                "neatlogs.llm.is_streaming": is_stream,
-            },
-        )
-
-        _set_input_attributes(span, input_messages, system, kwargs)
-
-        start = time.perf_counter()
-
         try:
-            response = orig_create(*args, **kwargs)
-        except Exception as e:
-            span.set_status(StatusCode.ERROR, str(e))
-            span.record_exception(e)
-            span.end()
-            raise
-
-        if is_stream:
-            return SyncStreamWrapper(response, span, _finalize_stream)
-
-        duration_ms = (time.perf_counter() - start) * 1000
-        _finalize_response(span, response, duration_ms)
-        return response
-
-    messages.create = patched_create
-
-    if orig_stream:
-
-        def patched_stream(*args, **kwargs):
-            if is_suppressed():
-                return orig_stream(*args, **kwargs)
-
             model = kwargs.get("model", "")
             input_messages = kwargs.get("messages", [])
             system = kwargs.get("system")
+            is_stream = kwargs.get("stream", False)
 
             tracer = get_provider_tracer()
             span = tracer.start_span(
@@ -164,14 +142,59 @@ def _patch_messages(messages: Any) -> None:
                     "neatlogs.llm.provider": "anthropic",
                     "neatlogs.llm.system": "anthropic",
                     "neatlogs.llm.model_name": model,
-                    "neatlogs.llm.is_streaming": True,
+                    "neatlogs.llm.is_streaming": is_stream,
                 },
             )
 
             _set_input_attributes(span, input_messages, system, kwargs)
 
-            stream_mgr = orig_stream(*args, **kwargs)
-            return _SyncStreamManagerWrapper(stream_mgr, span)
+            start = time.perf_counter()
+        except Exception:
+            return orig_create(*args, **kwargs)
+
+        try:
+            response = orig_create(*args, **kwargs)
+        except Exception as e:
+            _record_error(span, e)
+            raise
+
+        if is_stream:
+            return SyncStreamWrapper(response, span, _finalize_stream)
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        _finish_ok(span, lambda: _finalize_response(span, response, duration_ms))
+        return response
+
+    messages.create = patched_create
+
+    if orig_stream:
+        def patched_stream(*args, **kwargs):
+            if is_suppressed():
+                return orig_stream(*args, **kwargs)
+
+            try:
+                model = kwargs.get("model", "")
+                input_messages = kwargs.get("messages", [])
+                system = kwargs.get("system")
+
+                tracer = get_provider_tracer()
+                span = tracer.start_span(
+                    name="anthropic.messages.create",
+                    attributes={
+                        "neatlogs.span.kind": "llm",
+                        "neatlogs.llm.provider": "anthropic",
+                        "neatlogs.llm.system": "anthropic",
+                        "neatlogs.llm.model_name": model,
+                        "neatlogs.llm.is_streaming": True,
+                    },
+                )
+
+                _set_input_attributes(span, input_messages, system, kwargs)
+
+                stream_mgr = orig_stream(*args, **kwargs)
+                return _SyncStreamManagerWrapper(stream_mgr, span)
+            except Exception:
+                return orig_stream(*args, **kwargs)
 
         messages.stream = patched_stream
 
@@ -189,53 +212,11 @@ def _patch_async_messages(messages: Any) -> None:
         if is_suppressed():
             return await orig_create(*args, **kwargs)
 
-        model = kwargs.get("model", "")
-        input_messages = kwargs.get("messages", [])
-        system = kwargs.get("system")
-        is_stream = kwargs.get("stream", False)
-
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="anthropic.messages.create",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "anthropic",
-                "neatlogs.llm.system": "anthropic",
-                "neatlogs.llm.model_name": model,
-                "neatlogs.llm.is_streaming": is_stream,
-            },
-        )
-
-        _set_input_attributes(span, input_messages, system, kwargs)
-
-        start = time.perf_counter()
-
         try:
-            response = await orig_create(*args, **kwargs)
-        except Exception as e:
-            span.set_status(StatusCode.ERROR, str(e))
-            span.record_exception(e)
-            span.end()
-            raise
-
-        if is_stream:
-            return AsyncStreamWrapper(response, span, _finalize_stream)
-
-        duration_ms = (time.perf_counter() - start) * 1000
-        _finalize_response(span, response, duration_ms)
-        return response
-
-    messages.create = patched_create
-
-    if orig_stream:
-
-        def patched_stream(*args, **kwargs):
-            if is_suppressed():
-                return orig_stream(*args, **kwargs)
-
             model = kwargs.get("model", "")
             input_messages = kwargs.get("messages", [])
             system = kwargs.get("system")
+            is_stream = kwargs.get("stream", False)
 
             tracer = get_provider_tracer()
             span = tracer.start_span(
@@ -245,14 +226,59 @@ def _patch_async_messages(messages: Any) -> None:
                     "neatlogs.llm.provider": "anthropic",
                     "neatlogs.llm.system": "anthropic",
                     "neatlogs.llm.model_name": model,
-                    "neatlogs.llm.is_streaming": True,
+                    "neatlogs.llm.is_streaming": is_stream,
                 },
             )
 
             _set_input_attributes(span, input_messages, system, kwargs)
 
-            stream_mgr = orig_stream(*args, **kwargs)
-            return _AsyncStreamManagerWrapper(stream_mgr, span)
+            start = time.perf_counter()
+        except Exception:
+            return await orig_create(*args, **kwargs)
+
+        try:
+            response = await orig_create(*args, **kwargs)
+        except Exception as e:
+            _record_error(span, e)
+            raise
+
+        if is_stream:
+            return AsyncStreamWrapper(response, span, _finalize_stream)
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        _finish_ok(span, lambda: _finalize_response(span, response, duration_ms))
+        return response
+
+    messages.create = patched_create
+
+    if orig_stream:
+        def patched_stream(*args, **kwargs):
+            if is_suppressed():
+                return orig_stream(*args, **kwargs)
+
+            try:
+                model = kwargs.get("model", "")
+                input_messages = kwargs.get("messages", [])
+                system = kwargs.get("system")
+
+                tracer = get_provider_tracer()
+                span = tracer.start_span(
+                    name="anthropic.messages.create",
+                    attributes={
+                        "neatlogs.span.kind": "llm",
+                        "neatlogs.llm.provider": "anthropic",
+                        "neatlogs.llm.system": "anthropic",
+                        "neatlogs.llm.model_name": model,
+                        "neatlogs.llm.is_streaming": True,
+                    },
+                )
+
+                _set_input_attributes(span, input_messages, system, kwargs)
+
+                stream_mgr = orig_stream(*args, **kwargs)
+                return _AsyncStreamManagerWrapper(stream_mgr, span)
+            except Exception:
+                return orig_stream(*args, **kwargs)
 
         messages.stream = patched_stream
 

--- a/neatlogs/anthropic.py
+++ b/neatlogs/anthropic.py
@@ -47,26 +47,54 @@ def wrap_anthropic_client(client: Any) -> Any:
     Wrap an Anthropic client instance. Patches messages (create/stream/parse/
     count_tokens), legacy completions, and beta.messages.
     """
-    _patch_messages(client.messages)
-    _extra_message_methods(client.messages, is_async=False)
-    _patch_legacy_completions(getattr(client, "completions", None), is_async=False)
+    messages = getattr(client, "messages", None)
+    _safe(_patch_messages, messages)
+    if messages is not None:
+        _safe(_extra_message_methods, messages, is_async=False)
+    _safe(_patch_legacy_completions, getattr(client, "completions", None), is_async=False)
     beta = getattr(client, "beta", None)
-    if beta is not None and getattr(beta, "messages", None) is not None:
-        _patch_messages(beta.messages)
-        _extra_message_methods(beta.messages, is_async=False)
+    if beta is not None:
+        beta_messages = getattr(beta, "messages", None)
+        _safe(_patch_messages, beta_messages)
+        if beta_messages is not None:
+            _safe(_extra_message_methods, beta_messages, is_async=False)
     return client
 
 
 def wrap_async_anthropic_client(client: Any) -> Any:
     """Wrap an AsyncAnthropic client instance — full coverage."""
-    _patch_async_messages(client.messages)
-    _extra_message_methods(client.messages, is_async=True)
-    _patch_legacy_completions(getattr(client, "completions", None), is_async=True)
+    messages = getattr(client, "messages", None)
+    _safe(_patch_async_messages, messages)
+    if messages is not None:
+        _safe(_extra_message_methods, messages, is_async=True)
+    _safe(_patch_legacy_completions, getattr(client, "completions", None), is_async=True)
     beta = getattr(client, "beta", None)
-    if beta is not None and getattr(beta, "messages", None) is not None:
-        _patch_async_messages(beta.messages)
-        _extra_message_methods(beta.messages, is_async=True)
+    if beta is not None:
+        beta_messages = getattr(beta, "messages", None)
+        _safe(_patch_async_messages, beta_messages)
+        if beta_messages is not None:
+            _safe(_extra_message_methods, beta_messages, is_async=True)
     return client
+
+
+def _resource(client: Any, *path):
+    """Safely walk a nested resource path."""
+    obj = client
+    for p in path:
+        obj = getattr(obj, p, None)
+        if obj is None:
+            return None
+    return obj
+
+
+def _safe(fn, resource, **kw):
+    """Call a patch fn only if the resource exists; never raise."""
+    if resource is None:
+        return
+    try:
+        fn(resource, **kw) if kw else fn(resource)
+    except Exception:
+        pass
 
 
 def _patch_messages(messages: Any) -> None:

--- a/tests/integration/test_anthropic_fail_open.py
+++ b/tests/integration/test_anthropic_fail_open.py
@@ -95,3 +95,86 @@ class TestAnthropicFailOpen:
                 model="claude-3-haiku-20240307",
                 messages=[{"role": "user", "content": "hi"}],
             )
+
+    def test_sync_stream_called_once_when_setup_fails(self, in_memory_span_exporter):
+        """When telemetry setup fails, orig_stream must be called exactly once (not double-called)."""
+        from neatlogs.anthropic import wrap_anthropic_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        call_count = {"n": 0}
+
+        def stream_fn(**kwargs):
+            call_count["n"] += 1
+            return SimpleNamespace()
+
+        messages = SimpleNamespace(create=lambda **k: None, stream=stream_fn)
+        client = SimpleNamespace(messages=messages, completions=None, beta=None)
+        wrap_anthropic_client(client)
+
+        with patch(
+            "neatlogs.anthropic.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            result = client.messages.stream(
+                model="claude-3-haiku-20240307",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert call_count["n"] == 1, f"orig_stream was called {call_count['n']} times, expected 1"
+        assert result is not None
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_stream_called_once_when_setup_fails(self, in_memory_span_exporter):
+        """Async path: when telemetry setup fails, orig_stream must be called exactly once."""
+        from neatlogs.anthropic import wrap_async_anthropic_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        call_count = {"n": 0}
+
+        async def stream_fn(**kwargs):
+            call_count["n"] += 1
+            return SimpleNamespace()
+
+        messages = SimpleNamespace(create=lambda **k: None, stream=stream_fn)
+        client = SimpleNamespace(messages=messages, completions=None, beta=None)
+        wrap_async_anthropic_client(client)
+
+        with patch(
+            "neatlogs.anthropic.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            result = await client.messages.stream(
+                model="claude-3-haiku-20240307",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert call_count["n"] == 1, f"orig_stream was called {call_count['n']} times, expected 1"
+        assert result is not None
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    def test_sync_stream_called_once_when_orig_stream_raises(self, in_memory_span_exporter):
+        """When orig_stream raises, the fallback must NOT re-invoke it (no double-call)."""
+        from neatlogs.anthropic import wrap_anthropic_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        call_count = {"n": 0}
+
+        def stream_fn(**kwargs):
+            call_count["n"] += 1
+            raise RuntimeError("stream failed")
+
+        messages = SimpleNamespace(create=lambda **k: None, stream=stream_fn)
+        client = SimpleNamespace(messages=messages, completions=None, beta=None)
+        wrap_anthropic_client(client)
+
+        with pytest.raises(RuntimeError, match="stream failed"):
+            client.messages.stream(
+                model="claude-3-haiku-20240307",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert call_count["n"] == 1, f"orig_stream was called {call_count['n']} times, expected 1"

--- a/tests/integration/test_anthropic_fail_open.py
+++ b/tests/integration/test_anthropic_fail_open.py
@@ -178,3 +178,65 @@ class TestAnthropicFailOpen:
             )
 
         assert call_count["n"] == 1, f"orig_stream was called {call_count['n']} times, expected 1"
+
+    def test_parse_fails_open_on_tracer_error(self, in_memory_span_exporter):
+        """messages.parse has the same fail-open contract when telemetry setup fails."""
+        from neatlogs.anthropic import wrap_anthropic_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        call_count = {"n": 0}
+
+        def parse(**kwargs):
+            call_count["n"] += 1
+            return _message_response()
+
+        messages = SimpleNamespace(
+            create=lambda **k: None, stream=None, parse=parse, count_tokens=None
+        )
+        client = SimpleNamespace(messages=messages, completions=None, beta=None)
+        wrap_anthropic_client(client)
+
+        with patch(
+            "neatlogs.anthropic.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = client.messages.parse(
+                model="claude-3-haiku-20240307",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert call_count["n"] == 1, f"called {call_count['n']} times, expected 1"
+        assert getattr(response.content[0], "text", None) == "hello"
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    def test_count_tokens_fails_open_on_tracer_error(self, in_memory_span_exporter):
+        """messages.count_tokens has the same fail-open contract when telemetry setup fails."""
+        from neatlogs.anthropic import wrap_anthropic_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        call_count = {"n": 0}
+
+        def count_tokens(**kwargs):
+            call_count["n"] += 1
+            return SimpleNamespace(input_tokens=5)
+
+        messages = SimpleNamespace(
+            create=lambda **k: None, stream=None, parse=None, count_tokens=count_tokens
+        )
+        client = SimpleNamespace(messages=messages, completions=None, beta=None)
+        wrap_anthropic_client(client)
+
+        with patch(
+            "neatlogs.anthropic.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = client.messages.count_tokens(
+                model="claude-3-haiku-20240307",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert call_count["n"] == 1, f"called {call_count['n']} times, expected 1"
+        assert response.input_tokens == 5
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0

--- a/tests/integration/test_anthropic_fail_open.py
+++ b/tests/integration/test_anthropic_fail_open.py
@@ -1,0 +1,97 @@
+"""Regression tests for Anthropic wrapper fail-open behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+
+def _setup_tracer(exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    import neatlogs._wrap_utils as _wu
+
+    _wu._wrapper_tracer = None
+    return provider
+
+
+def _message_response():
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="hello")],
+        stop_reason="end_turn",
+        model="claude-3-haiku-20240307",
+        usage=SimpleNamespace(input_tokens=5, output_tokens=3),
+    )
+
+
+class TestAnthropicFailOpen:
+    def test_sync_create_fails_open_on_tracer_error(self, in_memory_span_exporter):
+        from neatlogs.anthropic import wrap_anthropic_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        def create(**kwargs):
+            return _message_response()
+
+        messages = SimpleNamespace(create=create, stream=None)
+        client = SimpleNamespace(messages=messages, completions=None, beta=None)
+        wrap_anthropic_client(client)
+
+        with patch(
+            "neatlogs.anthropic.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = client.messages.create(
+                model="claude-3-haiku-20240307",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert getattr(response.content[0], "text", None) == "hello"
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_create_fails_open_on_tracer_error(self, in_memory_span_exporter):
+        from neatlogs.anthropic import wrap_async_anthropic_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        async def create(**kwargs):
+            return _message_response()
+
+        messages = SimpleNamespace(create=create, stream=None)
+        client = SimpleNamespace(messages=messages, completions=None, beta=None)
+        wrap_async_anthropic_client(client)
+
+        with patch(
+            "neatlogs.anthropic.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = await client.messages.create(
+                model="claude-3-haiku-20240307",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert getattr(response.content[0], "text", None) == "hello"
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    def test_sync_create_propagates_sdk_errors(self, in_memory_span_exporter):
+        from neatlogs.anthropic import wrap_anthropic_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        def create(**kwargs):
+            raise ValueError("sdk failure")
+
+        messages = SimpleNamespace(create=create, stream=None)
+        client = SimpleNamespace(messages=messages, completions=None, beta=None)
+        wrap_anthropic_client(client)
+
+        with pytest.raises(ValueError, match="sdk failure"):
+            client.messages.create(
+                model="claude-3-haiku-20240307",
+                messages=[{"role": "user", "content": "hi"}],
+            )


### PR DESCRIPTION
Fixes #28

Adds _safe guards around Anthropic wrap-time patches, matching openai.py and azure_openai.py. When get_provider_tracer or span setup fails in messages.create (sync and async) and messages.stream, the wrapper falls through to the original SDK call instead of crashing the host app. SDK errors still propagate.

Related to #15 / PR #23, which covers the same pattern for OpenAI.

Verification:
uv run ... python -m pytest tests/integration/test_anthropic_fail_open.py -q
3 passed