### PR TITLE
fix(vertex_ai): fail open when telemetry setup fails

### DIFF
--- a/neatlogs/vertex_ai.py
+++ b/neatlogs/vertex_ai.py
@@ -68,13 +68,30 @@ def wrap_vertex_ai_client(client: Any) -> Any:
     (generate_content + generate_content_stream) on sync and async, and chat
     sessions (Chat/AsyncChat send_message + send_message_stream).
     """
-    _patch_models(client.models)
-    _patch_models_extra(client.models, is_async=False)
-    if hasattr(client, "aio") and hasattr(client.aio, "models"):
-        _patch_async_models(client.aio.models)
-        _patch_models_extra(client.aio.models, is_async=True)
-    _patch_chat_classes()
+    models = getattr(client, "models", None)
+    _safe(_patch_models, models)
+    if models is not None:
+        _safe(_patch_models_extra, models, is_async=False)
+    aio = getattr(client, "aio", None)
+    aio_models = getattr(aio, "models", None) if aio is not None else None
+    if aio_models is not None:
+        _safe(_patch_async_models, aio_models)
+        _safe(_patch_models_extra, aio_models, is_async=True)
+    try:
+        _patch_chat_classes()
+    except Exception:
+        pass
     return client
+
+
+def _safe(fn, resource, **kw):
+    """Call a patch fn only if the resource exists; never raise."""
+    if resource is None:
+        return
+    try:
+        fn(resource, **kw) if kw else fn(resource)
+    except Exception:
+        pass
 
 
 def _start_span(model: Any, stream: bool, name: str = "vertex_ai.models.generate_content") -> Any:

--- a/neatlogs/vertex_ai.py
+++ b/neatlogs/vertex_ai.py
@@ -94,6 +94,26 @@ def _safe(fn, resource, **kw):
         pass
 
 
+def _record_error(span: Any, error: Exception) -> None:
+    try:
+        span.set_status(StatusCode.ERROR, str(error))
+        span.record_exception(error)
+        span.end()
+    except Exception:
+        pass
+
+
+def _finish_ok(span: Any, finalize) -> None:
+    try:
+        finalize()
+    except Exception:
+        try:
+            span.set_status(StatusCode.OK)
+            span.end()
+        except Exception:
+            pass
+
+
 def _start_span(model: Any, stream: bool, name: str = "vertex_ai.models.generate_content") -> Any:
     return get_provider_tracer().start_span(
         name=name,
@@ -118,20 +138,25 @@ def _patch_models(models: Any) -> None:
         if is_suppressed():
             return orig_generate(*args, **kwargs)
 
-        model = kwargs.get("model", args[0] if args else "")
-        contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+        try:
+            model = kwargs.get("model", args[0] if args else "")
+            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-        span = _start_span(model, stream=False)
-        _set_input_attributes(span, contents, kwargs)
+            span = _start_span(model, stream=False)
+            _set_input_attributes(span, contents, kwargs)
 
-        start = time.perf_counter()
+            start = time.perf_counter()
+        except Exception:
+            return orig_generate(*args, **kwargs)
+
         try:
             response = orig_generate(*args, **kwargs)
         except Exception as e:
-            _err(span, e)
+            _record_error(span, e)
             raise
 
-        _finalize_response(span, response, (time.perf_counter() - start) * 1000)
+        duration_ms = (time.perf_counter() - start) * 1000
+        _finish_ok(span, lambda: _finalize_response(span, response, duration_ms))
         return response
 
     models.generate_content = patched_generate_content
@@ -142,14 +167,17 @@ def _patch_models(models: Any) -> None:
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
 
-            model = kwargs.get("model", args[0] if args else "")
-            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+            try:
+                model = kwargs.get("model", args[0] if args else "")
+                contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-            span = _start_span(model, stream=True)
-            _set_input_attributes(span, contents, kwargs)
+                span = _start_span(model, stream=True)
+                _set_input_attributes(span, contents, kwargs)
 
-            stream = orig_stream(*args, **kwargs)
-            return SyncStreamWrapper(stream, span, _finalize_stream)
+                stream = orig_stream(*args, **kwargs)
+                return SyncStreamWrapper(stream, span, _finalize_stream)
+            except Exception:
+                return orig_stream(*args, **kwargs)
 
         models.generate_content_stream = patched_generate_content_stream
 
@@ -167,20 +195,25 @@ def _patch_async_models(models: Any) -> None:
         if is_suppressed():
             return await orig_generate(*args, **kwargs)
 
-        model = kwargs.get("model", args[0] if args else "")
-        contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+        try:
+            model = kwargs.get("model", args[0] if args else "")
+            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-        span = _start_span(model, stream=False)
-        _set_input_attributes(span, contents, kwargs)
+            span = _start_span(model, stream=False)
+            _set_input_attributes(span, contents, kwargs)
 
-        start = time.perf_counter()
+            start = time.perf_counter()
+        except Exception:
+            return await orig_generate(*args, **kwargs)
+
         try:
             response = await orig_generate(*args, **kwargs)
         except Exception as e:
-            _err(span, e)
+            _record_error(span, e)
             raise
 
-        _finalize_response(span, response, (time.perf_counter() - start) * 1000)
+        duration_ms = (time.perf_counter() - start) * 1000
+        _finish_ok(span, lambda: _finalize_response(span, response, duration_ms))
         return response
 
     models.generate_content = patched_generate_content
@@ -193,19 +226,17 @@ def _patch_async_models(models: Any) -> None:
             if is_suppressed():
                 return await orig_stream(*args, **kwargs)
 
-            model = kwargs.get("model", args[0] if args else "")
-            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
-
-            span = _start_span(model, stream=True)
-            _set_input_attributes(span, contents, kwargs)
-
             try:
-                stream = await orig_stream(*args, **kwargs)
-            except Exception as e:
-                _err(span, e)
-                raise
+                model = kwargs.get("model", args[0] if args else "")
+                contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-            return AsyncStreamWrapper(stream, span, _finalize_stream)
+                span = _start_span(model, stream=True)
+                _set_input_attributes(span, contents, kwargs)
+
+                stream = await orig_stream(*args, **kwargs)
+                return AsyncStreamWrapper(stream, span, _finalize_stream)
+            except Exception:
+                return await orig_stream(*args, **kwargs)
 
         models.generate_content_stream = patched_generate_content_stream
 

--- a/neatlogs/vertex_ai.py
+++ b/neatlogs/vertex_ai.py
@@ -138,6 +138,7 @@ def _patch_models(models: Any) -> None:
         if is_suppressed():
             return orig_generate(*args, **kwargs)
 
+        span = None
         try:
             model = kwargs.get("model", args[0] if args else "")
             contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
@@ -147,12 +148,20 @@ def _patch_models(models: Any) -> None:
 
             start = time.perf_counter()
         except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
             return orig_generate(*args, **kwargs)
 
         try:
             response = orig_generate(*args, **kwargs)
         except Exception as e:
-            _record_error(span, e)
+            try:
+                _record_error(span, e)
+            except Exception:
+                pass
             raise
 
         duration_ms = (time.perf_counter() - start) * 1000
@@ -167,17 +176,30 @@ def _patch_models(models: Any) -> None:
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
 
+            span = None
             try:
                 model = kwargs.get("model", args[0] if args else "")
                 contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
                 span = _start_span(model, stream=True)
                 _set_input_attributes(span, contents, kwargs)
-
-                stream = orig_stream(*args, **kwargs)
-                return SyncStreamWrapper(stream, span, _finalize_stream)
             except Exception:
+                if span is not None:
+                    try:
+                        span.end()
+                    except Exception:
+                        pass
                 return orig_stream(*args, **kwargs)
+
+            try:
+                stream = orig_stream(*args, **kwargs)
+            except Exception:
+                try:
+                    span.end()
+                except Exception:
+                    pass
+                raise
+            return SyncStreamWrapper(stream, span, _finalize_stream)
 
         models.generate_content_stream = patched_generate_content_stream
 
@@ -195,6 +217,7 @@ def _patch_async_models(models: Any) -> None:
         if is_suppressed():
             return await orig_generate(*args, **kwargs)
 
+        span = None
         try:
             model = kwargs.get("model", args[0] if args else "")
             contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
@@ -204,12 +227,20 @@ def _patch_async_models(models: Any) -> None:
 
             start = time.perf_counter()
         except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
             return await orig_generate(*args, **kwargs)
 
         try:
             response = await orig_generate(*args, **kwargs)
         except Exception as e:
-            _record_error(span, e)
+            try:
+                _record_error(span, e)
+            except Exception:
+                pass
             raise
 
         duration_ms = (time.perf_counter() - start) * 1000
@@ -226,17 +257,30 @@ def _patch_async_models(models: Any) -> None:
             if is_suppressed():
                 return await orig_stream(*args, **kwargs)
 
+            span = None
             try:
                 model = kwargs.get("model", args[0] if args else "")
                 contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
                 span = _start_span(model, stream=True)
                 _set_input_attributes(span, contents, kwargs)
-
-                stream = await orig_stream(*args, **kwargs)
-                return AsyncStreamWrapper(stream, span, _finalize_stream)
             except Exception:
+                if span is not None:
+                    try:
+                        span.end()
+                    except Exception:
+                        pass
                 return await orig_stream(*args, **kwargs)
+
+            try:
+                stream = await orig_stream(*args, **kwargs)
+            except Exception:
+                try:
+                    span.end()
+                except Exception:
+                    pass
+                raise
+            return AsyncStreamWrapper(stream, span, _finalize_stream)
 
         models.generate_content_stream = patched_generate_content_stream
 

--- a/neatlogs/vertex_ai.py
+++ b/neatlogs/vertex_ai.py
@@ -688,7 +688,9 @@ def _patch_chat_classes() -> None:
             except Exception as e:
                 _err(span, e)
                 raise
-            _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            _finish_ok(
+                span, lambda: _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            )
             return resp
 
         Chat.send_message = patched_send
@@ -724,7 +726,9 @@ def _patch_chat_classes() -> None:
             except Exception as e:
                 _err(span, e)
                 raise
-            _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            _finish_ok(
+                span, lambda: _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            )
             return resp
 
         AsyncChat.send_message = patched_asend

--- a/tests/integration/test_vertex_ai_fail_open.py
+++ b/tests/integration/test_vertex_ai_fail_open.py
@@ -1,0 +1,104 @@
+"""Regression tests for Vertex AI wrapper fail-open behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+
+def _setup_tracer(exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    import neatlogs._wrap_utils as _wu
+
+    _wu._wrapper_tracer = None
+    return provider
+
+
+def _vertex_response():
+    part = SimpleNamespace(text="hello", thought=False, function_call=None)
+    content = SimpleNamespace(parts=[part])
+    candidate = SimpleNamespace(content=content, finish_reason="STOP")
+    usage = SimpleNamespace(
+        prompt_token_count=5,
+        candidates_token_count=3,
+        total_token_count=8,
+        cached_content_token_count=None,
+        thoughts_token_count=None,
+    )
+    return SimpleNamespace(candidates=[candidate], usage_metadata=usage)
+
+
+class TestVertexAIFailOpen:
+    def test_sync_generate_content_fails_open_on_tracer_error(
+        self, in_memory_span_exporter
+    ):
+        from neatlogs.vertex_ai import wrap_vertex_ai_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        def generate_content(*args, **kwargs):
+            return _vertex_response()
+
+        models = SimpleNamespace(
+            generate_content=generate_content, generate_content_stream=None
+        )
+        client = SimpleNamespace(models=models, aio=None)
+        wrap_vertex_ai_client(client)
+
+        with patch(
+            "neatlogs.vertex_ai.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = client.models.generate_content(
+                model="gemini-2.0-flash", contents="hi"
+            )
+
+        assert response.candidates[0].content.parts[0].text == "hello"
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_generate_content_fails_open_on_tracer_error(
+        self, in_memory_span_exporter
+    ):
+        from neatlogs.vertex_ai import wrap_vertex_ai_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        async def generate_content(*args, **kwargs):
+            return _vertex_response()
+
+        models = SimpleNamespace(
+            generate_content=generate_content, generate_content_stream=None
+        )
+        aio = SimpleNamespace(models=models)
+        client = SimpleNamespace(models=SimpleNamespace(), aio=aio)
+        wrap_vertex_ai_client(client)
+
+        with patch(
+            "neatlogs.vertex_ai.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = await client.aio.models.generate_content(
+                model="gemini-2.0-flash", contents="hi"
+            )
+
+        assert response.candidates[0].content.parts[0].text == "hello"
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    def test_wrap_survives_patch_failure(self):
+        from neatlogs.vertex_ai import wrap_vertex_ai_client
+
+        client = SimpleNamespace(models=SimpleNamespace(), aio=None)
+
+        with patch(
+            "neatlogs.vertex_ai._patch_models",
+            side_effect=RuntimeError("patch failed"),
+        ):
+            result = wrap_vertex_ai_client(client)
+
+        assert result is client

--- a/tests/integration/test_vertex_ai_fail_open.py
+++ b/tests/integration/test_vertex_ai_fail_open.py
@@ -34,9 +34,7 @@ def _vertex_response():
 
 
 class TestVertexAIFailOpen:
-    def test_sync_generate_content_fails_open_on_tracer_error(
-        self, in_memory_span_exporter
-    ):
+    def test_sync_generate_content_fails_open_on_tracer_error(self, in_memory_span_exporter):
         from neatlogs.vertex_ai import wrap_vertex_ai_client
 
         _setup_tracer(in_memory_span_exporter)
@@ -44,9 +42,7 @@ class TestVertexAIFailOpen:
         def generate_content(*args, **kwargs):
             return _vertex_response()
 
-        models = SimpleNamespace(
-            generate_content=generate_content, generate_content_stream=None
-        )
+        models = SimpleNamespace(generate_content=generate_content, generate_content_stream=None)
         client = SimpleNamespace(models=models, aio=None)
         wrap_vertex_ai_client(client)
 
@@ -54,17 +50,13 @@ class TestVertexAIFailOpen:
             "neatlogs.vertex_ai.get_provider_tracer",
             side_effect=RuntimeError("trace failed"),
         ):
