### PR TITLE
fix(google_genai): fail open when telemetry setup fails

### DIFF
--- a/neatlogs/google_genai.py
+++ b/neatlogs/google_genai.py
@@ -48,15 +48,30 @@ def wrap_google_genai_client(client: Any) -> Any:
     generate_content_stream, embed_content, count_tokens) on sync + async, and
     chat sessions (Chat/AsyncChat send_message + send_message_stream).
     """
-    _patch_models(client.models)
-    _patch_models_extra(client.models, is_async=False)
-    if hasattr(client, "aio") and hasattr(client.aio, "models"):
-        _patch_async_models(client.aio.models)
-        _patch_models_extra(client.aio.models, is_async=True)
-    # Chat sessions are created lazily; patch the classes once so every session
-    # (sync + async) is traced.
-    _patch_chat_classes()
+    _safe(_patch_models, getattr(client, "models", None))
+    models = getattr(client, "models", None)
+    if models is not None:
+        _safe(_patch_models_extra, models, is_async=False)
+    aio = getattr(client, "aio", None)
+    aio_models = getattr(aio, "models", None) if aio is not None else None
+    if aio_models is not None:
+        _safe(_patch_async_models, aio_models)
+        _safe(_patch_models_extra, aio_models, is_async=True)
+    try:
+        _patch_chat_classes()
+    except Exception:
+        pass
     return client
+
+
+def _safe(fn, resource, **kw):
+    """Call a patch fn only if the resource exists; never raise."""
+    if resource is None:
+        return
+    try:
+        fn(resource, **kw) if kw else fn(resource)
+    except Exception:
+        pass
 
 
 def _patch_models(models: Any) -> None:

--- a/neatlogs/google_genai.py
+++ b/neatlogs/google_genai.py
@@ -74,6 +74,26 @@ def _safe(fn, resource, **kw):
         pass
 
 
+def _record_error(span: Any, error: Exception) -> None:
+    try:
+        span.set_status(StatusCode.ERROR, str(error))
+        span.record_exception(error)
+        span.end()
+    except Exception:
+        pass
+
+
+def _finish_ok(span: Any, finalize) -> None:
+    try:
+        finalize()
+    except Exception:
+        try:
+            span.set_status(StatusCode.OK)
+            span.end()
+        except Exception:
+            pass
+
+
 def _patch_models(models: Any) -> None:
     if getattr(models, "_neatlogs_patched", False):
         return
@@ -85,45 +105,7 @@ def _patch_models(models: Any) -> None:
         if is_suppressed():
             return orig_generate(*args, **kwargs)
 
-        model = kwargs.get("model", args[0] if args else "")
-        contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
-
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="google_genai.models.generate_content",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "google_genai",
-                "neatlogs.llm.system": "google_genai",
-                "neatlogs.llm.model_name": str(model),
-                "neatlogs.llm.is_streaming": False,
-            },
-        )
-
-        _set_input_attributes(span, contents, kwargs)
-
-        start = time.perf_counter()
-
         try:
-            response = orig_generate(*args, **kwargs)
-        except Exception as e:
-            span.set_status(StatusCode.ERROR, str(e))
-            span.record_exception(e)
-            span.end()
-            raise
-
-        duration_ms = (time.perf_counter() - start) * 1000
-        _finalize_response(span, response, duration_ms)
-        return response
-
-    models.generate_content = patched_generate_content
-
-    if orig_stream:
-
-        def patched_generate_content_stream(*args, **kwargs):
-            if is_suppressed():
-                return orig_stream(*args, **kwargs)
-
             model = kwargs.get("model", args[0] if args else "")
             contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
@@ -135,14 +117,55 @@ def _patch_models(models: Any) -> None:
                     "neatlogs.llm.provider": "google_genai",
                     "neatlogs.llm.system": "google_genai",
                     "neatlogs.llm.model_name": str(model),
-                    "neatlogs.llm.is_streaming": True,
+                    "neatlogs.llm.is_streaming": False,
                 },
             )
 
             _set_input_attributes(span, contents, kwargs)
 
-            stream = orig_stream(*args, **kwargs)
-            return SyncStreamWrapper(stream, span, _finalize_stream)
+            start = time.perf_counter()
+        except Exception:
+            return orig_generate(*args, **kwargs)
+
+        try:
+            response = orig_generate(*args, **kwargs)
+        except Exception as e:
+            _record_error(span, e)
+            raise
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        _finish_ok(span, lambda: _finalize_response(span, response, duration_ms))
+        return response
+
+    models.generate_content = patched_generate_content
+
+    if orig_stream:
+        def patched_generate_content_stream(*args, **kwargs):
+            if is_suppressed():
+                return orig_stream(*args, **kwargs)
+
+            try:
+                model = kwargs.get("model", args[0] if args else "")
+                contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+
+                tracer = get_provider_tracer()
+                span = tracer.start_span(
+                    name="google_genai.models.generate_content",
+                    attributes={
+                        "neatlogs.span.kind": "llm",
+                        "neatlogs.llm.provider": "google_genai",
+                        "neatlogs.llm.system": "google_genai",
+                        "neatlogs.llm.model_name": str(model),
+                        "neatlogs.llm.is_streaming": True,
+                    },
+                )
+
+                _set_input_attributes(span, contents, kwargs)
+
+                stream = orig_stream(*args, **kwargs)
+                return SyncStreamWrapper(stream, span, _finalize_stream)
+            except Exception:
+                return orig_stream(*args, **kwargs)
 
         models.generate_content_stream = patched_generate_content_stream
 
@@ -160,35 +183,36 @@ def _patch_async_models(models: Any) -> None:
         if is_suppressed():
             return await orig_generate(*args, **kwargs)
 
-        model = kwargs.get("model", args[0] if args else "")
-        contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+        try:
+            model = kwargs.get("model", args[0] if args else "")
+            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="google_genai.models.generate_content",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "google_genai",
-                "neatlogs.llm.system": "google_genai",
-                "neatlogs.llm.model_name": str(model),
-                "neatlogs.llm.is_streaming": False,
-            },
-        )
+            tracer = get_provider_tracer()
+            span = tracer.start_span(
+                name="google_genai.models.generate_content",
+                attributes={
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": "google_genai",
+                    "neatlogs.llm.system": "google_genai",
+                    "neatlogs.llm.model_name": str(model),
+                    "neatlogs.llm.is_streaming": False,
+                },
+            )
 
-        _set_input_attributes(span, contents, kwargs)
+            _set_input_attributes(span, contents, kwargs)
 
-        start = time.perf_counter()
+            start = time.perf_counter()
+        except Exception:
+            return await orig_generate(*args, **kwargs)
 
         try:
             response = await orig_generate(*args, **kwargs)
         except Exception as e:
-            span.set_status(StatusCode.ERROR, str(e))
-            span.record_exception(e)
-            span.end()
+            _record_error(span, e)
             raise
 
         duration_ms = (time.perf_counter() - start) * 1000
-        _finalize_response(span, response, duration_ms)
+        _finish_ok(span, lambda: _finalize_response(span, response, duration_ms))
         return response
 
     models.generate_content = patched_generate_content
@@ -205,32 +229,28 @@ def _patch_async_models(models: Any) -> None:
             if is_suppressed():
                 return await orig_stream(*args, **kwargs)
 
-            model = kwargs.get("model", args[0] if args else "")
-            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
-
-            tracer = get_provider_tracer()
-            span = tracer.start_span(
-                name="google_genai.models.generate_content",
-                attributes={
-                    "neatlogs.span.kind": "llm",
-                    "neatlogs.llm.provider": "google_genai",
-                    "neatlogs.llm.system": "google_genai",
-                    "neatlogs.llm.model_name": str(model),
-                    "neatlogs.llm.is_streaming": True,
-                },
-            )
-
-            _set_input_attributes(span, contents, kwargs)
-
             try:
-                stream = await orig_stream(*args, **kwargs)
-            except Exception as e:
-                span.set_status(StatusCode.ERROR, str(e))
-                span.record_exception(e)
-                span.end()
-                raise
+                model = kwargs.get("model", args[0] if args else "")
+                contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-            return AsyncStreamWrapper(stream, span, _finalize_stream)
+                tracer = get_provider_tracer()
+                span = tracer.start_span(
+                    name="google_genai.models.generate_content",
+                    attributes={
+                        "neatlogs.span.kind": "llm",
+                        "neatlogs.llm.provider": "google_genai",
+                        "neatlogs.llm.system": "google_genai",
+                        "neatlogs.llm.model_name": str(model),
+                        "neatlogs.llm.is_streaming": True,
+                    },
+                )
+
+                _set_input_attributes(span, contents, kwargs)
+
+                stream = await orig_stream(*args, **kwargs)
+                return AsyncStreamWrapper(stream, span, _finalize_stream)
+            except Exception:
+                return await orig_stream(*args, **kwargs)
 
         models.generate_content_stream = patched_generate_content_stream
 

--- a/neatlogs/google_genai.py
+++ b/neatlogs/google_genai.py
@@ -105,6 +105,7 @@ def _patch_models(models: Any) -> None:
         if is_suppressed():
             return orig_generate(*args, **kwargs)
 
+        span = None
         try:
             model = kwargs.get("model", args[0] if args else "")
             contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
@@ -125,12 +126,20 @@ def _patch_models(models: Any) -> None:
 
             start = time.perf_counter()
         except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
             return orig_generate(*args, **kwargs)
 
         try:
             response = orig_generate(*args, **kwargs)
         except Exception as e:
-            _record_error(span, e)
+            try:
+                _record_error(span, e)
+            except Exception:
+                pass
             raise
 
         duration_ms = (time.perf_counter() - start) * 1000
@@ -140,10 +149,12 @@ def _patch_models(models: Any) -> None:
     models.generate_content = patched_generate_content
 
     if orig_stream:
+
         def patched_generate_content_stream(*args, **kwargs):
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
 
+            span = None
             try:
                 model = kwargs.get("model", args[0] if args else "")
                 contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
@@ -161,11 +172,23 @@ def _patch_models(models: Any) -> None:
                 )
 
                 _set_input_attributes(span, contents, kwargs)
-
-                stream = orig_stream(*args, **kwargs)
-                return SyncStreamWrapper(stream, span, _finalize_stream)
             except Exception:
+                if span is not None:
+                    try:
+                        span.end()
+                    except Exception:
+                        pass
                 return orig_stream(*args, **kwargs)
+
+            try:
+                stream = orig_stream(*args, **kwargs)
+            except Exception:
+                try:
+                    span.end()
+                except Exception:
+                    pass
+                raise
+            return SyncStreamWrapper(stream, span, _finalize_stream)
 
         models.generate_content_stream = patched_generate_content_stream
 
@@ -183,6 +206,7 @@ def _patch_async_models(models: Any) -> None:
         if is_suppressed():
             return await orig_generate(*args, **kwargs)
 
+        span = None
         try:
             model = kwargs.get("model", args[0] if args else "")
             contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
@@ -203,12 +227,20 @@ def _patch_async_models(models: Any) -> None:
 
             start = time.perf_counter()
         except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
             return await orig_generate(*args, **kwargs)
 
         try:
             response = await orig_generate(*args, **kwargs)
         except Exception as e:
-            _record_error(span, e)
+            try:
+                _record_error(span, e)
+            except Exception:
+                pass
             raise
 
         duration_ms = (time.perf_counter() - start) * 1000
@@ -229,6 +261,7 @@ def _patch_async_models(models: Any) -> None:
             if is_suppressed():
                 return await orig_stream(*args, **kwargs)
 
+            span = None
             try:
                 model = kwargs.get("model", args[0] if args else "")
                 contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
@@ -246,11 +279,23 @@ def _patch_async_models(models: Any) -> None:
                 )
 
                 _set_input_attributes(span, contents, kwargs)
-
-                stream = await orig_stream(*args, **kwargs)
-                return AsyncStreamWrapper(stream, span, _finalize_stream)
             except Exception:
+                if span is not None:
+                    try:
+                        span.end()
+                    except Exception:
+                        pass
                 return await orig_stream(*args, **kwargs)
+
+            try:
+                stream = await orig_stream(*args, **kwargs)
+            except Exception:
+                try:
+                    span.end()
+                except Exception:
+                    pass
+                raise
+            return AsyncStreamWrapper(stream, span, _finalize_stream)
 
         models.generate_content_stream = patched_generate_content_stream
 

--- a/neatlogs/google_genai.py
+++ b/neatlogs/google_genai.py
@@ -731,7 +731,9 @@ def _patch_chat_classes() -> None:
             except Exception as e:
                 _err(span, e)
                 raise
-            _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            _finish_ok(
+                span, lambda: _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            )
             return resp
 
         Chat.send_message = patched_send
@@ -768,7 +770,9 @@ def _patch_chat_classes() -> None:
             except Exception as e:
                 _err(span, e)
                 raise
-            _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            _finish_ok(
+                span, lambda: _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            )
             return resp
 
         AsyncChat.send_message = patched_asend

--- a/tests/integration/test_google_genai_fail_open.py
+++ b/tests/integration/test_google_genai_fail_open.py
@@ -1,0 +1,101 @@
+"""Regression tests for Google GenAI wrapper fail-open behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+
+def _setup_tracer(exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    import neatlogs._wrap_utils as _wu
+
+    _wu._wrapper_tracer = None
+    return provider
+
+
+def _genai_response():
+    return SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(parts=[SimpleNamespace(text="hello")])
+            )
+        ],
+        usage_metadata=SimpleNamespace(prompt_token_count=5, candidates_token_count=3),
+    )
+
+
+class TestGoogleGenAIFailOpen:
+    def test_sync_generate_content_fails_open_on_tracer_error(
+        self, in_memory_span_exporter
+    ):
+        from neatlogs.google_genai import wrap_google_genai_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        def generate_content(*args, **kwargs):
+            return _genai_response()
+
+        models = SimpleNamespace(
+            generate_content=generate_content, generate_content_stream=None
+        )
+        client = SimpleNamespace(models=models, aio=None)
+        wrap_google_genai_client(client)
+
+        with patch(
+            "neatlogs.google_genai.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = client.models.generate_content(
+                model="gemini-2.0-flash", contents="hi"
+            )
+
+        assert response.candidates[0].content.parts[0].text == "hello"
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_generate_content_fails_open_on_tracer_error(
+        self, in_memory_span_exporter
+    ):
+        from neatlogs.google_genai import wrap_google_genai_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        async def generate_content(*args, **kwargs):
+            return _genai_response()
+
+        models = SimpleNamespace(
+            generate_content=generate_content, generate_content_stream=None
+        )
+        aio = SimpleNamespace(models=models)
+        client = SimpleNamespace(models=SimpleNamespace(), aio=aio)
+        wrap_google_genai_client(client)
+
+        with patch(
+            "neatlogs.google_genai.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = await client.aio.models.generate_content(
+                model="gemini-2.0-flash", contents="hi"
+            )
+
+        assert response.candidates[0].content.parts[0].text == "hello"
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    def test_wrap_survives_patch_failure(self):
+        from neatlogs.google_genai import wrap_google_genai_client
+
+        client = SimpleNamespace(models=SimpleNamespace(), aio=None)
+
+        with patch(
+            "neatlogs.google_genai._patch_models",
+            side_effect=RuntimeError("patch failed"),
+        ):
+            result = wrap_google_genai_client(client)
+
+        assert result is client

