### PR TITLE
fix: capture standard LangChain usage metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .
-          python -m pip install black isort pytest pytest-asyncio pytest-mock respx
+          python -m pip install black isort pytest pytest-asyncio pytest-mock respx langchain-core
 
       - name: Format (black)
         run: black --check neatlogs tests

--- a/neatlogs/langchain.py
+++ b/neatlogs/langchain.py
@@ -113,6 +113,85 @@ def _set_invocation_params(span: Any, kwargs: Dict[str, Any]) -> None:
                     span.set_attribute(f"neatlogs.llm.tools.{i}.input_schema", serialize(params))
 
 
+def _normalize_token_usage(usage: Any) -> Dict[str, Any]:
+    """Normalize provider-specific and LangChain-standard token usage keys."""
+    if not isinstance(usage, dict):
+        return {}
+
+    normalized: Dict[str, Any] = {}
+    aliases = {
+        "prompt_tokens": ("prompt_tokens", "input_tokens", "prompt_token_count"),
+        "completion_tokens": (
+            "completion_tokens",
+            "output_tokens",
+            "candidates_token_count",
+        ),
+        "total_tokens": ("total_tokens", "total_token_count"),
+        "cache_read_input_tokens": (
+            "cache_read_input_tokens",
+            "cached_content_token_count",
+        ),
+        "cache_creation_input_tokens": ("cache_creation_input_tokens",),
+        "reasoning_tokens": ("reasoning_tokens", "thoughts_token_count"),
+    }
+    for target, sources in aliases.items():
+        for source in sources:
+            value = usage.get(source)
+            if value is not None:
+                normalized[target] = value
+                break
+
+    input_details = usage.get("input_token_details") or {}
+    if isinstance(input_details, dict):
+        if (
+            "cache_read_input_tokens" not in normalized
+            and input_details.get("cache_read") is not None
+        ):
+            normalized["cache_read_input_tokens"] = input_details["cache_read"]
+        if (
+            "cache_creation_input_tokens" not in normalized
+            and input_details.get("cache_creation") is not None
+        ):
+            normalized["cache_creation_input_tokens"] = input_details["cache_creation"]
+
+    output_details = usage.get("output_token_details") or {}
+    if (
+        isinstance(output_details, dict)
+        and "reasoning_tokens" not in normalized
+        and output_details.get("reasoning") is not None
+    ):
+        normalized["reasoning_tokens"] = output_details["reasoning"]
+
+    return normalized
+
+
+def _message_token_usage(response: Any) -> Dict[str, Any]:
+    """Aggregate standardized usage from the top generation for each prompt."""
+    aggregated: Dict[str, Any] = {}
+    for gen_list in getattr(response, "generations", None) or []:
+        if not gen_list:
+            continue
+        message = getattr(gen_list[0], "message", None)
+        usage = _normalize_token_usage(getattr(message, "usage_metadata", None))
+        for key, value in usage.items():
+            try:
+                aggregated[key] = aggregated.get(key, 0) + value
+            except TypeError:
+                continue
+    return aggregated
+
+
+def _extract_token_usage(response: Any, llm_output: Dict[str, Any]) -> Dict[str, Any]:
+    """Prefer recognized llm_output fields, then fill gaps from AIMessage usage."""
+    normalized: Dict[str, Any] = {}
+    for raw_usage in (llm_output.get("token_usage"), llm_output.get("usage")):
+        for key, value in _normalize_token_usage(raw_usage).items():
+            normalized.setdefault(key, value)
+    for key, value in _message_token_usage(response).items():
+        normalized.setdefault(key, value)
+    return normalized
+
+
 class NeatlogsCallbackHandler(AsyncCallbackHandler, BaseCallbackHandler):
     """LangChain callback handler that creates neatlogs.llm.* spans.
 
@@ -365,8 +444,8 @@ class NeatlogsCallbackHandler(AsyncCallbackHandler, BaseCallbackHandler):
 
         # Token usage
         llm_output = getattr(response, "llm_output", None) or {}
-        token_usage = llm_output.get("token_usage") or llm_output.get("usage") or {}
-        if isinstance(token_usage, dict):
+        token_usage = _extract_token_usage(response, llm_output)
+        if token_usage:
             if "prompt_tokens" in token_usage:
                 span.set_attribute("neatlogs.llm.token_count.prompt", token_usage["prompt_tokens"])
             if "completion_tokens" in token_usage:

--- a/tests/unit/test_langchain_callback_usage.py
+++ b/tests/unit/test_langchain_callback_usage.py
@@ -1,0 +1,202 @@
+import importlib
+from uuid import uuid4
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+messages = pytest.importorskip("langchain_core.messages")
+outputs = pytest.importorskip("langchain_core.outputs")
+AIMessage = messages.AIMessage
+HumanMessage = messages.HumanMessage
+ChatGeneration = outputs.ChatGeneration
+LLMResult = outputs.LLMResult
+langchain_integration = importlib.import_module("neatlogs.langchain")
+
+
+async def _capture_callback_span(monkeypatch, in_memory_span_exporter, response):
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+    monkeypatch.setattr(
+        langchain_integration,
+        "get_tracer",
+        lambda: provider.get_tracer("neatlogs.test.langchain"),
+    )
+    monkeypatch.setattr(langchain_integration, "_auto_root_enabled", lambda: False)
+
+    handler = langchain_integration.NeatlogsCallbackHandler()
+    run_id = uuid4()
+    await handler.on_chat_model_start(
+        {"id": ["langchain_google_genai", "ChatGoogleGenerativeAI"]},
+        [[HumanMessage(content="Say hello")]],
+        run_id=run_id,
+        invocation_params={"model": "gemini-2.5-flash"},
+    )
+
+    await handler.on_llm_end(response, run_id=run_id)
+
+    return next(
+        span
+        for span in in_memory_span_exporter.get_finished_spans()
+        if span.name == "langchain.chat_model"
+    )
+
+
+def _chat_result(usage_metadata, llm_output=None):
+    return LLMResult(
+        generations=[
+            [
+                ChatGeneration(
+                    message=AIMessage(
+                        content="Hello",
+                        usage_metadata=usage_metadata,
+                    )
+                )
+            ]
+        ],
+        llm_output=llm_output or {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_callback_records_standard_message_usage_metadata(
+    monkeypatch, in_memory_span_exporter
+):
+    response = _chat_result(
+        {
+            "input_tokens": 7,
+            "output_tokens": 329,
+            "total_tokens": 336,
+            "input_token_details": {
+                "cache_read": 5,
+                "cache_creation": 2,
+            },
+            "output_token_details": {"reasoning": 325},
+        }
+    )
+    span = await _capture_callback_span(monkeypatch, in_memory_span_exporter, response)
+
+    assert span.attributes["neatlogs.llm.token_count.prompt"] == 7
+    assert span.attributes["neatlogs.llm.token_count.completion"] == 329
+    assert span.attributes["neatlogs.llm.token_count.total"] == 336
+    assert span.attributes["neatlogs.llm.token_count.cache_read"] == 5
+    assert span.attributes["neatlogs.llm.token_count.cache_write"] == 2
+    assert span.attributes["neatlogs.llm.token_count.reasoning"] == 325
+
+
+@pytest.mark.asyncio
+async def test_callback_normalizes_standard_llm_output_usage(monkeypatch, in_memory_span_exporter):
+    response = _chat_result(
+        None,
+        llm_output={
+            "usage": {
+                "input_tokens": 11,
+                "output_tokens": 13,
+                "total_tokens": 24,
+                "input_token_details": {
+                    "cache_read": 3,
+                    "cache_creation": 1,
+                },
+                "output_token_details": {"reasoning": 8},
+            }
+        },
+    )
+    span = await _capture_callback_span(monkeypatch, in_memory_span_exporter, response)
+
+    assert span.attributes["neatlogs.llm.token_count.prompt"] == 11
+    assert span.attributes["neatlogs.llm.token_count.completion"] == 13
+    assert span.attributes["neatlogs.llm.token_count.total"] == 24
+    assert span.attributes["neatlogs.llm.token_count.cache_read"] == 3
+    assert span.attributes["neatlogs.llm.token_count.cache_write"] == 1
+    assert span.attributes["neatlogs.llm.token_count.reasoning"] == 8
+
+
+@pytest.mark.asyncio
+async def test_callback_fills_missing_legacy_fields_from_message_usage(
+    monkeypatch, in_memory_span_exporter
+):
+    response = _chat_result(
+        {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "total_tokens": 120,
+        },
+        llm_output={"token_usage": {"prompt_tokens": 10}},
+    )
+    span = await _capture_callback_span(monkeypatch, in_memory_span_exporter, response)
+
+    assert span.attributes["neatlogs.llm.token_count.prompt"] == 10
+    assert span.attributes["neatlogs.llm.token_count.completion"] == 20
+    assert span.attributes["neatlogs.llm.token_count.total"] == 120
+
+
+@pytest.mark.asyncio
+async def test_callback_combines_llm_output_usage_sources_before_message_fallback(
+    monkeypatch, in_memory_span_exporter
+):
+    response = _chat_result(
+        {
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "total_tokens": 300,
+        },
+        llm_output={
+            "token_usage": {"prompt_tokens": 10},
+            "usage": {"output_tokens": 15, "total_tokens": 25},
+        },
+    )
+    span = await _capture_callback_span(monkeypatch, in_memory_span_exporter, response)
+
+    assert span.attributes["neatlogs.llm.token_count.prompt"] == 10
+    assert span.attributes["neatlogs.llm.token_count.completion"] == 15
+    assert span.attributes["neatlogs.llm.token_count.total"] == 25
+
+
+@pytest.mark.asyncio
+async def test_callback_aggregates_message_usage_for_batched_prompts(
+    monkeypatch, in_memory_span_exporter
+):
+    response = LLMResult(
+        generations=[
+            [
+                ChatGeneration(
+                    message=AIMessage(
+                        content="First",
+                        usage_metadata={
+                            "input_tokens": 3,
+                            "output_tokens": 4,
+                            "total_tokens": 7,
+                        },
+                    )
+                ),
+                ChatGeneration(
+                    message=AIMessage(
+                        content="Alternate candidate",
+                        usage_metadata={
+                            "input_tokens": 100,
+                            "output_tokens": 200,
+                            "total_tokens": 300,
+                        },
+                    )
+                ),
+            ],
+            [
+                ChatGeneration(
+                    message=AIMessage(
+                        content="Second",
+                        usage_metadata={
+                            "input_tokens": 5,
+                            "output_tokens": 6,
+                            "total_tokens": 11,
+                        },
+                    )
+                )
+            ],
+        ],
+        llm_output={},
+    )
+    span = await _capture_callback_span(monkeypatch, in_memory_span_exporter, response)
+
+    assert span.attributes["neatlogs.llm.token_count.prompt"] == 8
+    assert span.attributes["neatlogs.llm.token_count.completion"] == 10
+    assert span.attributes["neatlogs.llm.token_count.total"] == 18


### PR DESCRIPTION
## Summary

- Capture token usage from LangChain's standardized `AIMessage.usage_metadata` when provider-specific `LLMResult.llm_output` usage is absent or incomplete.
- Normalize legacy, standard, Gemini, cache, and reasoning token fields while preserving existing per-field precedence.
- Add real LangChain regression coverage and ensure `langchain-core` is installed in the Python 3.10-3.13 CI unit-test matrix.

## User-visible problem

Gemini calls made through `ChatGoogleGenerativeAI` and `neatlogs.langchain_handler()` completed successfully, but their NeatLogs LLM spans contained no `neatlogs.llm.token_count.*` attributes. Server-side pricing therefore received zero tokens and displayed $0 cost.

This is an observability-only defect. It does not affect model responses, application data, or application control flow.

## Discovery context and scope

The issue was reproduced while testing a downstream LangChain application workflow that attaches `neatlogs.langchain_handler()` to a native Gemini chat-model invocation. The model call succeeded, but the resulting NeatLogs span had no token attributes.

This public SDK PR intentionally omits downstream application, organization, repository, workflow, and deployment names.

- Native Gemini is a confirmed reproduction.
- The fallback also supports other LangChain chat-model results that expose usage through standard `AIMessage.usage_metadata`.
- This does not imply every LangChain provider or configuration is affected.
- The change only restores token/cost telemetry; it does not alter model output or span hierarchy.

## Root cause

NeatLogs 1.4.10 only inspected:

- `response.llm_output["token_usage"]`
- `response.llm_output["usage"]`

Current LangChain represents standardized cross-provider usage on `generation.message.usage_metadata`. `ChatGoogleGenerativeAI` supplies input, output, total, cache, and reasoning counts there while its `llm_output` may contain only prompt feedback.

Consequently, model identification still worked, but token extraction silently produced no span attributes.

Relevant upstream behavior:

- LangChain `AIMessage.usage_metadata`: https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/messages/ai.py
- Google GenAI chat result construction: https://github.com/langchain-ai/langchain-google/blob/main/libs/genai/langchain_google_genai/chat_models.py

## Implementation

`neatlogs/langchain.py` now:

- Normalizes:
  - `prompt_tokens`, `input_tokens`, `prompt_token_count`
  - `completion_tokens`, `output_tokens`, `candidates_token_count`
  - `total_tokens`, `total_token_count`
- Maps nested standard details:
  - `input_token_details.cache_read` -> cache-read tokens
  - `input_token_details.cache_creation` -> cache-write tokens
  - `output_token_details.reasoning` -> reasoning tokens
- Reads both legacy `token_usage` and `usage` dictionaries per field.
- Preserves existing legacy values and fills only missing fields from `AIMessage.usage_metadata`.
- Preserves legitimate zero values.
- Aggregates the top generation for each batched input prompt while excluding alternative candidates from token totals.

There is no separate `on_chat_model_end()` path in this handler; LangChain chat models finish through `on_llm_end()`.

## Before/after evidence

Test environment:

- NeatLogs SDK: `1.4.10`
- `langchain-google-genai`: `4.2.7`
- `langchain-core`: `1.4.9`
- Model: `gemini-2.5-flash`

### Live call before the fix

Provider response:

```text
input=7, output=26, total=33, cache_read=0, reasoning=24
```

NeatLogs in-memory span:

```text
model_name=gemini-2.5-flash
token attributes={}
```

### Live call after the fix

A second call produced different output/reasoning counts, as expected for separate model calls. Each provider value matched the resulting span exactly:

```text
provider: prompt=7, completion=19, total=26, cache_read=0, reasoning=17
span:     prompt=7, completion=19, total=26, cache_read=0, reasoning=17
model:    gemini-2.5-flash
```

A deterministic `LLMResult` reproduction also failed before the change and records all six token fields after it.

## Regression coverage

`tests/unit/test_langchain_callback_usage.py` covers:

- Gemini/LangChain-standard message usage, including cache and reasoning details.
- Standard-shaped nonempty `llm_output["usage"]`.
- Per-field fallback while preserving legacy OpenAI-shaped precedence.
- Combining `token_usage` and `usage` before message fallback.
- Batched prompt aggregation without double-counting alternate candidates.

## Verification

- [x] Fresh post-commit SDK unit suite: `70 passed`
- [x] Focused LangChain regression suite: `5 passed`
- [x] Built `neatlogs-1.4.10-py3-none-any.whl`
- [x] Isolated installed-wheel smoke test with current LangChain
- [x] Isolated installed-wheel smoke test with minimum supported `langchain-core==0.3.0`
- [x] Python compilation check
- [x] Changed-file diff/format checks
- [x] Independent code review: no remaining critical, important, or minor findings

## CI note

The repository-wide latest Black/isort checks currently report existing formatting drift in untouched files. The latest `main` CI run fails the same Black gate: https://github.com/neatlogs/neatlogs/actions/runs/29273147582

The new regression module passes targeted Black/isort checks, and the SDK unit suite passes locally. This PR does not reformat unrelated files.

## Files changed

- `neatlogs/langchain.py` — normalized extraction and message-level fallback.
- `tests/unit/test_langchain_callback_usage.py` — deterministic regression coverage.
- `.github/workflows/ci.yml` — install `langchain-core` for the unit-test matrix.

## Compatibility and release

- No public API change.
- SDK version remains `1.4.10`; versioning and release should follow the normal SDK release process after merge.
- Existing provider-specific `llm_output` usage retains precedence, minimizing behavioral risk for current integrations.