-            response = client.models.generate_content(
-                model="gemini-2.0-flash", contents="hi"
-            )
+            response = client.models.generate_content(model="gemini-2.0-flash", contents="hi")
 
         assert response.candidates[0].content.parts[0].text == "hello"
         assert len(in_memory_span_exporter.get_finished_spans()) == 0
 
     @pytest.mark.asyncio
-    async def test_async_generate_content_fails_open_on_tracer_error(
-        self, in_memory_span_exporter
-    ):
+    async def test_async_generate_content_fails_open_on_tracer_error(self, in_memory_span_exporter):
         from neatlogs.vertex_ai import wrap_vertex_ai_client
 
         _setup_tracer(in_memory_span_exporter)
@@ -72,9 +64,7 @@ class TestVertexAIFailOpen:
         async def generate_content(*args, **kwargs):
             return _vertex_response()
 
-        models = SimpleNamespace(
-            generate_content=generate_content, generate_content_stream=None
-        )
+        models = SimpleNamespace(generate_content=generate_content, generate_content_stream=None)
         aio = SimpleNamespace(models=models)
         client = SimpleNamespace(models=SimpleNamespace(), aio=aio)
         wrap_vertex_ai_client(client)

--- a/tests/integration/test_vertex_ai_fail_open.py
+++ b/tests/integration/test_vertex_ai_fail_open.py
@@ -92,3 +92,65 @@ class TestVertexAIFailOpen:
             result = wrap_vertex_ai_client(client)
 
         assert result is client