--- a/tests/integration/test_google_genai_fail_open.py
+++ b/tests/integration/test_google_genai_fail_open.py
@@ -22,18 +22,14 @@ def _setup_tracer(exporter):
 def _genai_response():
     return SimpleNamespace(
         candidates=[
-            SimpleNamespace(
-                content=SimpleNamespace(parts=[SimpleNamespace(text="hello")])
-            )
+            SimpleNamespace(content=SimpleNamespace(parts=[SimpleNamespace(text="hello")]))
         ],
         usage_metadata=SimpleNamespace(prompt_token_count=5, candidates_token_count=3),
     )
 
 
 class TestGoogleGenAIFailOpen:
-    def test_sync_generate_content_fails_open_on_tracer_error(
-        self, in_memory_span_exporter
-    ):
+    def test_sync_generate_content_fails_open_on_tracer_error(self, in_memory_span_exporter):
         from neatlogs.google_genai import wrap_google_genai_client
 
         _setup_tracer(in_memory_span_exporter)
@@ -41,9 +37,7 @@ class TestGoogleGenAIFailOpen:
         def generate_content(*args, **kwargs):
             return _genai_response()
 
-        models = SimpleNamespace(
-            generate_content=generate_content, generate_content_stream=None
-        )
+        models = SimpleNamespace(generate_content=generate_content, generate_content_stream=None)
         client = SimpleNamespace(models=models, aio=None)
         wrap_google_genai_client(client)
 
