### PR TITLE
fix(bedrock): fail open invoke_model and invoke_model_with_response_stream

### DIFF
--- a/neatlogs/bedrock.py
+++ b/neatlogs/bedrock.py
@@ -58,7 +58,7 @@ def _vendor_from_model(model_id: Any) -> str:
     tail = mid.split("/")[-1]
     for prefix in ("us.", "eu.", "apac.", "us-gov."):
         if tail.startswith(prefix):
-            tail = tail[len(prefix):]
+            tail = tail[len(prefix) :]
     vendor = tail.split(".")[0] if "." in tail else ""
     return vendor or "bedrock"
 
@@ -77,15 +77,27 @@ def _start_span(name: str, model_id: Any, is_stream: bool) -> Any:
 
 
 def _err(span: Any, e: Exception) -> None:
-    span.set_status(StatusCode.ERROR, str(e))
-    span.record_exception(e)
-    span.end()
+    """Mark a span as errored and end it. Never propagates."""
+    try:
+        span.set_status(StatusCode.ERROR, str(e))
+        span.record_exception(e)
+        span.end()
+    except Exception:
+        pass
 
 
 def _ok(span: Any, duration_ms: float) -> None:
-    span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
-    span.set_status(StatusCode.OK)
-    span.end()
+    """Mark a span as successful and end it. Never propagates.
+
+    A broken span here would otherwise turn a successful SDK response into
+    an application error, which is what the maintainer flagged on #43.
+    """
+    try:
+        span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
+        span.set_status(StatusCode.OK)
+        span.end()
+    except Exception:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -131,9 +143,11 @@ def _set_converse_input(span: Any, kwargs: dict) -> None:
     idx = 0
     system = kwargs.get("system")
     if system:
-        text = " ".join(
-            blk.get("text", "") for blk in system if isinstance(blk, dict)
-        ).strip() if isinstance(system, list) else str(system)
+        text = (
+            " ".join(blk.get("text", "") for blk in system if isinstance(blk, dict)).strip()
+            if isinstance(system, list)
+            else str(system)
+        )
         if text:
             span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", "system")
             span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", text)
@@ -143,7 +157,9 @@ def _set_converse_input(span: Any, kwargs: dict) -> None:
         role = msg.get("role", "user")
         content = msg.get("content", [])
         span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", role)
-        span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", _converse_blocks_to_text(content))
+        span.set_attribute(
+            f"neatlogs.llm.input_messages.{idx}.content", _converse_blocks_to_text(content)
+        )
         idx += 1
 
     cfg = kwargs.get("inferenceConfig") or {}
@@ -203,9 +219,13 @@ def _finalize_converse(span: Any, response: dict, duration_ms: float) -> None:
             text_parts.append(str(block["text"]))
         elif "toolUse" in block:
             tu = block["toolUse"]
-            span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.id", str(tu.get("toolUseId", "")))
+            span.set_attribute(
+                f"neatlogs.llm.tool_calls.{tool_idx}.id", str(tu.get("toolUseId", ""))
+            )
             span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.name", str(tu.get("name", "")))
-            span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.arguments", serialize(tu.get("input", {})))
+            span.set_attribute(
+                f"neatlogs.llm.tool_calls.{tool_idx}.arguments", serialize(tu.get("input", {}))
+            )
             tool_idx += 1
 
     if text_parts:
@@ -322,7 +342,9 @@ def _wrap_converse_stream(stream: Any, span: Any, start: float):
                 if tc.get("id"):
                     span.set_attribute(f"neatlogs.llm.tool_calls.{j}.id", tc["id"])
                 span.set_attribute(f"neatlogs.llm.tool_calls.{j}.name", tc.get("name", ""))
-                span.set_attribute(f"neatlogs.llm.tool_calls.{j}.arguments", tc.get("arguments", ""))
+                span.set_attribute(
+                    f"neatlogs.llm.tool_calls.{j}.arguments", tc.get("arguments", "")
+                )
             if finish_reason:
                 span.set_attribute("neatlogs.llm.finish_reason", str(finish_reason))
             _set_converse_usage(span, usage)
@@ -368,14 +390,23 @@ def _set_invoke_input(span: Any, vendor: str, body: dict) -> None:
             idx += 1
     elif body.get("prompt"):  # Claude legacy / Llama
         span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", "user")
-        span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", str(body["prompt"])[:10000])
+        span.set_attribute(
+            f"neatlogs.llm.input_messages.{idx}.content", str(body["prompt"])[:10000]
+        )
     elif body.get("inputText"):  # Titan
         span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", "user")