+
+    def test_sync_stream_called_once_when_setup_fails(self, in_memory_span_exporter):
+        """When telemetry setup fails, orig_generate_content_stream must be called exactly once."""
+        from neatlogs.vertex_ai import wrap_vertex_ai_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        call_count = {"n": 0}
+
+        def generate_content_stream(*args, **kwargs):
+            call_count["n"] += 1
+            return SimpleNamespace()
+
+        models = SimpleNamespace(
+            generate_content=lambda *a, **k: None,
+            generate_content_stream=generate_content_stream,
+        )
+        client = SimpleNamespace(models=models, aio=None)
+        wrap_vertex_ai_client(client)
+
+        with patch(
+            "neatlogs.vertex_ai.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            stream = client.models.generate_content_stream(model="gemini-1.5-pro", contents="hi")
+
+        assert call_count["n"] == 1, f"called {call_count['n']} times, expected 1"
+        assert stream is not None
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_stream_called_once_when_setup_fails(self, in_memory_span_exporter):
+        """Async path: setup fail → orig_generate_content_stream called exactly once."""
+        from neatlogs.vertex_ai import wrap_vertex_ai_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        call_count = {"n": 0}
+
+        async def generate_content_stream(*args, **kwargs):
+            call_count["n"] += 1
+            return SimpleNamespace()
+
+        models = SimpleNamespace(
+            generate_content=lambda *a, **k: None,
+            generate_content_stream=generate_content_stream,
+        )
+        aio = SimpleNamespace(models=models)
+        client = SimpleNamespace(models=SimpleNamespace(), aio=aio)
+        wrap_vertex_ai_client(client)
+
+        with patch(
+            "neatlogs.vertex_ai.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            stream = await client.aio.models.generate_content_stream(
+                model="gemini-1.5-pro", contents="hi"
+            )
+
+        assert call_count["n"] == 1, f"called {call_count['n']} times, expected 1"
+        assert stream is not None
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0


### PR DESCRIPTION
Fixes #33

The Vertex AI wrapper now matches the OpenAI/Anthropic/Google GenAI fail-open behavior. Wrap-time patches use _safe; sync and async generate_content and generate_content_stream skip tracing when span setup fails and call the original SDK method instead.

Chat sessions are out of scope for this PR.

Tests: tests/integration/test_vertex_ai_fail_open.py (3 passed with google-genai optional dep).