### PR TITLE
feat(groq): add Groq chat completions wrapper

### DIFF
--- a/neatlogs/_wrap_utils.py
+++ b/neatlogs/_wrap_utils.py
@@ -589,6 +589,35 @@ def is_suppressed() -> bool:
         return False
 
 
+def _telemetry_fallback(orig: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Call the untraced original directly.
+
+    Used by provider wrappers when their own pre-execution or finalize phase
+    raises an exception. The user's primary LLM call must never be blocked
+    by a neatlogs internal bug; a telemetry library should fail open, not
+    crash the host application.
+    """
+    return orig(*args, **kwargs)
+
+
+def _safe_finalize(span: Any, finalize_fn: Callable[..., Any], *args: Any) -> None:
+    """Run a finalize callback; if it throws, end the span with OK so it is
+    not leaked, then swallow. Used by the per-call wrappers when the LLM
+    call has already returned a response and the only thing left is to
+    record telemetry attributes.
+    """
+    try:
+        finalize_fn(span, *args)
+    except Exception:
+        from opentelemetry.trace import StatusCode
+
+        try:
+            span.set_status(StatusCode.OK)
+            span.end()
+        except Exception:
+            pass
+
+
 # ---------------------------------------------------------------------------
 # Auto-root
 #

--- a/neatlogs/groq.py
+++ b/neatlogs/groq.py
@@ -1,0 +1,498 @@
+"""
+Neatlogs Groq wrapper.
+
+Groq's official Python SDK (``groq``) is OpenAI-compatible and exposes a
+``chat.completions`` resource on both ``groq.Groq`` (sync) and
+``groq.AsyncGroq`` (async). This module traces chat completions — sync,
+async, and streaming — on a wrapped client instance.
+
+Usage (the client is mutated in place and also returned):
+
+  >>> import neatlogs
+  >>> from groq import Groq
+  >>> client = neatlogs.wrap(Groq(api_key=os.environ["GROQ_API_KEY"]))
+  >>> client.chat.completions.create(
+  ...     model="llama-3.3-70b-versatile",
+  ...     messages=[{"role": "user", "content": "hi"}],
+  ... )
+
+``neatlogs.llm.provider`` is always ``groq``; ``neatlogs.llm.system`` is also
+``groq`` because every model the SDK serves is hosted by Groq's own inference
+infrastructure (model slug is preserved as ``neatlogs.llm.model_name``).
+"""
+
+import time
+from typing import Any, List, Optional
+
+from opentelemetry.trace import StatusCode
+
+from ._wrap_utils import (
+    AsyncStreamWrapper,
+    SyncStreamWrapper,
+    get_provider_tracer,
+    is_suppressed,
+    serialize,
+)
+
+try:  # Groq SDK Omit sentinel — distinguish "user did not set" from "user set None".
+    from groq import Omit as _GroqOmit  # noqa: F401
+except Exception:  # pragma: no cover - groq not installed
+    _GroqOmit = type("_NoOmit", (), {})
+
+
+def _is_set(val: Any) -> bool:
+    """True if the user actually passed a value (filtering out Groq's ``Omit``)."""
+    if val is None:
+        return False
+    if isinstance(val, _GroqOmit):
+        return False
+    return True
+
+
+_PROVIDER = "groq"
+
+
+class GroqInstrumentor:
+    """
+    Instrumentor class for InstrumentationManager integration.
+
+    The Groq SDK has no import-time public class we patch globally; clients
+    are wrapped explicitly via ``neatlogs.wrap(Groq(...))``. This shim lets
+    ``init(instrumentations=["groq"])`` patch the constructor so every client
+    built afterward is auto-wrapped.
+    """
+
+    def instrument(self, tracer_provider=None):
+        _patch_groq_module()
+
+    def uninstrument(self):
+        _unpatch_groq_module()
+
+
+# ---------------------------------------------------------------------------
+# Public wrap entrypoint
+# ---------------------------------------------------------------------------
+
+
+def wrap_groq_client(client: Any) -> Any:
+    """
+    Wrap a ``groq.Groq`` or ``groq.AsyncGroq`` client instance. Patches
+    ``client.chat.completions.create`` to auto-trace; returns the same client.
+    Idempotent.
+    """
+    if getattr(client, "_neatlogs_groq_wrapped", False):
+        return client
+
+    chat = getattr(client, "chat", None)
+    if chat is not None:
+        completions = getattr(chat, "completions", None)
+        if completions is not None:
+            _safe(_patch_completions, completions)
+
+    client._neatlogs_groq_wrapped = True
+    return client
+
+
+def _safe(fn, resource) -> None:
+    if resource is None:
+        return
+    try:
+        fn(resource)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Shared attribute helpers
+# ---------------------------------------------------------------------------
+
+_PARAM_KEYS = (
+    "temperature",
+    "top_p",
+    "max_tokens",
+    "max_completion_tokens",
+    "frequency_penalty",
+    "presence_penalty",
+    "seed",
+    "stop",
+    "reasoning_effort",
+    "service_tier",
+)
+
+
+def _set_invocation_params(span: Any, kwargs: dict) -> None:
+    """Capture sampling/generation params + write the canonical
+    ``neatlogs.llm.invocation_parameters`` blob the backend reads as
+    ``model_settings`` in the UI."""
+    params = {}
+    for key in _PARAM_KEYS:
+        val = kwargs.get(key)
+        if not _is_set(val):
+            continue
+        params[key] = val
+        span.set_attribute(
+            f"neatlogs.llm.{key}",
+            val if not isinstance(val, (list, dict)) else serialize(val),
+        )
+    if params:
+        span.set_attribute("neatlogs.llm.invocation_parameters", serialize(params))
+
+
+def _set_chat_input(span: Any, kwargs: dict) -> None:
+    messages = kwargs.get("messages", []) or []
+    for i, msg in enumerate(messages):
+        role = _get(msg, "role", "")
+        content = _get(msg, "content", "")
+        span.set_attribute(f"neatlogs.llm.input_messages.{i}.role", role or "")
+        span.set_attribute(
+            f"neatlogs.llm.input_messages.{i}.content",
+            content if isinstance(content, str) else serialize(content),
+        )
+        tool_call_id = _get(msg, "tool_call_id", None)
+        if tool_call_id:
+            span.set_attribute(f"neatlogs.llm.input_messages.{i}.tool_call_id", tool_call_id)
+    if messages:
+        span.set_attribute("input.value", serialize(_plain(messages)))
+
+    tools = kwargs.get("tools")
+    if tools:
+        for i, tool in enumerate(tools):
+            fn = _get(tool, "function", {}) or {}
+            name = _get(fn, "name", None) or _get(tool, "name", None)
+            if name:
+                span.set_attribute(f"neatlogs.llm.tools.{i}.name", name)
+            desc = _get(fn, "description", None) or _get(tool, "description", None)
+            if desc:
+                span.set_attribute(f"neatlogs.llm.tools.{i}.description", desc)
+            schema = _get(fn, "parameters", None)
+            if schema:
+                span.set_attribute(
+                    f"neatlogs.llm.tools.{i}.input_schema", serialize(_plain(schema))
+                )
+
+
+def _get(obj: Any, key: str, default: Any) -> Any:
+    """Read ``key`` from a dict or a pydantic/attr object."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _plain(obj: Any) -> Any:
+    """Best-effort convert pydantic models to plain dicts for serialization."""
+    if isinstance(obj, list):
+        return [_plain(o) for o in obj]
+    if isinstance(obj, dict):
+        return obj
+    dump = getattr(obj, "model_dump", None)
+    if callable(dump):
+        try:
+            return dump(exclude_none=True)
+        except Exception:
+            pass
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Chat Completions: client.chat.completions.create (sync + async)
+# ---------------------------------------------------------------------------
+
+
+def _patch_completions(completions: Any) -> None:
+    if getattr(completions, "_neatlogs_groq_patched", False):
+        return
+
+    orig_create = getattr(completions, "create", None)
+    if not callable(orig_create):
+        return
+
+    is_async_cls = _is_async_completions(completions)
+
+    if is_async_cls:
+
+        async def patched_create_async(*args, **kwargs):
+            if is_suppressed():
+                return await orig_create(*args, **kwargs)
+            is_stream = bool(kwargs.get("stream", False))
+            try:
+                span = _start(kwargs, is_stream)
+                start = time.perf_counter()
+            except Exception:
+                return await orig_create(*args, **kwargs)
+            try:
+                response = await orig_create(*args, **kwargs)
+            except Exception as e:
+                _err(span, e)
+                raise
+            if is_stream:
+                return AsyncStreamWrapper(response, span, _finalize_chat_stream)
+            _finalize_chat(span, response, (time.perf_counter() - start) * 1000)
+            return response
+
+        completions.create = patched_create_async
+    else:
+
+        def patched_create(*args, **kwargs):
+            if is_suppressed():
+                return orig_create(*args, **kwargs)
+            is_stream = bool(kwargs.get("stream", False))
+            try:
+                span = _start(kwargs, is_stream)
+                start = time.perf_counter()
+            except Exception:
+                return orig_create(*args, **kwargs)
+            try:
+                response = orig_create(*args, **kwargs)
+            except Exception as e:
+                _err(span, e)
+                raise
+            if is_stream:
+                return SyncStreamWrapper(response, span, _finalize_chat_stream)
+            _finalize_chat(span, response, (time.perf_counter() - start) * 1000)
+            return response
+
+        completions.create = patched_create
+
+    completions._neatlogs_groq_patched = True
+
+
+def _is_async_completions(completions: Any) -> bool:
+    """Groq SDK uses the same method name on sync/AsyncGroq; infer from class name."""
+    cls = type(completions)
+    return "Async" in cls.__name__
+
+
+def _start(kwargs: dict, is_stream: bool) -> Any:
+    model = kwargs.get("model", "")
+    span = get_provider_tracer().start_span(
+        name="groq.chat.completions.create",
+        attributes={
+            "neatlogs.span.kind": "llm",
+            "neatlogs.llm.provider": _PROVIDER,
+            "neatlogs.llm.system": _PROVIDER,
+            "neatlogs.llm.model_name": model,
+            "neatlogs.llm.is_streaming": is_stream,
+        },
+    )
+    _set_chat_input(span, kwargs)
+    _set_invocation_params(span, kwargs)
+    return span
+
+
+def _finalize_chat(span: Any, response: Any, duration_ms: float) -> None:
+    """Extract attributes from a non-streaming ChatCompletion."""
+    choices = _get(response, "choices", []) or []
+    for i, choice in enumerate(choices):
+        message = _get(choice, "message", None)
+        if message is None:
+            continue
+        span.set_attribute(f"neatlogs.llm.output_messages.{i}.role", "assistant")
+        content = _get(message, "content", None)
+        if content:
+            text = content if isinstance(content, str) else serialize(_plain(content))
+            span.set_attribute(f"neatlogs.llm.output_messages.{i}.content", text)
+            if i == 0:
+                span.set_attribute("output.value", text)
+        reasoning = _get(message, "reasoning", None)
+        if reasoning:
+            rtext = reasoning if isinstance(reasoning, str) else serialize(_plain(reasoning))
+            span.set_attribute(f"neatlogs.llm.output_messages.{i}.reasoning", rtext)
+        tool_calls = _get(message, "tool_calls", None)
+        if tool_calls:
+            for j, tc in enumerate(tool_calls):
+                fn = _get(tc, "function", None)
+                span.set_attribute(f"neatlogs.llm.tool_calls.{j}.id", _get(tc, "id", "") or "")
+                span.set_attribute(f"neatlogs.llm.tool_calls.{j}.name", _get(fn, "name", "") or "")
+                args = _get(fn, "arguments", "")
+                span.set_attribute(
+                    f"neatlogs.llm.tool_calls.{j}.arguments",
+                    args if isinstance(args, str) else serialize(_plain(args)),
+                )
+        finish_reason = _get(choice, "finish_reason", None)
+        if finish_reason:
+            span.set_attribute("neatlogs.llm.finish_reason", str(finish_reason))
+
+    _set_chat_usage(span, _get(response, "usage", None))
+
+    model = _get(response, "model", None)
+    if model:
+        span.set_attribute("neatlogs.llm.model_name", str(model))
+    response_id = _get(response, "id", None)
+    if response_id:
+        span.set_attribute("neatlogs.llm.response_id", str(response_id))
+
+    _ok(span, duration_ms)
+
+
+def _finalize_chat_stream(
+    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+) -> None:
+    text_parts: List[str] = []
+    reasoning_parts: List[str] = []
+    tool_calls_acc: dict = {}
+    finish_reason = None
+    model = None
+    usage = None
+
+    for chunk in chunks:
+        if _get(chunk, "model", None):
+            model = _get(chunk, "model", None)
+        if _get(chunk, "usage", None):
+            usage = _get(chunk, "usage", None)
+        choices = _get(chunk, "choices", None) or []
+        if not choices:
+            continue
+        choice = choices[0]
+        delta = _get(choice, "delta", None)
+        if delta is not None:
+            content = _get(delta, "content", None)
+            if content:
+                text_parts.append(content)
+            reasoning = _get(delta, "reasoning", None)
+            if reasoning:
+                reasoning_parts.append(reasoning)
+            for tc in _get(delta, "tool_calls", None) or []:
+                idx = _get(tc, "index", 0) or 0
+                acc = tool_calls_acc.setdefault(idx, {"id": "", "name": "", "arguments": ""})
+                if _get(tc, "id", None):
+                    acc["id"] = _get(tc, "id", "")
+                fn = _get(tc, "function", None)
+                if fn is not None:
+                    if _get(fn, "name", None):
+                        acc["name"] = _get(fn, "name", "")
+                    if _get(fn, "arguments", None):
+                        acc["arguments"] += _get(fn, "arguments", "")
+        fr = _get(choice, "finish_reason", None)
+        if fr:
+            finish_reason = fr
+
+    full_text = "".join(text_parts)
+    if full_text:
+        span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
+        span.set_attribute("neatlogs.llm.output_messages.0.content", full_text)
+        span.set_attribute("output.value", full_text)
+    full_reasoning = "".join(reasoning_parts)
+    if full_reasoning:
+        span.set_attribute("neatlogs.llm.output_messages.0.reasoning", full_reasoning)
+    for j, tc in enumerate(tool_calls_acc.values()):
+        span.set_attribute(f"neatlogs.llm.tool_calls.{j}.id", tc["id"])
+        span.set_attribute(f"neatlogs.llm.tool_calls.{j}.name", tc["name"])
+        span.set_attribute(f"neatlogs.llm.tool_calls.{j}.arguments", tc["arguments"])
+    if model:
+        span.set_attribute("neatlogs.llm.model_name", str(model))
+    if finish_reason:
+        span.set_attribute("neatlogs.llm.finish_reason", str(finish_reason))
+    _set_chat_usage(span, usage)
+
+    _ok(span, duration_ms, ttft_ms)
+
+
+def _set_chat_usage(span: Any, usage: Any) -> None:
+    if usage is None:
+        return
+    prompt = _get(usage, "prompt_tokens", None)
+    completion = _get(usage, "completion_tokens", None)
+    total = _get(usage, "total_tokens", None)
+    if prompt is not None:
+        span.set_attribute("neatlogs.llm.token_count.prompt", prompt)
+    if completion is not None:
+        span.set_attribute("neatlogs.llm.token_count.completion", completion)
+    if total is not None:
+        span.set_attribute("neatlogs.llm.token_count.total", total)
+    elif prompt is not None and completion is not None:
+        span.set_attribute("neatlogs.llm.token_count.total", prompt + completion)
+    details = _get(usage, "prompt_tokens_details", None)
+    if details is not None:
+        cached = _get(details, "cached_tokens", None)
+        if cached is not None:
+            span.set_attribute("neatlogs.llm.token_count.cache_read", cached)
+    cdetails = _get(usage, "completion_tokens_details", None)
+    if cdetails is not None:
+        reasoning = _get(cdetails, "reasoning_tokens", None)
+        if reasoning is not None:
+            span.set_attribute("neatlogs.llm.token_count.reasoning", reasoning)
+
+
+# ---------------------------------------------------------------------------
+# Span finalization helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok(span: Any, duration_ms: float, ttft_ms: Optional[float] = None) -> None:
+    span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
+    if ttft_ms is not None:
+        span.set_attribute("neatlogs.llm.metrics.ttft_ms", round(ttft_ms, 3))
+        if duration_ms > ttft_ms:
+            span.set_attribute(
+                "neatlogs.llm.metrics.streaming_time_to_generate_ms",
+                round(duration_ms - ttft_ms, 3),
+            )
+    span.set_status(StatusCode.OK)
+    span.end()
+
+
+def _err(span: Any, e: Exception) -> None:
+    span.set_status(StatusCode.ERROR, str(e))
+    span.record_exception(e)
+    span.end()
+
+
+# ---------------------------------------------------------------------------
+# Import-replacement: `from neatlogs.groq import Groq`
+# Patches groq.Groq.__init__ so every client constructed is auto-wrapped.
+# ---------------------------------------------------------------------------
+
+_PATCHED = False
+_ORIG_INIT = None
+_ORIG_ASYNC_INIT = None
+
+
+def _patch_groq_module() -> None:
+    global _PATCHED, _ORIG_INIT, _ORIG_ASYNC_INIT
+    if _PATCHED:
+        return
+    try:
+        from groq import AsyncGroq as _AsyncGroq
+        from groq import Groq as _Groq
+    except Exception:
+        return
+
+    _PATCHED = True
+    _ORIG_INIT = _Groq.__init__
+    _ORIG_ASYNC_INIT = _AsyncGroq.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        _ORIG_INIT(self, *args, **kwargs)
+        wrap_groq_client(self)
+
+    def _patched_async_init(self, *args, **kwargs):
+        _ORIG_ASYNC_INIT(self, *args, **kwargs)
+        wrap_groq_client(self)
+
+    _Groq.__init__ = _patched_init
+    _AsyncGroq.__init__ = _patched_async_init
+
+
+def _unpatch_groq_module() -> None:
+    global _PATCHED, _ORIG_INIT, _ORIG_ASYNC_INIT
+    if not _PATCHED:
+        return
+    try:
+        from groq import AsyncGroq as _AsyncGroq
+        from groq import Groq as _Groq
+    except Exception:
+        return
+    if _ORIG_INIT is not None:
+        _Groq.__init__ = _ORIG_INIT
+    if _ORIG_ASYNC_INIT is not None:
+        _AsyncGroq.__init__ = _ORIG_ASYNC_INIT
+    _PATCHED = False
+    _ORIG_INIT = None
+    _ORIG_ASYNC_INIT = None
+
+
+try:  # noqa: E402 - re-export for `from neatlogs.groq import Groq`
+    from groq import AsyncGroq  # noqa: F401
+    from groq import Groq  # noqa: F401
+except Exception:  # pragma: no cover - groq not installed
+    pass

--- a/neatlogs/groq.py
+++ b/neatlogs/groq.py
@@ -29,6 +29,8 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import (
     AsyncStreamWrapper,
     SyncStreamWrapper,
+    _safe_finalize,
+    _telemetry_fallback,
     get_provider_tracer,
     is_suppressed,
     serialize,
@@ -218,7 +220,7 @@ def _patch_completions(completions: Any) -> None:
                 span = _start(kwargs, is_stream)
                 start = time.perf_counter()
             except Exception:
-                return await orig_create(*args, **kwargs)
+                return await _telemetry_fallback(orig_create, *args, **kwargs)
             try:
                 response = await orig_create(*args, **kwargs)
             except Exception as e:
@@ -226,7 +228,7 @@ def _patch_completions(completions: Any) -> None:
                 raise
             if is_stream:
                 return AsyncStreamWrapper(response, span, _finalize_chat_stream)
-            _finalize_chat(span, response, (time.perf_counter() - start) * 1000)
+            _safe_finalize(span, _finalize_chat, response, (time.perf_counter() - start) * 1000)
             return response
 
         completions.create = patched_create_async
@@ -240,7 +242,7 @@ def _patch_completions(completions: Any) -> None:
                 span = _start(kwargs, is_stream)
                 start = time.perf_counter()
             except Exception:
-                return orig_create(*args, **kwargs)
+                return _telemetry_fallback(orig_create, *args, **kwargs)
             try:
                 response = orig_create(*args, **kwargs)
             except Exception as e:
@@ -248,7 +250,7 @@ def _patch_completions(completions: Any) -> None:
                 raise
             if is_stream:
                 return SyncStreamWrapper(response, span, _finalize_chat_stream)
-            _finalize_chat(span, response, (time.perf_counter() - start) * 1000)
+            _safe_finalize(span, _finalize_chat, response, (time.perf_counter() - start) * 1000)
             return response
 
         completions.create = patched_create

--- a/neatlogs/instrumentation/registry.py
+++ b/neatlogs/instrumentation/registry.py
@@ -105,6 +105,7 @@ INSTRUMENTATION_REGISTRY = {
             "default_span_kind": "LLM",
         },
         "groq": {
+            "neatlogs": "neatlogs.groq",
             "openllmetry": "opentelemetry.instrumentation.groq",
             "openinference": "openinference.instrumentation.groq",
             "default_span_kind": "LLM",

--- a/tests/integration/test_groq_instrumentation.py
+++ b/tests/integration/test_groq_instrumentation.py
@@ -328,3 +328,52 @@ class TestGroqFailOpen:
 
         assert response.choices[0].message.content == "async ok"
         assert len(_llm_spans(in_memory_span_exporter)) == 0
+
+
+def test_groq_finalize_throws_still_ends_span_and_returns_response(in_memory_span_exporter):
+    """Finalize-phase regression: if _finalize_chat raises after a successful
+    LLM call, the response must still be returned and the span must be ended
+    (not leaked). Same shape as the PR #71 finalize-leak fix."""
+    from opentelemetry.trace import StatusCode
+
+    _setup_tracer(in_memory_span_exporter)
+    from neatlogs import groq as _groq_mod
+    from neatlogs.groq import wrap_groq_client
+
+    orig_finalize = _groq_mod._finalize_chat
+
+    def _explode(span, response, duration_ms):
+        raise RuntimeError("simulated finalize bug")
+
+    _groq_mod._finalize_chat = _explode
+    try:
+
+        def create(*, messages, model, **kwargs):
+            return SimpleNamespace(
+                id="ok",
+                model=model,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        finish_reason="stop",
+                        message=SimpleNamespace(
+                            role="assistant", content="hi", tool_calls=None, reasoning=None
+                        ),
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+
+        client = _fake_groq_client(create=create)
+        wrap_groq_client(client)
+        response = client.chat.completions.create(
+            model="llama-3.3-70b-versatile",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert response.choices[0].message.content == "hi"
+        llm_spans = _llm_spans(in_memory_span_exporter)
+        assert len(llm_spans) == 1
+        assert llm_spans[0].end_time is not None
+        assert llm_spans[0].status.status_code == StatusCode.OK
+    finally:
+        _groq_mod._finalize_chat = orig_finalize

--- a/tests/integration/test_groq_instrumentation.py
+++ b/tests/integration/test_groq_instrumentation.py
@@ -1,0 +1,330 @@
+"""
+Tests for Groq Instrumentation
+==============================
+Verifies ``neatlogs.groq`` traces chat completions on both sync ``Groq`` and
+async ``AsyncGroq`` clients — including streaming — with
+``provider="groq"``, ``system="groq"``, and the canonical ``neatlogs.*``
+attributes, plus regression coverage for fail-open on telemetry-setup errors.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+
+def _setup_tracer(exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    import neatlogs._wrap_utils as _wu
+
+    _wu._wrapper_tracer = None
+    return provider
+
+
+def _fake_groq_client(create=None, async_create=None):
+    """Minimal fake groq.Groq / groq.AsyncGroq client."""
+    completions = SimpleNamespace()
+    if create is not None:
+        completions.create = create
+    if async_create is not None:
+        completions.create = async_create
+    chat = SimpleNamespace(completions=completions)
+    return SimpleNamespace(chat=chat)
+
+
+def _llm_spans(exporter):
+    return [
+        s
+        for s in exporter.get_finished_spans()
+        if s.attributes.get("neatlogs.llm.provider") == "groq"
+        and s.attributes.get("neatlogs.span.kind") == "llm"
+    ]
+
+
+class TestGroqChatCompletions:
+    def test_create_traces_io_tokens_and_params(self, in_memory_span_exporter):
+        _setup_tracer(in_memory_span_exporter)
+        from neatlogs.groq import wrap_groq_client
+
+        def create(*, messages, model, **kwargs):
+            return SimpleNamespace(
+                id="cmpl-groq-1",
+                model=model,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        finish_reason="stop",
+                        message=SimpleNamespace(
+                            role="assistant",
+                            content="hello from llama",
+                            tool_calls=None,
+                            reasoning=None,
+                        ),
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+            )
+
+        client = _fake_groq_client(create=create)
+        wrap_groq_client(client)
+
+        client.chat.completions.create(
+            model="llama-3.3-70b-versatile",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.5,
+            top_p=0.9,
+            max_tokens=256,
+        )
+
+        spans = _llm_spans(in_memory_span_exporter)
+        assert len(spans) == 1
+        attrs = spans[0].attributes
+        assert attrs.get("neatlogs.span.kind") == "llm"
+        assert attrs.get("neatlogs.llm.provider") == "groq"
+        assert attrs.get("neatlogs.llm.system") == "groq"
+        assert attrs.get("neatlogs.llm.model_name") == "llama-3.3-70b-versatile"
+        assert attrs.get("neatlogs.llm.input_messages.0.role") == "user"
+        assert attrs.get("neatlogs.llm.input_messages.0.content") == "hi"
+        assert attrs.get("neatlogs.llm.output_messages.0.content") == "hello from llama"
+        assert attrs.get("output.value") == "hello from llama"
+        assert attrs.get("neatlogs.llm.token_count.prompt") == 5
+        assert attrs.get("neatlogs.llm.token_count.completion") == 3
+        assert attrs.get("neatlogs.llm.token_count.total") == 8
+        assert attrs.get("neatlogs.llm.finish_reason") == "stop"
+        assert attrs.get("neatlogs.llm.response_id") == "cmpl-groq-1"
+        assert attrs.get("neatlogs.llm.temperature") == 0.5
+        assert attrs.get("neatlogs.llm.top_p") == 0.9
+        assert attrs.get("neatlogs.llm.max_tokens") == 256
+        import json
+
+        blob = json.loads(attrs.get("neatlogs.llm.invocation_parameters"))
+        assert blob == {"temperature": 0.5, "top_p": 0.9, "max_tokens": 256}
+
+    def test_create_streaming(self, in_memory_span_exporter):
+        _setup_tracer(in_memory_span_exporter)
+        from neatlogs.groq import wrap_groq_client
+
+        def _chunk(text=None, finish=None, usage=None):
+            delta = SimpleNamespace(content=text, tool_calls=None, reasoning=None)
+            choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish)
+            return SimpleNamespace(model="llama-3.3-70b-versatile", choices=[choice], usage=usage)
+
+        def create(*, messages, model, stream=False, **kwargs):
+            assert stream is True
+            return iter(
+                [
+                    _chunk("Hello"),
+                    _chunk(" world"),
+                    _chunk(
+                        finish="stop",
+                        usage=SimpleNamespace(prompt_tokens=4, completion_tokens=2, total_tokens=6),
+                    ),
+                ]
+            )
+
+        client = _fake_groq_client(create=create)
+        wrap_groq_client(client)
+
+        stream = client.chat.completions.create(
+            model="llama-3.3-70b-versatile",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+        collected = "".join((getattr(c.choices[0].delta, "content", "") or "") for c in stream)
+        assert collected == "Hello world"
+
+        spans = _llm_spans(in_memory_span_exporter)
+        assert len(spans) == 1
+        attrs = spans[0].attributes
+        assert attrs.get("neatlogs.llm.is_streaming") is True
+        assert attrs.get("neatlogs.llm.output_messages.0.content") == "Hello world"
+        assert attrs.get("neatlogs.llm.token_count.prompt") == 4
+        assert attrs.get("neatlogs.llm.token_count.completion") == 2
+        assert attrs.get("neatlogs.llm.finish_reason") == "stop"
+
+    @pytest.mark.asyncio
+    async def test_async_create_traces(self, in_memory_span_exporter):
+        _setup_tracer(in_memory_span_exporter)
+        from neatlogs.groq import wrap_groq_client
+
+        async def create(*, messages, model, **kwargs):
+            return SimpleNamespace(
+                id="cmpl-async-1",
+                model=model,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        finish_reason="stop",
+                        message=SimpleNamespace(
+                            role="assistant", content="async hi", tool_calls=None, reasoning=None
+                        ),
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=2, completion_tokens=1, total_tokens=3),
+            )
+
+        # AsyncGroq's class name contains "Async" — the wrapper detects it.
+        from groq.resources.chat.completions import AsyncCompletions
+
+        completions = AsyncCompletions.__new__(AsyncCompletions)
+        completions.create = create
+        chat = SimpleNamespace(completions=completions)
+        client = SimpleNamespace(chat=chat)
+        wrap_groq_client(client)
+
+        await client.chat.completions.create(
+            model="llama-3.3-70b-versatile",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        spans = _llm_spans(in_memory_span_exporter)
+        assert len(spans) == 1
+        attrs = spans[0].attributes
+        assert attrs.get("neatlogs.llm.provider") == "groq"
+        assert attrs.get("neatlogs.llm.output_messages.0.content") == "async hi"
+
+
+class TestGroqReasoningFields:
+    def test_reasoning_field_recorded(self, in_memory_span_exporter):
+        _setup_tracer(in_memory_span_exporter)
+        from neatlogs.groq import wrap_groq_client
+
+        def create(*, messages, model, **kwargs):
+            return SimpleNamespace(
+                id="r1",
+                model=model,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        finish_reason="stop",
+                        message=SimpleNamespace(
+                            role="assistant",
+                            content="final answer",
+                            tool_calls=None,
+                            reasoning="step-by-step thoughts",
+                        ),
+                    )
+                ],
+                usage=SimpleNamespace(
+                    prompt_tokens=10,
+                    completion_tokens=20,
+                    total_tokens=30,
+                    completion_tokens_details=SimpleNamespace(reasoning_tokens=15),
+                ),
+            )
+
+        client = _fake_groq_client(create=create)
+        wrap_groq_client(client)
+        client.chat.completions.create(
+            model="openai/gpt-oss-120b",
+            messages=[{"role": "user", "content": "explain"}],
+        )
+
+        attrs = _llm_spans(in_memory_span_exporter)[0].attributes
+        assert attrs.get("neatlogs.llm.output_messages.0.reasoning") == "step-by-step thoughts"
+        assert attrs.get("neatlogs.llm.token_count.reasoning") == 15
+
+
+class TestGroqIdempotentAndSuppress:
+    def test_wrap_is_idempotent(self, in_memory_span_exporter):
+        _setup_tracer(in_memory_span_exporter)
+        from neatlogs.groq import wrap_groq_client
+
+        def create(*, messages, model, **kwargs):
+            return SimpleNamespace(
+                id="x",
+                model=model,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        finish_reason="stop",
+                        message=SimpleNamespace(
+                            role="assistant", content="ok", tool_calls=None, reasoning=None
+                        ),
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+
+        client = _fake_groq_client(create=create)
+        wrap_groq_client(client)
+        patched = client.chat.completions.create
+        wrap_groq_client(client)
+        assert client.chat.completions.create is patched
+
+
+class TestGroqFailOpen:
+    def test_create_fails_open_on_tracer_error(self, in_memory_span_exporter):
+        _setup_tracer(in_memory_span_exporter)
+        from neatlogs.groq import wrap_groq_client
+
+        def create(*, messages, model, **kwargs):
+            return SimpleNamespace(
+                id="ok",
+                model=model,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        finish_reason="stop",
+                        message=SimpleNamespace(
+                            role="assistant", content="ok", tool_calls=None, reasoning=None
+                        ),
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+
+        client = _fake_groq_client(create=create)
+        wrap_groq_client(client)
+
+        with patch("neatlogs.groq.get_provider_tracer", side_effect=RuntimeError("trace failed")):
+            response = client.chat.completions.create(
+                model="llama-3.3-70b-versatile",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert response.choices[0].message.content == "ok"
+        assert len(_llm_spans(in_memory_span_exporter)) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_create_fails_open_on_tracer_error(self, in_memory_span_exporter):
+        _setup_tracer(in_memory_span_exporter)
+        from neatlogs.groq import wrap_groq_client
+
+        async def create(*, messages, model, **kwargs):
+            return SimpleNamespace(
+                id="ok",
+                model=model,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        finish_reason="stop",
+                        message=SimpleNamespace(
+                            role="assistant", content="async ok", tool_calls=None, reasoning=None
+                        ),
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+
+        from groq.resources.chat.completions import AsyncCompletions
+
+        completions = AsyncCompletions.__new__(AsyncCompletions)
+        completions.create = create
+        chat = SimpleNamespace(completions=completions)
+        client = SimpleNamespace(chat=chat)
+        wrap_groq_client(client)
+
+        with patch("neatlogs.groq.get_provider_tracer", side_effect=RuntimeError("trace failed")):
+            response = await client.chat.completions.create(
+                model="llama-3.3-70b-versatile",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert response.choices[0].message.content == "async ok"
+        assert len(_llm_spans(in_memory_span_exporter)) == 0


### PR DESCRIPTION
Closes #47.

## Problem

The README advertises Groq support with key 'groq' and install command 'pip install "neatlogs[groq]"'. neatlogs/instrumentation/registry.py:107 registers it for openllmetry and openinference conventions, but the neatlogs convention block at neatlogs/instrumentation/manager.py:1459 references a GroqInstrumentor class that does not exist (no neatlogs/groq.py module).

Failure mode today (verified): running neatlogs.init(instrumentations=["groq"]) under the default neatlogs convention does NOT raise ImportError. The manager's _instrument_dual (manager.py:118) checks info.get("neatlogs") first; since registry.py:107 has no neatlogs key for groq, it falls through to the OpenInference branch and tries to import openinference.instrumentation.groq. With the openinference package not installed (the typical setup), the exception is swallowed and the call is silently skipped. The user-visible result is even worse than a hard error: chat completions run completely untraced while the user thinks they enabled Groq tracing. With openinference installed, Groq gets OI instrumentation instead of the Neatlogs schema, which is a different attribute namespace than every other provider wrapper uses.

## Change

New module neatlogs/groq.py:

- wrap_groq_client(client): idempotent in-place wrapper that patches client.chat.completions.create on both sync (groq.Groq) and async (groq.AsyncGroq) clients. Async path is detected from the class name ("Async" in cls.__name__).
- GroqInstrumentor class matches the string already referenced by manager.py:1459.
- Module-level try/except for from groq import Groq / AsyncGroq so neatlogs.groq imports cleanly even without the groq SDK installed. Same try/except pattern re-exports them as a convenience (like neatlogs.openrouter does).
- Runtime try/except guards around span setup so telemetry-setup failures fall through to the untraced original call (same pattern as PRs #23, #29, #31, #34, #37, #43, #46).
- Spans emit neatlogs.span.kind="llm", neatlogs.llm.provider="groq", neatlogs.llm.system="groq", canonical input/output message attrs, token counts, duration_ms, ttft_ms (when streaming), the invocation_parameters blob the backend reads as model_settings, and a separate neatlogs.llm.output_messages.0.reasoning attr plus neatlogs.llm.token_count.reasoning for reasoning-capable models.
- Groq SDK Omit sentinel is filtered out of invocation param capture so the blob reflects only what the user actually passed.
- Streaming uses the existing SyncStreamWrapper / AsyncStreamWrapper from neatlogs/_wrap_utils.py — no new helpers.

Wiring:

- neatlogs/instrumentation/registry.py:108 — added neatlogs: neatlogs.groq so the manager picks the Neatlogs instrumentor first (before the OI/OpenLLMetry fallbacks).

## Tests

tests/integration/test_groq_instrumentation.py (new), 7 tests:

- test_create_traces_io_tokens_and_params (sync chat, asserts all canonical attrs + invocation_parameters blob)
- test_create_streaming (streaming variant, asserts is_streaming + ttft-able span)
- test_async_create_traces (async path on AsyncCompletions instance)
- test_reasoning_field_recorded (reasoning content + reasoning_tokens)
- test_wrap_is_idempotent
- test_create_fails_open_on_tracer_error (sync fail-open)
- test_async_create_fails_open_on_tracer_error (async fail-open)

uv run --no-project --python 3.13 --with pytest --with pytest-asyncio --with groq --with opentelemetry-api --with opentelemetry-sdk --with opentelemetry-exporter-otlp-proto-http --with opentelemetry-instrumentation-threading --with opentelemetry-instrumentation-logging --with httpx --with respx python -m pytest tests/integration/test_groq_instrumentation.py -q

-> 7 passed.

black + isort clean on touched files.

## Out of scope (deliberate)

Embeddings, audio transcription / translation, tool-call capture nuances, and batch. Each of these would warrant a separate small issue + PR; the chat-completions surface is the highest-traffic Groq endpoint and matches the single-PR scope.

## Backward compatibility

None for users who did NOT pass 'groq' in instrumentations. For users who did, the behavior changes from "silently skipped" (or OI if installed) to "Neatlogs instrumentor picks up first" — strictly more tracing, never less. Users who want to keep the OI behavior can pin openinference as before.