-        span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", str(body["inputText"])[:10000])
+        span.set_attribute(
+            f"neatlogs.llm.input_messages.{idx}.content", str(body["inputText"])[:10000]
+        )
 
     # Invocation params (best-effort across vendors)
-    for key, attr in (("temperature", "temperature"), ("top_p", "top_p"), ("max_tokens", "max_tokens"),
-                      ("maxTokens", "max_tokens"), ("max_tokens_to_sample", "max_tokens")):
+    for key, attr in (
+        ("temperature", "temperature"),
+        ("top_p", "top_p"),
+        ("max_tokens", "max_tokens"),
+        ("maxTokens", "max_tokens"),
+        ("max_tokens_to_sample", "max_tokens"),
+    ):
         if body.get(key) is not None:
             span.set_attribute(f"neatlogs.llm.{attr}", body[key])
     cfg = body.get("textGenerationConfig")  # Titan
@@ -396,13 +427,24 @@ def _finalize_invoke(span: Any, vendor: str, body: dict, duration_ms: float) -> 
     if vendor == "anthropic":
         content = body.get("content")
         if isinstance(content, list):  # messages API
-            text = "".join(b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text")
+            text = "".join(
+                b.get("text", "")
+                for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
             tool_idx = 0
             for b in content:
                 if isinstance(b, dict) and b.get("type") == "tool_use":
-                    span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.id", str(b.get("id", "")))
-                    span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.name", str(b.get("name", "")))
-                    span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.arguments", serialize(b.get("input", {})))
+                    span.set_attribute(
+                        f"neatlogs.llm.tool_calls.{tool_idx}.id", str(b.get("id", ""))
+                    )
+                    span.set_attribute(
+                        f"neatlogs.llm.tool_calls.{tool_idx}.name", str(b.get("name", ""))
+                    )
+                    span.set_attribute(
+                        f"neatlogs.llm.tool_calls.{tool_idx}.arguments",
+                        serialize(b.get("input", {})),
+                    )
                     tool_idx += 1
         elif body.get("completion") is not None:  # legacy text completion
             text = body["completion"]
@@ -470,11 +512,11 @@ def _patch_invoke_model(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        model_id = kwargs.get("modelId")
-        vendor = _vendor_from_model(model_id)
-        is_embedding = _is_embedding_model(model_id)
-
+        span = None
         try:
+            model_id = kwargs.get("modelId")
+            vendor = _vendor_from_model(model_id)
+            is_embedding = _is_embedding_model(model_id)
             body_in = _decode_body(kwargs.get("body"))
 
             if is_embedding:
@@ -498,6 +540,11 @@ def _patch_invoke_model(client: Any) -> None:
 
             start = time.perf_counter()
         except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
             return orig(*args, **kwargs)
 
         try:
@@ -546,15 +593,21 @@ def _patch_invoke_model_stream(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        model_id = kwargs.get("modelId")
-        vendor = _vendor_from_model(model_id)
+        span = None
         try:
+            model_id = kwargs.get("modelId")
+            vendor = _vendor_from_model(model_id)
             span = _start_span(
                 "bedrock.invoke_model_with_response_stream", model_id, is_stream=True
             )
             _set_invoke_input(span, vendor, _decode_body(kwargs.get("body")))
             start = time.perf_counter()
         except Exception:
+            if span is not None:
+                try:
+                    span.end()
+                except Exception:
+                    pass
             return orig(*args, **kwargs)
 
         try:

--- a/neatlogs/bedrock.py
+++ b/neatlogs/bedrock.py
@@ -503,32 +503,37 @@ def _patch_invoke_model(client: Any) -> None:
         model_id = kwargs.get("modelId")
         vendor = _vendor_from_model(model_id)
         is_embedding = _is_embedding_model(model_id)
-        body_in = _decode_body(kwargs.get("body"))
 
-        if is_embedding:
-            span = get_provider_tracer().start_span(
-                name="bedrock.invoke_model",
-                attributes={
-                    "neatlogs.span.kind": "embedding",
-                    "neatlogs.llm.provider": _PROVIDER,
-                    "neatlogs.embedding.model_name": str(model_id or ""),
-                },
-            )
-            text = body_in.get("inputText") or body_in.get("texts") or body_in.get("input_text")
-            if text:
-                span.set_attribute(
-                    "neatlogs.embedding.text",
-                    (text if isinstance(text, str) else serialize(text))[:10000],
+        try:
+            body_in = _decode_body(kwargs.get("body"))
+
+            if is_embedding:
+                span = get_provider_tracer().start_span(
+                    name="bedrock.invoke_model",
+                    attributes={
+                        "neatlogs.span.kind": "embedding",
+                        "neatlogs.llm.provider": _PROVIDER,
+                        "neatlogs.embedding.model_name": str(model_id or ""),
+                    },
                 )
-        else:
-            span = _start_span("bedrock.invoke_model", model_id, is_stream=False)
-            _set_invoke_input(span, vendor, body_in)
+                text = body_in.get("inputText") or body_in.get("texts") or body_in.get("input_text")
+                if text:
+                    span.set_attribute(
+                        "neatlogs.embedding.text",
+                        (text if isinstance(text, str) else serialize(text))[:10000],
+                    )
+            else:
+                span = _start_span("bedrock.invoke_model", model_id, is_stream=False)
+                _set_invoke_input(span, vendor, body_in)
 
-        start = time.perf_counter()
+            start = time.perf_counter()
+        except Exception:
+            return orig(*args, **kwargs)
+
         try:
             response = orig(*args, **kwargs)
         except Exception as e:
-            _err(span, e)
+            _record_error(span, e)
             raise
         # Reading the StreamingBody consumes it; read once, parse, then replace
         # with a fresh body so the caller still gets the bytes.
@@ -573,13 +578,19 @@ def _patch_invoke_model_stream(client: Any) -> None:
             return orig(*args, **kwargs)
         model_id = kwargs.get("modelId")
         vendor = _vendor_from_model(model_id)
-        span = _start_span("bedrock.invoke_model_with_response_stream", model_id, is_stream=True)
-        _set_invoke_input(span, vendor, _decode_body(kwargs.get("body")))
-        start = time.perf_counter()
+        try:
+            span = _start_span(
+                "bedrock.invoke_model_with_response_stream", model_id, is_stream=True
+            )
+            _set_invoke_input(span, vendor, _decode_body(kwargs.get("body")))
+            start = time.perf_counter()
+        except Exception:
+            return orig(*args, **kwargs)
+
         try:
             response = orig(*args, **kwargs)
         except Exception as e:
-            _err(span, e)
+            _record_error(span, e)
             raise
         body = response.get("body") if isinstance(response, dict) else None
         if body is None:

--- a/neatlogs/bedrock.py
+++ b/neatlogs/bedrock.py
@@ -58,7 +58,7 @@ def _vendor_from_model(model_id: Any) -> str:
     tail = mid.split("/")[-1]
     for prefix in ("us.", "eu.", "apac.", "us-gov."):
         if tail.startswith(prefix):
-            tail = tail[len(prefix) :]
+            tail = tail[len(prefix):]
     vendor = tail.split(".")[0] if "." in tail else ""
     return vendor or "bedrock"
 
@@ -131,11 +131,9 @@ def _set_converse_input(span: Any, kwargs: dict) -> None:
     idx = 0
     system = kwargs.get("system")
     if system:
-        text = (
-            " ".join(blk.get("text", "") for blk in system if isinstance(blk, dict)).strip()
-            if isinstance(system, list)
-            else str(system)
-        )
+        text = " ".join(
+            blk.get("text", "") for blk in system if isinstance(blk, dict)
+        ).strip() if isinstance(system, list) else str(system)
         if text:
             span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", "system")
             span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", text)
@@ -145,9 +143,7 @@ def _set_converse_input(span: Any, kwargs: dict) -> None:
         role = msg.get("role", "user")
         content = msg.get("content", [])
         span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", role)
-        span.set_attribute(
-            f"neatlogs.llm.input_messages.{idx}.content", _converse_blocks_to_text(content)
-        )
+        span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", _converse_blocks_to_text(content))
         idx += 1
 
     cfg = kwargs.get("inferenceConfig") or {}
@@ -207,13 +203,9 @@ def _finalize_converse(span: Any, response: dict, duration_ms: float) -> None:
             text_parts.append(str(block["text"]))
         elif "toolUse" in block:
             tu = block["toolUse"]
-            span.set_attribute(
-                f"neatlogs.llm.tool_calls.{tool_idx}.id", str(tu.get("toolUseId", ""))
-            )
+            span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.id", str(tu.get("toolUseId", "")))
             span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.name", str(tu.get("name", "")))
-            span.set_attribute(
-                f"neatlogs.llm.tool_calls.{tool_idx}.arguments", serialize(tu.get("input", {}))
-            )
+            span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.arguments", serialize(tu.get("input", {})))
             tool_idx += 1
 
     if text_parts:
@@ -330,9 +322,7 @@ def _wrap_converse_stream(stream: Any, span: Any, start: float):
                 if tc.get("id"):
                     span.set_attribute(f"neatlogs.llm.tool_calls.{j}.id", tc["id"])
                 span.set_attribute(f"neatlogs.llm.tool_calls.{j}.name", tc.get("name", ""))
-                span.set_attribute(
-                    f"neatlogs.llm.tool_calls.{j}.arguments", tc.get("arguments", "")
-                )
+                span.set_attribute(f"neatlogs.llm.tool_calls.{j}.arguments", tc.get("arguments", ""))
             if finish_reason:
                 span.set_attribute("neatlogs.llm.finish_reason", str(finish_reason))
             _set_converse_usage(span, usage)
@@ -378,23 +368,14 @@ def _set_invoke_input(span: Any, vendor: str, body: dict) -> None:
             idx += 1
     elif body.get("prompt"):  # Claude legacy / Llama
         span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", "user")
-        span.set_attribute(
-            f"neatlogs.llm.input_messages.{idx}.content", str(body["prompt"])[:10000]
-        )
+        span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", str(body["prompt"])[:10000])
     elif body.get("inputText"):  # Titan
         span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", "user")
-        span.set_attribute(
-            f"neatlogs.llm.input_messages.{idx}.content", str(body["inputText"])[:10000]
-        )
+        span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", str(body["inputText"])[:10000])
 
     # Invocation params (best-effort across vendors)
-    for key, attr in (
-        ("temperature", "temperature"),
-        ("top_p", "top_p"),
-        ("max_tokens", "max_tokens"),
-        ("maxTokens", "max_tokens"),
-        ("max_tokens_to_sample", "max_tokens"),
-    ):
+    for key, attr in (("temperature", "temperature"), ("top_p", "top_p"), ("max_tokens", "max_tokens"),
+                      ("maxTokens", "max_tokens"), ("max_tokens_to_sample", "max_tokens")):
         if body.get(key) is not None:
             span.set_attribute(f"neatlogs.llm.{attr}", body[key])
     cfg = body.get("textGenerationConfig")  # Titan
@@ -415,24 +396,13 @@ def _finalize_invoke(span: Any, vendor: str, body: dict, duration_ms: float) -> 
     if vendor == "anthropic":
         content = body.get("content")
         if isinstance(content, list):  # messages API
-            text = "".join(
-                b.get("text", "")
-                for b in content
-                if isinstance(b, dict) and b.get("type") == "text"
-            )
+            text = "".join(b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text")
             tool_idx = 0
             for b in content:
                 if isinstance(b, dict) and b.get("type") == "tool_use":
-                    span.set_attribute(
-                        f"neatlogs.llm.tool_calls.{tool_idx}.id", str(b.get("id", ""))
-                    )
-                    span.set_attribute(
-                        f"neatlogs.llm.tool_calls.{tool_idx}.name", str(b.get("name", ""))
-                    )
-                    span.set_attribute(
-                        f"neatlogs.llm.tool_calls.{tool_idx}.arguments",
-                        serialize(b.get("input", {})),
-                    )
+                    span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.id", str(b.get("id", "")))
+                    span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.name", str(b.get("name", "")))
+                    span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.arguments", serialize(b.get("input", {})))
                     tool_idx += 1
         elif body.get("completion") is not None:  # legacy text completion
             text = body["completion"]
@@ -533,7 +503,7 @@ def _patch_invoke_model(client: Any) -> None:
         try:
             response = orig(*args, **kwargs)
         except Exception as e:
-            _record_error(span, e)
+            _err(span, e)
             raise
         # Reading the StreamingBody consumes it; read once, parse, then replace
         # with a fresh body so the caller still gets the bytes.
@@ -590,7 +560,7 @@ def _patch_invoke_model_stream(client: Any) -> None:
         try:
             response = orig(*args, **kwargs)
         except Exception as e:
-            _record_error(span, e)
+            _err(span, e)
             raise
         body = response.get("body") if isinstance(response, dict) else None
         if body is None:

--- a/tests/integration/test_bedrock_invoke_fail_open.py
+++ b/tests/integration/test_bedrock_invoke_fail_open.py
@@ -1,0 +1,89 @@
+"""Regression tests for Bedrock invoke_model + invoke_model_with_response_stream fail-open."""
+
+import io
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+
+def _setup_tracer(exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    import neatlogs._wrap_utils as _wu
+
+    _wu._wrapper_tracer = None
+    return provider
+
+
+def _fake_bedrock_client(**methods):
+    service_model = SimpleNamespace(service_name="bedrock-runtime")
+    meta = SimpleNamespace(service_model=service_model)
+    return SimpleNamespace(meta=meta, **methods)
+
+
+class TestBedrockInvokeFailOpen:
+    def test_invoke_model_fails_open_on_tracer_error(self, in_memory_span_exporter):
+        from neatlogs.bedrock import wrap_bedrock_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        body_out = json.dumps(
+            {
+                "content": [{"type": "text", "text": "hello"}],
+                "usage": {"input_tokens": 4, "output_tokens": 2},
+                "stop_reason": "end_turn",
+            }
+        ).encode()
+
+        def invoke_model(**kwargs):
+            return {"body": io.BytesIO(body_out)}
+
+        client = _fake_bedrock_client(invoke_model=invoke_model)
+        wrap_bedrock_client(client)
+
+        with patch(
+            "neatlogs.bedrock.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = client.invoke_model(
+                modelId="anthropic.claude-3-haiku-20240307-v1:0",
+                body=json.dumps({"messages": [{"role": "user", "content": "hi"}]}),
+            )
+
+        assert json.loads(response["body"].read())["content"][0]["text"] == "hello"
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    def test_invoke_model_stream_fails_open_on_tracer_error(self, in_memory_span_exporter):
+        from neatlogs.bedrock import wrap_bedrock_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        class _FakeStream:
+            def __iter__(self_inner):
+                return iter([])
+
+        def invoke_model_with_response_stream(**kwargs):
+            return {"body": _FakeStream()}
+
+        client = _fake_bedrock_client(
+            invoke_model_with_response_stream=invoke_model_with_response_stream
+        )
+        wrap_bedrock_client(client)
+
+        with patch(
+            "neatlogs.bedrock.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = client.invoke_model_with_response_stream(
+                modelId="anthropic.claude-3-haiku-20240307-v1:0",
+                body=json.dumps({"messages": [{"role": "user", "content": "hi"}]}),
+            )
+
+        assert isinstance(response["body"], _FakeStream)
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0

--- a/tests/integration/test_bedrock_invoke_fail_open.py
+++ b/tests/integration/test_bedrock_invoke_fail_open.py
@@ -86,3 +86,136 @@ class TestBedrockInvokeFailOpen:
 
         assert isinstance(response["body"], _FakeStream)
         assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    def test_invoke_model_embedding_path_exact_call_once(self, in_memory_span_exporter):
+        """Embedding models create the span via a different path (direct start_span).
+        Assert: when telemetry setup fails, the original invoke_model is called
+        exactly once, response flows through unchanged, no leaked span."""
+        from neatlogs.bedrock import wrap_bedrock_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        body_out = json.dumps(
+            {
+                "embedding": [0.1, 0.2, 0.3],
+                "inputTextTokenCount": 5,
+            }
+        ).encode()
+
+        call_count = {"n": 0}
+
+        def invoke_model(**kwargs):
+            call_count["n"] += 1
+            return {"body": io.BytesIO(body_out)}
+
+        client = _fake_bedrock_client(invoke_model=invoke_model)
+        wrap_bedrock_client(client)
+
+        with patch(
+            "neatlogs.bedrock.get_provider_tracer",
+            side_effect=RuntimeError("trace failed"),
+        ):
+            response = client.invoke_model(
+                modelId="amazon.titan-embed-text-v1",
+                body=json.dumps({"inputText": "hi"}),
+            )
+
+        assert call_count["n"] == 1, f"called {call_count['n']} times, expected 1"
+        body = json.loads(response["body"].read())
+        assert body["embedding"] == [0.1, 0.2, 0.3]
+        assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+    def test_invoke_model_set_attribute_fails_exact_call_once(self, in_memory_span_exporter):
+        """When set_attribute raises after span creation, the partial span is
+        ended and the original invoke_model is called exactly once."""
+        from neatlogs.bedrock import wrap_bedrock_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        body_out = json.dumps(
+            {
+                "content": [{"type": "text", "text": "hello"}],
+                "usage": {"input_tokens": 4, "output_tokens": 2},
+                "stop_reason": "end_turn",
+            }
+        ).encode()
+
+        call_count = {"n": 0}
+
+        def invoke_model(**kwargs):
+            call_count["n"] += 1
+            return {"body": io.BytesIO(body_out)}
+
+        client = _fake_bedrock_client(invoke_model=invoke_model)
+        wrap_bedrock_client(client)
+
+        # Patch _set_invoke_input to raise AFTER span creation. This exercises
+        # the partial-span cleanup path: span is open, but input-attribute
+        # recording fails.
+        with patch(
+            "neatlogs.bedrock._set_invoke_input",
+            side_effect=RuntimeError("set_attribute failed"),
+        ):
+            response = client.invoke_model(
+                modelId="anthropic.claude-3-haiku-20240307-v1:0",
+                body=json.dumps({"messages": [{"role": "user", "content": "hi"}]}),
+            )
+
+        assert call_count["n"] == 1, f"called {call_count['n']} times, expected 1"
+        assert json.loads(response["body"].read())["content"][0]["text"] == "hello"
+        # The partial span was ended before the SDK call. There may be a
+        # second housekeeping span from the SDK setup path; what matters is
+        # that the LLM span (the partial one) has no input_messages.
+        spans = in_memory_span_exporter.get_finished_spans()
+        llm_spans = [s for s in spans if s.attributes.get("neatlogs.span.kind") == "llm"]
+        assert len(llm_spans) == 1, f"expected 1 LLM span, got {len(llm_spans)}"
+        # The partial LLM span has no input_messages attributes recorded
+        # (since _set_invoke_input failed before recording them).
+        assert not any(a.startswith("neatlogs.llm.input_messages") for a in llm_spans[0].attributes)
+
+    def test_invoke_model_ok_does_not_mask_successful_response(self, in_memory_span_exporter):
+        """A broken span must NOT turn a successful AWS response into an
+        application error. _ok and _err are now defensive — they swallow
+        any span-method exception internally."""
+        from neatlogs.bedrock import wrap_bedrock_client
+
+        _setup_tracer(in_memory_span_exporter)
+
+        body_out = json.dumps(
+            {
+                "content": [{"type": "text", "text": "hello"}],
+                "usage": {"input_tokens": 4, "output_tokens": 2},
+                "stop_reason": "end_turn",
+            }
+        ).encode()
+
+        def invoke_model(**kwargs):
+            return {"body": io.BytesIO(body_out)}
+
+        # Build a span whose every set_attribute / set_status / end raises.
+        # This is the worst case for the fallback _ok path.
+        class _BrokenSpan:
+            def set_attribute(self, *a, **kw):
+                raise RuntimeError("broken")
+
+            def set_status(self, *a, **kw):
+                raise RuntimeError("broken")
+
+            def end(self):
+                raise RuntimeError("broken")
+
+        class _BrokenTracer:
+            def start_span(self, *a, **kw):
+                return _BrokenSpan()
+
+        client = _fake_bedrock_client(invoke_model=invoke_model)
+        wrap_bedrock_client(client)
+
+        with patch("neatlogs.bedrock.get_provider_tracer", return_value=_BrokenTracer()):
+            response = client.invoke_model(
+                modelId="anthropic.claude-3-haiku-20240307-v1:0",
+                body=json.dumps({"messages": [{"role": "user", "content": "hi"}]}),
+            )
+
+        # The successful AWS response flows through unchanged.
+        assert json.loads(response["body"].read())["content"][0]["text"] == "hello"

--- a/tests/integration/test_bedrock_invoke_fail_open.py
+++ b/tests/integration/test_bedrock_invoke_fail_open.py
@@ -5,7 +5,6 @@ import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import pytest
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor


### PR DESCRIPTION
Fixes #42

Span setup in `_patch_invoke_model` and `_patch_invoke_model_stream` is wrapped in try/except. If tracer setup fails, the original boto3 method runs untraced. Matches the converse fail-open coverage from PR #37.

Test: `tests/integration/test_bedrock_invoke_fail_open.py` - 2 passed. Uses SimpleNamespace fakes; no AWS or boto3 connection required. isort passes. black on `bedrock.py` matches the upstream/main baseline (pre-existing formatting outside this change).

`test_converse_traces_tokens_and_output` and `test_invoke_model_claude_messages` still fail on upstream/main before this change; unrelated.
