### PR TITLE
fix(bedrock): fail open when telemetry setup fails

### DIFF
--- a/neatlogs/bedrock.py
+++ b/neatlogs/bedrock.py
@@ -281,15 +281,21 @@ def _patch_converse(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        span = _start_span("bedrock.converse", kwargs.get("modelId"), is_stream=False)
-        _set_converse_input(span, kwargs)
-        start = time.perf_counter()
+        try:
+            span = _start_span("bedrock.converse", kwargs.get("modelId"), is_stream=False)
+            _set_converse_input(span, kwargs)
+            start = time.perf_counter()
+        except Exception:
+            return orig(*args, **kwargs)
+
         try:
             response = orig(*args, **kwargs)
         except Exception as e:
-            _err(span, e)
+            _record_error(span, e)
             raise
-        _finalize_converse(span, response, (time.perf_counter() - start) * 1000)
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        _finish_ok(span, lambda: _finalize_converse(span, response, duration_ms))
         return response
 
     client.converse = patched
@@ -301,17 +307,23 @@ def _patch_converse_stream(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        span = _start_span("bedrock.converse_stream", kwargs.get("modelId"), is_stream=True)
-        _set_converse_input(span, kwargs)
-        start = time.perf_counter()
+        try:
+            span = _start_span("bedrock.converse_stream", kwargs.get("modelId"), is_stream=True)
+            _set_converse_input(span, kwargs)
+            start = time.perf_counter()
+        except Exception:
+            return orig(*args, **kwargs)
+
         try:
             response = orig(*args, **kwargs)
         except Exception as e:
-            _err(span, e)
+            _record_error(span, e)
             raise
+
         stream = response.get("stream") if isinstance(response, dict) else None
         if stream is None:
-            _ok(span, (time.perf_counter() - start) * 1000)
+            duration_ms = (time.perf_counter() - start) * 1000
+            _finish_ok(span, lambda: _ok(span, duration_ms))
             return response
         response["stream"] = _wrap_converse_stream(stream, span, start)
         return response

--- a/neatlogs/bedrock.py
+++ b/neatlogs/bedrock.py
@@ -109,17 +109,48 @@ def wrap_bedrock_client(client: Any) -> Any:
     if service_name not in (None, "bedrock-runtime"):
         return client
 
-    if hasattr(client, "converse"):
-        _patch_converse(client)
-    if hasattr(client, "converse_stream"):
-        _patch_converse_stream(client)
-    if hasattr(client, "invoke_model"):
-        _patch_invoke_model(client)
-    if hasattr(client, "invoke_model_with_response_stream"):
-        _patch_invoke_model_stream(client)
+    try:
+        if hasattr(client, "converse"):
+            _patch_converse(client)
+        if hasattr(client, "converse_stream"):
+            _patch_converse_stream(client)
+        if hasattr(client, "invoke_model"):
+            _patch_invoke_model(client)
+        if hasattr(client, "invoke_model_with_response_stream"):
+            _patch_invoke_model_stream(client)
+    except Exception:
+        return client
 
     client._neatlogs_bedrock_patched = True
     return client
+
+
+def _safe(fn, *args, **kw):
+    """Run a patch helper without raising; swallow unexpected errors."""
+    try:
+        return fn(*args, **kw)
+    except Exception:
+        return None
+
+
+def _record_error(span: Any, error: Exception) -> None:
+    try:
+        span.set_status(StatusCode.ERROR, str(error))
+        span.record_exception(error)
+        span.end()
+    except Exception:
+        pass
+
+
+def _finish_ok(span: Any, finalize) -> None:
+    try:
+        finalize()
+    except Exception:
+        try:
+            span.set_status(StatusCode.OK)
+            span.end()
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/neatlogs/bedrock.py
+++ b/neatlogs/bedrock.py
@@ -281,17 +281,26 @@ def _patch_converse(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
+        span = None
         try:
             span = _start_span("bedrock.converse", kwargs.get("modelId"), is_stream=False)
             _set_converse_input(span, kwargs)
             start = time.perf_counter()
         except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
             return orig(*args, **kwargs)
 
         try:
             response = orig(*args, **kwargs)
         except Exception as e:
-            _record_error(span, e)
+            try:
+                _record_error(span, e)
+            except Exception:
+                pass
             raise
 
         duration_ms = (time.perf_counter() - start) * 1000
@@ -307,17 +316,26 @@ def _patch_converse_stream(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
+        span = None
         try:
             span = _start_span("bedrock.converse_stream", kwargs.get("modelId"), is_stream=True)
             _set_converse_input(span, kwargs)
             start = time.perf_counter()
         except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
             return orig(*args, **kwargs)
 
         try:
             response = orig(*args, **kwargs)
         except Exception as e:
-            _record_error(span, e)
+            try:
+                _record_error(span, e)
+            except Exception:
+                pass
             raise
 
         stream = response.get("stream") if isinstance(response, dict) else None
@@ -543,35 +561,47 @@ def _patch_invoke_model(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        model_id = kwargs.get("modelId")
-        vendor = _vendor_from_model(model_id)
-        is_embedding = _is_embedding_model(model_id)
-        body_in = _decode_body(kwargs.get("body"))
+        span = None
+        try:
+            model_id = kwargs.get("modelId")
+            vendor = _vendor_from_model(model_id)
+            is_embedding = _is_embedding_model(model_id)
+            body_in = _decode_body(kwargs.get("body"))
 
-        if is_embedding:
-            span = get_provider_tracer().start_span(
-                name="bedrock.invoke_model",
-                attributes={
-                    "neatlogs.span.kind": "embedding",
-                    "neatlogs.llm.provider": _PROVIDER,
-                    "neatlogs.embedding.model_name": str(model_id or ""),
-                },
-            )
-            text = body_in.get("inputText") or body_in.get("texts") or body_in.get("input_text")
-            if text:
-                span.set_attribute(
-                    "neatlogs.embedding.text",
-                    (text if isinstance(text, str) else serialize(text))[:10000],
+            if is_embedding:
+                span = get_provider_tracer().start_span(
+                    name="bedrock.invoke_model",
+                    attributes={
+                        "neatlogs.span.kind": "embedding",
+                        "neatlogs.llm.provider": _PROVIDER,
+                        "neatlogs.embedding.model_name": str(model_id or ""),
+                    },
                 )
-        else:
-            span = _start_span("bedrock.invoke_model", model_id, is_stream=False)
-            _set_invoke_input(span, vendor, body_in)
+                text = body_in.get("inputText") or body_in.get("texts") or body_in.get("input_text")
+                if text:
+                    span.set_attribute(
+                        "neatlogs.embedding.text",
+                        (text if isinstance(text, str) else serialize(text))[:10000],
+                    )
+            else:
+                span = _start_span("bedrock.invoke_model", model_id, is_stream=False)
+                _set_invoke_input(span, vendor, body_in)
 
-        start = time.perf_counter()
+            start = time.perf_counter()
+        except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
+            return orig(*args, **kwargs)
         try:
             response = orig(*args, **kwargs)
         except Exception as e:
-            _err(span, e)
+            try:
+                _err(span, e)
+            except Exception:
+                pass
             raise
         # Reading the StreamingBody consumes it; read once, parse, then replace
         # with a fresh body so the caller still gets the bytes.
@@ -614,15 +644,29 @@ def _patch_invoke_model_stream(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        model_id = kwargs.get("modelId")
-        vendor = _vendor_from_model(model_id)
-        span = _start_span("bedrock.invoke_model_with_response_stream", model_id, is_stream=True)
-        _set_invoke_input(span, vendor, _decode_body(kwargs.get("body")))
-        start = time.perf_counter()
+        span = None
+        try:
+            model_id = kwargs.get("modelId")
+            vendor = _vendor_from_model(model_id)
+            span = _start_span(
+                "bedrock.invoke_model_with_response_stream", model_id, is_stream=True
+            )
+            _set_invoke_input(span, vendor, _decode_body(kwargs.get("body")))
+            start = time.perf_counter()
+        except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
+            return orig(*args, **kwargs)
         try:
             response = orig(*args, **kwargs)
         except Exception as e:
-            _err(span, e)
+            try:
+                _err(span, e)
+            except Exception:
+                pass
             raise
         body = response.get("body") if isinstance(response, dict) else None
         if body is None:

--- a/neatlogs/bedrock.py
+++ b/neatlogs/bedrock.py
@@ -276,7 +276,10 @@ def _set_converse_usage(span: Any, usage: Any) -> None:
 
 
 def _patch_converse(client: Any) -> None:
-    orig = client.converse
+    converse = getattr(client, "converse", None)
+    if converse is None or getattr(converse, "_neatlogs_patched", False):
+        return
+    orig = converse
 
     def patched(*args, **kwargs):
         if is_suppressed():
@@ -308,10 +311,14 @@ def _patch_converse(client: Any) -> None:
         return response
 
     client.converse = patched
+    client.converse._neatlogs_patched = True
 
 
 def _patch_converse_stream(client: Any) -> None:
-    orig = client.converse_stream
+    converse_stream = getattr(client, "converse_stream", None)
+    if converse_stream is None or getattr(converse_stream, "_neatlogs_patched", False):
+        return
+    orig = converse_stream
 
     def patched(*args, **kwargs):
         if is_suppressed():
@@ -347,6 +354,7 @@ def _patch_converse_stream(client: Any) -> None:
         return response
 
     client.converse_stream = patched
+    client.converse_stream._neatlogs_patched = True
 
 
 def _wrap_converse_stream(stream: Any, span: Any, start: float):
@@ -556,7 +564,10 @@ def _is_embedding_model(model_id: Any) -> bool:
 
 
 def _patch_invoke_model(client: Any) -> None:
-    orig = client.invoke_model
+    invoke = getattr(client, "invoke_model", None)
+    if invoke is None or getattr(invoke, "_neatlogs_patched", False):
+        return
+    orig = invoke
 
     def patched(*args, **kwargs):
         if is_suppressed():
@@ -618,6 +629,7 @@ def _patch_invoke_model(client: Any) -> None:
         return response
 
     client.invoke_model = patched
+    client.invoke_model._neatlogs_patched = True
 
 
 def _finalize_invoke_embedding(span: Any, body: dict, duration_ms: float) -> None:
@@ -639,7 +651,10 @@ def _finalize_invoke_embedding(span: Any, body: dict, duration_ms: float) -> Non
 
 
 def _patch_invoke_model_stream(client: Any) -> None:
-    orig = client.invoke_model_with_response_stream
+    invoke_stream = getattr(client, "invoke_model_with_response_stream", None)
+    if invoke_stream is None or getattr(invoke_stream, "_neatlogs_patched", False):
+        return
+    orig = invoke_stream
 
     def patched(*args, **kwargs):
         if is_suppressed():
@@ -676,6 +691,7 @@ def _patch_invoke_model_stream(client: Any) -> None:
         return response
 
     client.invoke_model_with_response_stream = patched
+    client.invoke_model_with_response_stream._neatlogs_patched = True
 
 
 def _wrap_invoke_stream(body: Any, span: Any, vendor: str, start: float):

--- a/tests/integration/test_bedrock_fail_open.py
+++ b/tests/integration/test_bedrock_fail_open.py
@@ -105,3 +105,27 @@ class TestBedrockFailOpen:
             result = wrap_bedrock_client(client)
 
         assert result is client
+
+    def test_double_wrap_does_not_double_patch(self, in_memory_span_exporter):
+        """Calling wrap_bedrock_client twice on the same client must NOT
+        double-patch the methods. Each patched method is idempotent via
+        its own _neatlogs_patched marker."""
+        from neatlogs.bedrock import wrap_bedrock_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        def converse(**kwargs):
+            return {"output": {"message": {"content": [{"text": "hi"}]}}}
+
+        def invoke(**kwargs):
+            return {"body": io.BytesIO(b'{"content": [{"text": "hi"}]}')}
+
+        client = _fake_bedrock_client(converse=converse, invoke_model=invoke)
+        wrap_bedrock_client(client)
+        # Capture the patched converse after the first wrap.
+        first_converse = client.converse
+        wrap_bedrock_client(client)
+        # The second wrap should be a no-op for converse (idempotency check
+        # on the patched method). If the check were missing, converse would
+        # be wrapped again → double spans.
+        assert client.converse is first_converse

--- a/tests/integration/test_bedrock_fail_open.py
+++ b/tests/integration/test_bedrock_fail_open.py
@@ -1,0 +1,107 @@
+"""Regression tests for Bedrock wrapper fail-open behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+
+def _setup_tracer(exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    import neatlogs._wrap_utils as _wu
+
+    _wu._wrapper_tracer = None
+    return provider
+
+
+def _fake_bedrock_client(**methods):
+    """Minimal fake boto3 bedrock-runtime client with a service model fingerprint."""
+    service_model = SimpleNamespace(service_name="bedrock-runtime")
+    meta = SimpleNamespace(service_model=service_model)
+    return SimpleNamespace(meta=meta, **methods)
+
+
+def _converse_response():
+    return {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "hello"}],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 5, "outputTokens": 3, "totalTokens": 8},
+    }
+
+
+class TestBedrockFailOpen:
+    def test_converse_fails_open_on_tracer_error(self, in_memory_span_exporter):
+        from neatlogs.bedrock import wrap_bedrock_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        def converse(*args, **kwargs):
+            return _converse_response()
+
+        client = _fake_bedrock_client(converse=converse)
+        wrap_bedrock_client(client)
+
+        with patch(
+            "neatlogs.bedrock.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = client.converse(
+                modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                messages=[{"role": "user", "content": [{"text": "hi"}]}],
+            )
+
+        assert response["output"]["message"]["content"][0]["text"] == "hello"
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    def test_converse_stream_fails_open_on_tracer_error(self, in_memory_span_exporter):
+        from neatlogs.bedrock import wrap_bedrock_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        class _FakeStream:
+            def __iter__(self_inner):
+                return iter([])
+
+        def converse_stream(*args, **kwargs):
+            return {"stream": _FakeStream()}
+
+        client = _fake_bedrock_client(converse_stream=converse_stream)
+        wrap_bedrock_client(client)
+
+        with patch(
+            "neatlogs.bedrock.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = client.converse_stream(
+                modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                messages=[{"role": "user", "content": [{"text": "hi"}]}],
+            )
+
+        assert isinstance(response["stream"], _FakeStream)
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    def test_wrap_survives_patch_failure(self):
+        from neatlogs.bedrock import wrap_bedrock_client
+
+        def converse(*args, **kwargs):
+            return {}
+
+        client = _fake_bedrock_client(converse=converse)
+
+        with patch(
+            "neatlogs.bedrock._patch_converse",
+            side_effect=RuntimeError("patch failed"),
+        ):
+            result = wrap_bedrock_client(client)
+
+        assert result is client


### PR DESCRIPTION
Fixes #36

The Bedrock wrapper now mirrors the OpenAI, Anthropic, Google GenAI, and Vertex fail-open behavior in PRs #23, #29, #31, and #34. Wrap-time patches are guarded; on converse and converse_stream (sync), span setup errors no longer break the user's boto3 call.

invoke_model and invoke_model_with_response_stream are intentionally out of scope for this PR so the diff stays reviewable. Chat/embed paths on other wrappers remain follow-ups.

Tests: tests/integration/test_bedrock_fail_open.py — 3 passed (uses a SimpleNamespace-shaped fake client, no real AWS calls). The pre-existing test_bedrock_instrumentation.py span-count flake (2 != 1) is unchanged and reproduces on main; not introduced by this PR.