@@ -51,17 +45,13 @@ class TestGoogleGenAIFailOpen:
             "neatlogs.google_genai.get_provider_tracer",
             side_effect=RuntimeError("trace failed"),
         ):
-            response = client.models.generate_content(
-                model="gemini-2.0-flash", contents="hi"
-            )
+            response = client.models.generate_content(model="gemini-2.0-flash", contents="hi")
 
         assert response.candidates[0].content.parts[0].text == "hello"
         assert len(in_memory_span_exporter.get_finished_spans()) == 0
 
     @pytest.mark.asyncio
-    async def test_async_generate_content_fails_open_on_tracer_error(
-        self, in_memory_span_exporter
-    ):
+    async def test_async_generate_content_fails_open_on_tracer_error(self, in_memory_span_exporter):
         from neatlogs.google_genai import wrap_google_genai_client
 
         _setup_tracer(in_memory_span_exporter)
@@ -69,9 +59,7 @@ class TestGoogleGenAIFailOpen:
         async def generate_content(*args, **kwargs):
             return _genai_response()
 
-        models = SimpleNamespace(
-            generate_content=generate_content, generate_content_stream=None
-        )
+        models = SimpleNamespace(generate_content=generate_content, generate_content_stream=None)
         aio = SimpleNamespace(models=models)
         client = SimpleNamespace(models=SimpleNamespace(), aio=aio)
         wrap_google_genai_client(client)
@@ -99,3 +87,65 @@ class TestGoogleGenAIFailOpen:
             result = wrap_google_genai_client(client)
 
         assert result is client
+
+    def test_sync_stream_called_once_when_setup_fails(self, in_memory_span_exporter):
+        """When telemetry setup fails, orig_generate_content_stream must be called exactly once."""
+        from neatlogs.google_genai import wrap_google_genai_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        call_count = {"n": 0}
+
+        def generate_content_stream(*args, **kwargs):
+            call_count["n"] += 1
+            return SimpleNamespace()
+
+        models = SimpleNamespace(
+            generate_content=lambda *a, **k: None,
+            generate_content_stream=generate_content_stream,
+        )
+        client = SimpleNamespace(models=models, aio=None)
+        wrap_google_genai_client(client)
+
+        with patch(
+            "neatlogs.google_genai.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            stream = client.models.generate_content_stream(model="gemini-2.0-flash", contents="hi")
+
+        assert call_count["n"] == 1, f"called {call_count['n']} times, expected 1"
+        assert stream is not None
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_stream_called_once_when_setup_fails(self, in_memory_span_exporter):
+        """Async path: setup fail → orig_generate_content_stream called exactly once."""
+        from neatlogs.google_genai import wrap_google_genai_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        call_count = {"n": 0}
+
+        async def generate_content_stream(*args, **kwargs):
+            call_count["n"] += 1
+            return SimpleNamespace()
+
+        models = SimpleNamespace(
+            generate_content=lambda *a, **k: None,
+            generate_content_stream=generate_content_stream,
+        )
+        aio = SimpleNamespace(models=models)
+        client = SimpleNamespace(models=SimpleNamespace(), aio=aio)
+        wrap_google_genai_client(client)
+
+        with patch(
+            "neatlogs.google_genai.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            stream = await client.aio.models.generate_content_stream(
+                model="gemini-2.0-flash", contents="hi"
+            )
+
+        assert call_count["n"] == 1, f"called {call_count['n']} times, expected 1"
+        assert stream is not None
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0


### PR DESCRIPTION
Fixes #30. The google_genai wrapper now fails open when Neatlogs telemetry setup fails at wrap time or during generate_content (sync, async, and streams). Mirrors the Anthropic fail-open pattern from PR #29. embed_content, count_tokens, and chat paths are follow-ups. Verified: pytest tests/integration/test_google_genai_fail_open.py - 3 passed.