### PR TITLE
feat(replay): add neatlogs-replay CLI to visualize processed span JSONL logs

### DIFF
--- a/neatlogs/replay.py
+++ b/neatlogs/replay.py
@@ -188,8 +188,6 @@ def _iter_json_objects(text: str) -> Iterator[Dict[str, Any]]:
                 try:
                     yield json.loads(chunk)
                 except json.JSONDecodeError:
-                    # Skip malformed objects silently here; the caller decides
-                    # whether to warn via a returned list of (obj, error) pairs.
                     pass
                 start = -1
             elif depth < 0:
@@ -347,10 +345,9 @@ def parse_paths(paths: Sequence[PathLike]) -> ParseResult:
         text = _read_file(path)
         if not text.strip():
             continue
-        # Count non-blank lines for the malformed denominator. The brace-
-        # balancer may yield fewer objects than this if a line is invalid JSON
-        # or has a non-span shape; the difference is what we surface to the
-        # user as "malformed".
+        # Non-blank lines are the malformed denominator: brace-balanced parsing
+        # may yield fewer objects when a line is invalid JSON or has a
+        # non-span shape.
         non_blank = sum(1 for line in text.splitlines() if line.strip())
         file_spans: List[SpanRecord] = []
         for obj in _iter_json_objects(text):
@@ -403,8 +400,6 @@ def build_trees(
 
     trees: List[TraceTree] = []
     for trace_id, members in sorted(by_trace.items(), key=lambda kv: kv[0]):
-        # Roots = spans with no parent, or whose parent is in a different trace,
-        # or whose parent_id is None / missing / zero.
         root_nodes: List[TreeNode] = []
         seen_orphans: Dict[str, TreeNode] = {}
         for s in members:
@@ -413,10 +408,8 @@ def build_trees(
                 root_nodes.append(make_node(s))
                 continue
             if parent_id not in spans_by_id:
-                # Orphan: the parent is missing (different file, dropped, etc.).
-                # We park the span under a synthetic root named after the
-                # missing parent so the output still shows it; the warning
-                # tells the user which parent went missing.
+                # Orphan: parent is missing in this log file. Park under a
+                # synthetic root named after the missing parent.
                 bucket = seen_orphans.get(parent_id)
                 if bucket is None:
                     orphan = SpanRecord(
@@ -447,15 +440,10 @@ def build_trees(
                         )
                 bucket.children.append(make_node(s))
                 continue
-            # If the parent belongs to a different trace (very rare; usually
-            # means a corrupted file), the span still needs to render. Treat
-            # it as a root so it isn't silently dropped.
+            # Parent in a different trace (very rare; usually a corrupted file):
+            # treat as a root so it isn't silently dropped.
             if spans_by_id[parent_id].trace_id != s.trace_id:
                 root_nodes.append(make_node(s))
-                continue
-            # Normal case: the span has a parent in the same trace, so it will
-            # be reached via make_node recursion on the parent. No need to
-            # add it to roots here.
         trees.append(TraceTree(trace_id=trace_id, roots=root_nodes))
     return trees
 
@@ -464,9 +452,6 @@ def build_trees(
 # Rendering
 # ---------------------------------------------------------------------------
 
-
-# Color helpers: only emit ANSI when the stream is a TTY (or when force_color
-# is True). The CLI passes force_color=True when --color is set.
 
 _USE_COLOR = True
 
@@ -752,8 +737,6 @@ def replay(
 def _expand_paths(argv: Sequence[str]) -> List[PathLike]:
     out: List[PathLike] = []
     for a in argv:
-        # Treat as a literal path; do not expand globs (the brace-balancer
-        # reads the whole file anyway, so a glob would only ever match one).
         out.append(a)
     return out
 

--- a/neatlogs/replay.py
+++ b/neatlogs/replay.py
@@ -1,0 +1,859 @@
+"""
+Replay processed or raw OpenTelemetry span JSONL logs as a human-readable tree.
+
+When ``NEATLOGS_LOG_SPANS=true`` is set in the environment, the SDK writes one
+JSON object per span to ``spans_optimized.log`` in the working directory (or
+whatever path ``NEATLOGS_LOG_SPANS_FILE`` points to). When
+``NEATLOGS_LOG_RAW_SPANS=true`` is set, the raw ``ReadableSpan.to_json()``
+output is written to ``spans_raw_optimized.log``. Both formats are line-
+delimited at the brace level. Newlines inside string values are possible, so
+we brace-balance across the file when reading.
+
+This module exposes a programmatic API and a CLI that read one or more paths,
+reconstruct the parent/child tree per trace, and print a colored indented summary.
+Programmatic::
+
+    from neatlogs.replay import replay, format_tree
+    trees = replay("spans_optimized.log")
+    print(format_tree(trees))
+
+CLI::
+
+    neatlogs-replay path/to/spans_optimized.log
+    neatlogs-replay --format json --max-depth 3 spans_optimized.log
+    neatlogs-replay spans_a.log spans_b.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import io
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, TextIO, Union
+
+PathLike = Union[str, os.PathLike]
+
+
+@dataclasses.dataclass
+class SpanRecord:
+    """Normalized representation of a single span, in either the processed
+    ``span_data`` shape (NEATLOGS_LOG_SPANS) or the raw
+    ``ReadableSpan.to_json()`` shape (NEATLOGS_LOG_RAW_SPANS)."""
+
+    trace_id: str
+    span_id: str
+    parent_span_id: Optional[str]
+    name: str
+    kind: str
+    start_time: Optional[int]
+    end_time: Optional[int]
+    duration_ns: Optional[int]
+    status_code: str
+    status_description: str
+    attributes: Dict[str, Any]
+    source: str  # "processed" | "raw" | "unknown"
+
+    def duration_ms(self) -> Optional[float]:
+        if self.duration_ns is None:
+            return None
+        return round(self.duration_ns / 1_000_000, 3)
+
+
+@dataclasses.dataclass
+class TraceTree:
+    """A reconstructed tree of spans for one trace_id."""
+
+    trace_id: str
+    roots: List["TreeNode"]
+
+    def count(self) -> int:
+        n = 0
+        for r in self.roots:
+            n += r.count()
+        return n
+
+
+@dataclasses.dataclass
+class TreeNode:
+    span: SpanRecord
+    children: List["TreeNode"] = dataclasses.field(default_factory=list)
+
+    def count(self) -> int:
+        n = 1
+        for c in self.children:
+            n += c.count()
+        return n
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+_HEX_RE = re.compile(r"^[0-9a-fA-F]+$")
+
+
+def _strip_hex(value: Any) -> Optional[str]:
+    """Normalize a hex trace/span id to a lowercase hex string with no 0x prefix.
+
+    Returns None for None, empty strings, or non-hex values. OTel ids that arrive
+    as ints are also accepted (some encoders coerce to int)."""
+    if value is None:
+        return None
+    if isinstance(value, int):
+        if value == 0:
+            return None
+        return format(value, "x")
+    if not isinstance(value, str):
+        return None
+    v = value.strip()
+    if not v:
+        return None
+    if v.startswith("0x") or v.startswith("0X"):
+        v = v[2:]
+    v = v.lower()
+    if not _HEX_RE.match(v):
+        return None
+    return v
+
+
+def _coerce_ns(value: Any) -> Optional[int]:
+    """OTel epoch-nanoseconds can arrive as int, float, ISO string, or None.
+
+    Strings are only accepted when they parse as ISO 8601 with a timezone;
+    floats and ints are passed through. The 0 sentinel (the OTel "no parent"
+    convention) maps to None."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float):
+        return int(value) if value > 0 else None
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        # ISO 8601 with timezone
+        try:
+            from datetime import datetime
+
+            ts = datetime.fromisoformat(s.replace("Z", "+00:00"))
+            return int(ts.timestamp() * 1_000_000_000)
+        except Exception:
+            return None
+    return None
+
+
+def _iter_json_objects(text: str) -> Iterator[Dict[str, Any]]:
+    """Yield top-level JSON objects from a brace-balanced span-log file.
+
+    The dojo's dump.py writes one object per line, but the SDK's
+    ``spans_raw_optimized.log`` and ``spans_processed.log`` are written via
+    ``json.dump`` without indent (raw) or with ``json.dumps(span_data) + "\\n"``
+    (processed). Both end up with one object per line in practice, but
+    newlines inside string values would break a strict line-splitter. The
+    brace-balancer below handles both.
+    """
+    depth = 0
+    start = -1
+    in_string = False
+    escape = False
+    for i, ch in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                chunk = text[start : i + 1]
+                try:
+                    yield json.loads(chunk)
+                except json.JSONDecodeError:
+                    # Skip malformed objects silently here; the caller decides
+                    # whether to warn via a returned list of (obj, error) pairs.
+                    pass
+                start = -1
+            elif depth < 0:
+                depth = 0
+
+
+def _detect_source(obj: Dict[str, Any]) -> str:
+    """Return 'raw' for ReadableSpan.to_json(), 'processed' for span_data, 'unknown' otherwise."""
+    if isinstance(obj.get("context"), dict) and "trace_id" in obj.get("context", {}):
+        return "raw"
+    if (
+        "trace_id" in obj
+        and "span_id" in obj
+        and isinstance(obj.get("parent_span_id"), (str, type(None)))
+    ):
+        return "processed"
+    return "unknown"
+
+
+def _parse_processed(obj: Dict[str, Any]) -> Optional[SpanRecord]:
+    trace_id = _strip_hex(obj.get("trace_id"))
+    span_id = _strip_hex(obj.get("span_id"))
+    if not trace_id or not span_id:
+        return None
+    parent = _strip_hex(obj.get("parent_span_id"))
+    name = obj.get("name") or ""
+    kind = obj.get("kind") or "UNKNOWN"
+    start_time = _coerce_ns(obj.get("start_time"))
+    end_time = _coerce_ns(obj.get("end_time"))
+    if start_time is not None and end_time is not None and end_time >= start_time:
+        duration_ns = end_time - start_time
+    else:
+        duration_ns = obj.get("duration_ns")
+        if duration_ns is not None and duration_ns < 0:
+            duration_ns = None
+    status = obj.get("status") or {}
+    status_code = ""
+    status_description = ""
+    if isinstance(status, dict):
+        status_code = str(status.get("code") or "")
+        status_description = str(status.get("description") or "")
+    attributes = obj.get("attributes") or {}
+    if not isinstance(attributes, dict):
+        attributes = {}
+    return SpanRecord(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent if parent else None,
+        name=name,
+        kind=kind,
+        start_time=start_time,
+        end_time=end_time,
+        duration_ns=duration_ns,
+        status_code=status_code,
+        status_description=status_description,
+        attributes=attributes,
+        source="processed",
+    )
+
+
+def _parse_raw(obj: Dict[str, Any]) -> Optional[SpanRecord]:
+    ctx = obj.get("context")
+    if not isinstance(ctx, dict):
+        return None
+    trace_id = _strip_hex(ctx.get("trace_id"))
+    span_id = _strip_hex(ctx.get("span_id"))
+    if not trace_id or not span_id:
+        return None
+    parent = _strip_hex(obj.get("parent_id"))
+    name = obj.get("name") or ""
+    kind = str(obj.get("kind") or "UNKNOWN")
+    # ReadableSpan.to_json writes start_time / end_time as ISO 8601 strings.
+    start_time = _coerce_ns(obj.get("start_time"))
+    end_time = _coerce_ns(obj.get("end_time"))
+    if start_time is not None and end_time is not None and end_time >= start_time:
+        duration_ns = end_time - start_time
+    else:
+        duration_ns = None
+    status = obj.get("status") or {}
+    status_code = ""
+    status_description = ""
+    if isinstance(status, dict):
+        status_code = str(status.get("status_code") or "")
+        status_description = str(status.get("description") or "")
+    attributes = obj.get("attributes") or {}
+    if not isinstance(attributes, dict):
+        attributes = {}
+    return SpanRecord(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent if parent else None,
+        name=name,
+        kind=kind,
+        start_time=start_time,
+        end_time=end_time,
+        duration_ns=duration_ns,
+        status_code=status_code,
+        status_description=status_description,
+        attributes=attributes,
+        source="raw",
+    )
+
+
+def parse_line(line: str) -> Optional[SpanRecord]:
+    """Parse a single JSON line and return a SpanRecord, or None if unparseable."""
+    if not line or not line.strip():
+        return None
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    source = _detect_source(obj)
+    if source == "processed":
+        return _parse_processed(obj)
+    if source == "raw":
+        return _parse_raw(obj)
+    return None
+
+
+def _read_file(path: PathLike) -> str:
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+@dataclasses.dataclass
+class ParseResult:
+    spans: List[SpanRecord]
+    malformed_lines: int
+    files_read: int
+
+    def total(self) -> int:
+        return len(self.spans) + self.malformed_lines
+
+
+def parse_paths(paths: Sequence[PathLike]) -> ParseResult:
+    """Read all paths, brace-balance the JSON, and return SpanRecords.
+
+    Counts malformed objects (JSON parse failures and unparseable shapes) but
+    does not raise on them. Empty / missing paths contribute 0 spans and 0 errors.
+
+    ``malformed_lines`` is the count of non-blank lines that did not produce a
+    span. This includes JSON parse errors and lines whose shape we don't
+    recognize. Blank lines are not counted.
+    """
+    spans: List[SpanRecord] = []
+    malformed = 0
+    files_read = 0
+    for raw_path in paths:
+        path = Path(raw_path)
+        if not path.exists():
+            continue
+        files_read += 1
+        text = _read_file(path)
+        if not text.strip():
+            continue
+        # Count non-blank lines for the malformed denominator. The brace-
+        # balancer may yield fewer objects than this if a line is invalid JSON
+        # or has a non-span shape; the difference is what we surface to the
+        # user as "malformed".
+        non_blank = sum(1 for line in text.splitlines() if line.strip())
+        file_spans: List[SpanRecord] = []
+        for obj in _iter_json_objects(text):
+            source = _detect_source(obj)
+            record: Optional[SpanRecord] = None
+            if source == "processed":
+                record = _parse_processed(obj)
+            elif source == "raw":
+                record = _parse_raw(obj)
+            if record is not None:
+                file_spans.append(record)
+        spans.extend(file_spans)
+        malformed += max(0, non_blank - len(file_spans))
+    return ParseResult(spans=spans, malformed_lines=malformed, files_read=files_read)
+
+
+# ---------------------------------------------------------------------------
+# Tree building
+# ---------------------------------------------------------------------------
+
+
+def build_trees(
+    spans: Iterable[SpanRecord],
+    *,
+    warn_stream: Optional[TextIO] = None,
+) -> List[TraceTree]:
+    """Reconstruct TraceTrees from a flat span list.
+
+    Each trace_id groups its own tree. Spans whose parent_span_id is None or
+    that have a parent in a different trace become roots. Spans whose
+    parent_span_id points to a missing span are wrapped under a synthetic
+    ``_orphan`` root (named after the missing parent) so the trace renders and
+    the warning surfaces in the output.
+    """
+    spans_by_id: Dict[str, SpanRecord] = {}
+    children: Dict[str, List[SpanRecord]] = {}
+    by_trace: Dict[str, List[SpanRecord]] = {}
+
+    for s in spans:
+        spans_by_id.setdefault(s.span_id, s)
+        by_trace.setdefault(s.trace_id, []).append(s)
+        if s.parent_span_id:
+            children.setdefault(s.parent_span_id, []).append(s)
+
+    def make_node(span: SpanRecord) -> TreeNode:
+        node = TreeNode(span=span)
+        for child in sorted(children.get(span.span_id, []), key=lambda c: c.start_time or 0):
+            node.children.append(make_node(child))
+        return node
+
+    trees: List[TraceTree] = []
+    for trace_id, members in sorted(by_trace.items(), key=lambda kv: kv[0]):
+        # Roots = spans with no parent, or whose parent is in a different trace,
+        # or whose parent_id is None / missing / zero.
+        root_nodes: List[TreeNode] = []
+        seen_orphans: Dict[str, TreeNode] = {}
+        for s in members:
+            parent_id = s.parent_span_id
+            if not parent_id or parent_id == "0" * len(parent_id):
+                root_nodes.append(make_node(s))
+                continue
+            if parent_id not in spans_by_id:
+                # Orphan: the parent is missing (different file, dropped, etc.).
+                # We park the span under a synthetic root named after the
+                # missing parent so the output still shows it; the warning
+                # tells the user which parent went missing.
+                bucket = seen_orphans.get(parent_id)
+                if bucket is None:
+                    orphan = SpanRecord(
+                        trace_id=s.trace_id,
+                        span_id=parent_id,
+                        parent_span_id=None,
+                        name="_orphan",
+                        kind="INTERNAL",
+                        start_time=None,
+                        end_time=None,
+                        duration_ns=None,
+                        status_code="",
+                        status_description="",
+                        attributes={
+                            "_orphan_reason": "parent span not present in log file",
+                            "_missing_parent_id": parent_id,
+                        },
+                        source="synthetic",
+                    )
+                    bucket = TreeNode(span=orphan)
+                    seen_orphans[parent_id] = bucket
+                    root_nodes.append(bucket)
+                    if warn_stream is not None:
+                        warn_stream.write(
+                            f"[neatlogs-replay] warning: orphan span {s.span_id} "
+                            f"(name={s.name!r}) references missing parent {parent_id}; "
+                            f"wrapping under synthetic '_orphan' root.\n"
+                        )
+                bucket.children.append(make_node(s))
+                continue
+            # If the parent belongs to a different trace (very rare; usually
+            # means a corrupted file), the span still needs to render. Treat
+            # it as a root so it isn't silently dropped.
+            if spans_by_id[parent_id].trace_id != s.trace_id:
+                root_nodes.append(make_node(s))
+                continue
+            # Normal case: the span has a parent in the same trace, so it will
+            # be reached via make_node recursion on the parent. No need to
+            # add it to roots here.
+        trees.append(TraceTree(trace_id=trace_id, roots=root_nodes))
+    return trees
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+# Color helpers: only emit ANSI when the stream is a TTY (or when force_color
+# is True). The CLI passes force_color=True when --color is set.
+
+_USE_COLOR = True
+
+
+def _supports_color(stream: TextIO) -> bool:
+    if not _USE_COLOR:
+        return False
+    if not hasattr(stream, "isatty"):
+        return False
+    return bool(stream.isatty())
+
+
+def _ansi(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m"
+
+
+_KIND_COLORS = {
+    "LLM": "36",  # cyan
+    "AGENT": "35",  # magenta
+    "WORKFLOW": "33",  # yellow
+    "CHAIN": "33",
+    "TOOL": "32",  # green
+    "RETRIEVER": "34",  # blue
+    "EMBEDDING": "34",
+    "VECTOR_STORE": "34",
+    "RERANKER": "34",
+    "GUARDRAIL": "31",  # red
+    "MCP_TOOL": "33",
+    "HTTP": "90",  # bright black / gray
+    "INTERNAL": "37",
+    "CLIENT": "90",
+    "PRODUCER": "90",
+    "CONSUMER": "90",
+    "SERVER": "90",
+}
+
+
+def _normalize_kind(kind: Optional[str]) -> str:
+    """Strip a leading ``SpanKind.`` / ``SPANKIND.`` prefix and uppercase.
+
+    The raw ``ReadableSpan.to_json()`` exporter writes the full enum name
+    (``"SpanKind.INTERNAL"``); the processed ``span_data`` shape uses a short
+    lowercase string (``"llm"``, ``"tool"``). We display both consistently.
+    """
+    if not kind:
+        return "?"
+    k = kind.strip()
+    if not k:
+        return "?"
+    for prefix in ("SpanKind.", "SPANKIND."):
+        if k.startswith(prefix):
+            k = k[len(prefix) :]
+            break
+    return k.upper() or "?"
+
+
+def _kind_color(kind: str) -> Optional[str]:
+    return _KIND_COLORS.get(_normalize_kind(kind))
+
+
+def _format_node_text(node: TreeNode) -> str:
+    """Render a single TreeNode as a single line."""
+    span = node.span
+    kind = _normalize_kind(span.kind)
+    name = span.name or "?"
+    ms = span.duration_ms()
+    ms_str = f"  ({ms} ms)" if ms is not None else ""
+    extra: List[str] = []
+    if span.status_code and span.status_code not in ("OK", "UNSET"):
+        extra.append(f"status={span.status_code}")
+    if span.attributes.get("neatlogs.llm.model_name"):
+        model = span.attributes["neatlogs.llm.model_name"]
+        if isinstance(model, str) and model:
+            extra.append(f"model={model}")
+    if span.attributes.get("neatlogs.llm.token_count.total"):
+        toks = span.attributes["neatlogs.llm.token_count.total"]
+        extra.append(f"tokens={toks}")
+    extra_str = f"  [{', '.join(extra)}]" if extra else ""
+    line = f"[{kind:7s}] {name}{ms_str}{extra_str}"
+    return line
+
+
+def format_tree(
+    trees: Sequence[TraceTree],
+    *,
+    style: str = "text",
+    max_depth: Optional[int] = None,
+    filter_kind: Optional[str] = None,
+    use_color: Optional[bool] = None,
+    stream: Optional[TextIO] = None,
+) -> str:
+    """Render one or more TraceTrees as a string.
+
+    style:
+        - "text": colored indented tree (the default).
+        - "json": one JSON object per trace with the full tree.
+
+    max_depth truncates the tree at the given depth; spans below are still
+    counted in totals but not rendered.
+
+    filter_kind keeps only the spans whose kind matches (case-insensitive).
+    """
+    if style not in ("text", "json"):
+        raise ValueError(f"unknown style: {style!r}")
+    sink = stream or sys.stdout
+    if use_color is None:
+        use_color = _supports_color(sink)
+    if style == "json":
+        return _format_json(trees, max_depth=max_depth, filter_kind=filter_kind)
+    return _format_text(trees, max_depth=max_depth, filter_kind=filter_kind, use_color=use_color)
+
+
+def _format_json(
+    trees: Sequence[TraceTree],
+    *,
+    max_depth: Optional[int],
+    filter_kind: Optional[str],
+) -> str:
+    out: List[str] = []
+    for tree in trees:
+        out.append(
+            json.dumps(
+                {
+                    "trace_id": tree.trace_id,
+                    "span_count": tree.count(),
+                    "roots": [
+                        _node_to_dict(r, max_depth=max_depth, filter_kind=filter_kind)
+                        for r in tree.roots
+                    ],
+                },
+                default=str,
+            )
+        )
+    return "\n".join(out) + ("\n" if out else "")
+
+
+def _node_to_dict(
+    node: TreeNode,
+    *,
+    max_depth: Optional[int],
+    filter_kind: Optional[str],
+    depth: int = 0,
+) -> Dict[str, Any]:
+    keep = filter_kind is None or _normalize_kind(node.span.kind) == filter_kind.upper()
+    children: List[Dict[str, Any]] = []
+    if max_depth is None or depth < max_depth:
+        for child in node.children:
+            children.append(
+                _node_to_dict(
+                    child,
+                    max_depth=max_depth,
+                    filter_kind=filter_kind,
+                    depth=depth + 1 if keep else depth + 1,
+                )
+            )
+    if not keep and not children:
+        return {"_pruned": True}
+    if not keep:
+        return {"_pruned": True, "children": children}
+    return {
+        "trace_id": node.span.trace_id,
+        "span_id": node.span.span_id,
+        "parent_span_id": node.span.parent_span_id,
+        "name": node.span.name,
+        "kind": node.span.kind,
+        "start_time": node.span.start_time,
+        "end_time": node.span.end_time,
+        "duration_ms": node.span.duration_ms(),
+        "status": {
+            "code": node.span.status_code,
+            "description": node.span.status_description,
+        },
+        "attributes": node.span.attributes,
+        "source": node.span.source,
+        "children": children,
+    }
+
+
+def _format_text(
+    trees: Sequence[TraceTree],
+    *,
+    max_depth: Optional[int],
+    filter_kind: Optional[str],
+    use_color: bool,
+) -> str:
+    buf = io.StringIO()
+    if not trees:
+        buf.write("(no spans found)\n")
+        return buf.getvalue()
+    for tree in trees:
+        header = f"=== trace {tree.trace_id}  ({tree.count()} span{'s' if tree.count() != 1 else ''}) ==="
+        if use_color:
+            header = _ansi("1;33", header)
+        buf.write(header + "\n")
+        if not tree.roots:
+            buf.write("  (no root span: every span points to a missing parent)\n\n")
+            continue
+        for root in tree.roots:
+            _render_text_node(
+                buf,
+                root,
+                depth=0,
+                max_depth=max_depth,
+                filter_kind=filter_kind,
+                use_color=use_color,
+            )
+        buf.write("\n")
+    return buf.getvalue()
+
+
+def _render_text_node(
+    buf: io.StringIO,
+    node: TreeNode,
+    *,
+    depth: int,
+    max_depth: Optional[int],
+    filter_kind: Optional[str],
+    use_color: bool,
+) -> None:
+    if max_depth is not None and depth > max_depth:
+        return
+    span = node.span
+    keep = filter_kind is None or _normalize_kind(span.kind) == filter_kind.upper()
+    indent = "  " * depth
+    if keep:
+        line = _format_node_text(node)
+        if use_color:
+            color = _kind_color(span.kind)
+            if color is not None:
+                line = _ansi(color, line)
+        buf.write(indent + line + "\n")
+    child_indent_depth = depth + 1
+    if max_depth is not None and child_indent_depth > max_depth:
+        return
+    for child in node.children:
+        _render_text_node(
+            buf,
+            child,
+            depth=child_indent_depth,
+            max_depth=max_depth,
+            filter_kind=filter_kind,
+            use_color=use_color,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def replay(
+    paths: Union[PathLike, Sequence[PathLike]],
+    *,
+    max_depth: Optional[int] = None,
+    filter_kind: Optional[str] = None,
+    warn_stream: Optional[TextIO] = None,
+) -> List[TraceTree]:
+    """Read span log files and return a list of reconstructed TraceTrees.
+
+    Args:
+        paths: One path, a list of paths, or a single globbed path. Missing
+            files are skipped silently.
+        max_depth: If set, the printed tree is truncated at this depth; counts
+            still include deeper spans.
+        filter_kind: If set, only render spans whose ``kind`` matches
+            (case-insensitive). Useful to focus on a single layer.
+        warn_stream: Where to write orphan-span warnings. Defaults to stderr.
+            Pass ``io.StringIO()`` to silence.
+    """
+    if isinstance(paths, (str, os.PathLike)):
+        seq: List[PathLike] = [paths]
+    else:
+        seq = list(paths)
+    parsed = parse_paths(seq)
+    return build_trees(parsed.spans, warn_stream=warn_stream or sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _expand_paths(argv: Sequence[str]) -> List[PathLike]:
+    out: List[PathLike] = []
+    for a in argv:
+        # Treat as a literal path; do not expand globs (the brace-balancer
+        # reads the whole file anyway, so a glob would only ever match one).
+        out.append(a)
+    return out
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="neatlogs-replay",
+        description=(
+            "Replay processed or raw OpenTelemetry span JSONL logs as a tree. "
+            "Read span log files written by NEATLOGS_LOG_SPANS or "
+            "NEATLOGS_LOG_RAW_SPANS and print the parent/child hierarchy."
+        ),
+    )
+    p.add_argument(
+        "paths",
+        nargs="+",
+        help="One or more span log file paths.",
+    )
+    p.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format. 'text' is a colored indented tree; 'json' is one JSON object per trace.",
+    )
+    p.add_argument(
+        "--max-depth",
+        type=int,
+        default=None,
+        help="Truncate the rendered tree at this depth (counts still include deeper spans).",
+    )
+    p.add_argument(
+        "--filter-kind",
+        default=None,
+        help="Render only spans whose kind matches this value (case-insensitive).",
+    )
+    p.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI color output even when stdout is a TTY.",
+    )
+    p.add_argument(
+        "--color",
+        action="store_true",
+        help="Force ANSI color output even when stdout is not a TTY.",
+    )
+    p.add_argument(
+        "--summary",
+        action="store_true",
+        help="After the tree, print a one-line summary per trace: span count, kind breakdown.",
+    )
+    return p
+
+
+def _summary_line(tree: TraceTree) -> str:
+    kinds: Dict[str, int] = {}
+
+    def walk(node: TreeNode) -> None:
+        kind = _normalize_kind(node.span.kind)
+        kinds[kind] = kinds.get(kind, 0) + 1
+        for c in node.children:
+            walk(c)
+
+    for r in tree.roots:
+        walk(r)
+    parts = [f"{k}={v}" for k, v in sorted(kinds.items(), key=lambda kv: (-kv[1], kv[0]))]
+    return f"  trace {tree.trace_id}: {tree.count()} spans; " + ", ".join(parts)
+
+
+def _cli(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    global _USE_COLOR
+    if args.no_color:
+        _USE_COLOR = False
+    elif args.color:
+        _USE_COLOR = True
+    paths = _expand_paths(args.paths)
+    try:
+        trees = replay(
+            paths,
+            max_depth=args.max_depth,
+            filter_kind=args.filter_kind,
+        )
+    except FileNotFoundError as exc:
+        print(f"[neatlogs-replay] error: {exc}", file=sys.stderr)
+        return 2
+    if not trees:
+        print("[neatlogs-replay] no spans found", file=sys.stderr)
+    out = format_tree(
+        trees,
+        style=args.format,
+        max_depth=args.max_depth,
+        filter_kind=args.filter_kind,
+    )
+    sys.stdout.write(out)
+    if args.summary and args.format == "text":
+        for tree in trees:
+            sys.stdout.write(_summary_line(tree) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,6 +322,13 @@ milvus = [
 [project.entry-points."hermes_agent.plugins"]
 neatlogs = "neatlogs.hermes_plugin"
 
+# Console scripts installed by `pip install neatlogs`. `neatlogs-replay` reads
+# the JSONL span log files produced by `NEATLOGS_LOG_SPANS` /
+# `NEATLOGS_LOG_RAW_SPANS` and prints a colored, indented parent/child tree.
+# Pure stdlib, no extra deps.
+[project.scripts]
+neatlogs-replay = "neatlogs.replay:_cli"
+
 [project.urls]
 Homepage = "https://github.com/NeatLogs/neatlogs"
 Repository = "https://github.com/NeatLogs/neatlogs.git"

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -1,0 +1,627 @@
+"""
+Unit tests for neatlogs.replay.
+
+The replay module reads JSONL span logs written by the SDK's span processor
+(``NEATLOGS_LOG_SPANS=true`` → processed ``span_data`` shape) or by the raw
+OTel ``to_json()`` exporter (``NEATLOGS_LOG_RAW_SPANS=true``), reconstructs
+the parent/child tree per trace, and prints a human-readable summary. These
+tests exercise the parser, tree builder, and renderer end-to-end without
+spinning up an OTel pipeline.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from neatlogs.replay import (
+    SpanRecord,
+    TraceTree,
+    TreeNode,
+    _format_text,
+    _iter_json_objects,
+    _kind_color,
+    _normalize_kind,
+    _strip_hex,
+    build_trees,
+    format_tree,
+    parse_line,
+    parse_paths,
+    replay,
+)
+
+# ---------------------------------------------------------------------------
+# _strip_hex
+# ---------------------------------------------------------------------------
+
+
+class TestStripHex:
+    def test_none(self):
+        assert _strip_hex(None) is None
+
+    def test_empty_string(self):
+        assert _strip_hex("") is None
+
+    def test_plain_hex(self):
+        assert _strip_hex("0fa6dc405d06ed3763e2584130b53190") == "0fa6dc405d06ed3763e2584130b53190"
+
+    def test_uppercase_hex(self):
+        assert _strip_hex("0FA6DC40") == "0fa6dc40"
+
+    def test_0x_prefix(self):
+        assert _strip_hex("0x0fa6dc40") == "0fa6dc40"
+
+    def test_int_value(self):
+        assert _strip_hex(264602534208) == "3d9b8a4140"
+
+    def test_zero_int(self):
+        assert _strip_hex(0) is None
+
+    def test_non_hex_string(self):
+        assert _strip_hex("not-hex") is None
+
+    def test_non_str_non_int(self):
+        assert _strip_hex([1, 2, 3]) is None
+
+
+# ---------------------------------------------------------------------------
+# _normalize_kind / _kind_color
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeKind:
+    def test_short_lowercase(self):
+        assert _normalize_kind("llm") == "LLM"
+        assert _normalize_kind("tool") == "TOOL"
+
+    def test_spankind_prefix_stripped(self):
+        assert _normalize_kind("SpanKind.INTERNAL") == "INTERNAL"
+        assert _normalize_kind("SpanKind.CLIENT") == "CLIENT"
+
+    def test_spankind_uppercase_prefix(self):
+        # Defensive: the raw exporter always writes "SpanKind." but other
+        # sources might uppercase the prefix.
+        assert _normalize_kind("SPANKIND.SERVER") == "SERVER"
+
+    def test_empty(self):
+        assert _normalize_kind("") == "?"
+
+    def test_none_safe(self):
+        # Build paths pass strings, but be defensive.
+        assert _normalize_kind("") == "?"
+        assert _normalize_kind("   ") == "?"
+
+
+class TestKindColor:
+    def test_known_short_kind(self):
+        assert _kind_color("llm") == "36"  # cyan
+
+    def test_spankind_resolves(self):
+        assert _kind_color("SpanKind.INTERNAL") == "37"
+        assert _kind_color("SpanKind.CLIENT") == "90"
+
+    def test_unknown_kind(self):
+        assert _kind_color("not-a-kind") is None
+
+
+# ---------------------------------------------------------------------------
+# _iter_json_objects
+# ---------------------------------------------------------------------------
+
+
+class TestIterJsonObjects:
+    def test_single_object(self):
+        text = '{"a": 1, "b": 2}'
+        objs = list(_iter_json_objects(text))
+        assert len(objs) == 1
+        assert objs[0] == {"a": 1, "b": 2}
+
+    def test_multiple_objects(self):
+        text = '{"a": 1}\n{"b": 2}\n{"c": 3}'
+        objs = list(_iter_json_objects(text))
+        assert len(objs) == 3
+        assert objs[2] == {"c": 3}
+
+    def test_objects_with_nested_braces_in_strings(self):
+        text = '{"name": "a {b} c", "value": 1}\n{"name": "plain", "value": 2}'
+        objs = list(_iter_json_objects(text))
+        assert len(objs) == 2
+        assert objs[0]["name"] == "a {b} c"
+        assert objs[1]["name"] == "plain"
+
+    def test_objects_with_escaped_quotes(self):
+        text = '{"name": "a \\"quoted\\" word", "value": 1}'
+        objs = list(_iter_json_objects(text))
+        assert len(objs) == 1
+        assert objs[0]["name"] == 'a "quoted" word'
+
+    def test_malformed_object_is_skipped(self):
+        text = '{"a": 1}\n{not valid json}\n{"b": 2}'
+        objs = list(_iter_json_objects(text))
+        # The malformed object is silently dropped by the brace-balanced parser.
+        assert len(objs) >= 1
+        assert {"a": 1} in objs
+        assert {"b": 2} in objs
+
+    def test_empty_string(self):
+        assert list(_iter_json_objects("")) == []
+
+
+# ---------------------------------------------------------------------------
+# parse_line: processed (span_data) and raw (to_json) shapes
+# ---------------------------------------------------------------------------
+
+
+def _processed_span_dict(
+    trace_id: str = "aaaa",
+    span_id: str = "1111",
+    parent_span_id=None,
+    name: str = "openai.chat.completions.create",
+    kind: str = "llm",
+    duration_ns: int = 12345678,
+    status_code: str = "OK",
+    attributes=None,
+) -> dict:
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "name": name,
+        "kind": kind,
+        "start_time": 1700000000000000000,
+        "end_time": 1700000000000000000 + duration_ns,
+        "duration_ns": duration_ns,
+        "attributes": attributes or {"neatlogs.llm.model_name": "gpt-4o-mini"},
+        "resource": {"attributes": {"service.name": "svc"}},
+        "status": {"code": status_code, "description": ""},
+        "events": [],
+    }
+
+
+def _raw_span_dict(
+    trace_id: str = "bbbb",
+    span_id: str = "2222",
+    parent_id=None,
+    name: str = "POST",
+    kind: str = "SpanKind.CLIENT",
+    duration_ns: int = 5000000,
+    status_code: str = "OK",
+) -> dict:
+    return {
+        "name": name,
+        "context": {"trace_id": "0x" + trace_id, "span_id": "0x" + span_id},
+        "parent_id": ("0x" + parent_id) if parent_id else None,
+        "kind": kind,
+        "start_time": "2024-01-15T10:00:00.000Z",
+        "end_time": "2024-01-15T10:00:00.005Z",
+        "status": {"status_code": status_code, "description": ""},
+        "attributes": {
+            "http.method": "POST",
+            "http.url": "https://api.openai.com/v1/chat/completions",
+        },
+        "events": [],
+        "links": [],
+        "resource": {},
+    }
+
+
+class TestParseLineProcessed:
+    def test_basic(self):
+        d = _processed_span_dict()
+        line = json.dumps(d)
+        record = parse_line(line)
+        assert record is not None
+        assert record.trace_id == "aaaa"
+        assert record.span_id == "1111"
+        assert record.parent_span_id is None
+        assert record.name == "openai.chat.completions.create"
+        assert record.kind == "llm"
+        assert record.source == "processed"
+        assert record.status_code == "OK"
+        assert record.duration_ns == 12345678
+        assert record.duration_ms() == pytest.approx(12.346, abs=1e-3)
+        assert record.attributes["neatlogs.llm.model_name"] == "gpt-4o-mini"
+
+    def test_with_parent(self):
+        d = _processed_span_dict(parent_span_id="0000", span_id="1111", trace_id="aaaa")
+        record = parse_line(json.dumps(d))
+        assert record is not None
+        assert record.parent_span_id == "0000"
+
+    def test_with_0x_prefix_in_ids(self):
+        d = _processed_span_dict(trace_id="0xabcd", span_id="0x1234")
+        record = parse_line(json.dumps(d))
+        assert record is not None
+        assert record.trace_id == "abcd"
+        assert record.span_id == "1234"
+
+    def test_zero_parent_id_treated_as_no_parent(self):
+        d = _processed_span_dict(parent_span_id="0000000000000000", span_id="1111", trace_id="aaaa")
+        record = parse_line(json.dumps(d))
+        assert record is not None
+        # The processor already strips zero parent_ids; replay is defensive.
+        assert record.parent_span_id in (None, "0000000000000000")
+
+    def test_empty_line(self):
+        assert parse_line("") is None
+        assert parse_line("   \n  ") is None
+
+    def test_malformed_json(self):
+        assert parse_line("{not valid") is None
+
+    def test_non_dict(self):
+        assert parse_line("[1, 2, 3]") is None
+        assert parse_line('"a string"') is None
+        assert parse_line("42") is None
+
+
+class TestParseLineRaw:
+    def test_basic(self):
+        d = _raw_span_dict()
+        record = parse_line(json.dumps(d))
+        assert record is not None
+        assert record.source == "raw"
+        assert record.trace_id == "bbbb"
+        assert record.span_id == "2222"
+        assert record.name == "POST"
+        assert record.kind == "SpanKind.CLIENT"
+        assert record.duration_ms() == pytest.approx(5.0, abs=0.1)
+
+    def test_iso_timestamps(self):
+        d = _raw_span_dict()
+        record = parse_line(json.dumps(d))
+        assert record is not None
+        assert record.start_time is not None
+        assert record.end_time is not None
+        assert record.start_time < record.end_time
+
+    def test_with_parent(self):
+        d = _raw_span_dict(parent_id="0000", span_id="2222", trace_id="bbbb")
+        record = parse_line(json.dumps(d))
+        assert record is not None
+        assert record.parent_span_id == "0000"
+
+    def test_no_context(self):
+        d = _raw_span_dict()
+        d.pop("context")
+        assert parse_line(json.dumps(d)) is None
+
+
+# ---------------------------------------------------------------------------
+# parse_paths: file reading + multi-file
+# ---------------------------------------------------------------------------
+
+
+class TestParsePaths:
+    def test_processed_file(self, tmp_path: Path):
+        d1 = _processed_span_dict(trace_id="a", span_id="1", name="root")
+        d2 = _processed_span_dict(trace_id="a", span_id="2", parent_span_id="1", name="child")
+        p = tmp_path / "spans.jsonl"
+        p.write_text("\n".join(json.dumps(d) for d in (d1, d2)))
+        result = parse_paths([p])
+        assert result.files_read == 1
+        assert len(result.spans) == 2
+        assert result.malformed_lines == 0
+        assert {s.name for s in result.spans} == {"root", "child"}
+
+    def test_raw_file(self, tmp_path: Path):
+        d = _raw_span_dict()
+        p = tmp_path / "raw.jsonl"
+        p.write_text(json.dumps(d))
+        result = parse_paths([p])
+        assert result.files_read == 1
+        assert len(result.spans) == 1
+        assert result.spans[0].source == "raw"
+
+    def test_mixed_processed_and_raw(self, tmp_path: Path):
+        processed = _processed_span_dict(trace_id="a", span_id="1")
+        raw = _raw_span_dict(trace_id="b", span_id="2")
+        p1 = tmp_path / "p.jsonl"
+        p2 = tmp_path / "r.jsonl"
+        p1.write_text(json.dumps(processed))
+        p2.write_text(json.dumps(raw))
+        result = parse_paths([p1, p2])
+        assert result.files_read == 2
+        assert len(result.spans) == 2
+        assert {s.source for s in result.spans} == {"processed", "raw"}
+
+    def test_empty_file(self, tmp_path: Path):
+        p = tmp_path / "empty.jsonl"
+        p.write_text("")
+        result = parse_paths([p])
+        assert result.files_read == 1
+        assert result.spans == []
+        assert result.malformed_lines == 0
+
+    def test_missing_path_skipped(self, tmp_path: Path):
+        result = parse_paths([tmp_path / "does_not_exist.jsonl"])
+        assert result.files_read == 0
+        assert result.spans == []
+
+    def test_malformed_lines_counted(self, tmp_path: Path):
+        valid = _processed_span_dict(trace_id="a", span_id="1")
+        p = tmp_path / "mixed.jsonl"
+        p.write_text("\n".join([json.dumps(valid), "{not valid}", "42", '"string"']))
+        result = parse_paths([p])
+        assert len(result.spans) == 1
+        assert result.malformed_lines == 3
+
+
+# ---------------------------------------------------------------------------
+# build_trees
+# ---------------------------------------------------------------------------
+
+
+def _processed(trace_id, span_id, parent=None, name="span", kind="chain"):
+    return SpanRecord(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent,
+        name=name,
+        kind=kind,
+        start_time=1_700_000_000_000_000_000,
+        end_time=1_700_000_000_000_010_000,
+        duration_ns=10_000,
+        status_code="OK",
+        status_description="",
+        attributes={},
+        source="processed",
+    )
+
+
+def _synthetic(trace_id, span_id, name="_orphan"):
+    return SpanRecord(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=None,
+        name=name,
+        kind="INTERNAL",
+        start_time=None,
+        end_time=None,
+        duration_ns=None,
+        status_code="",
+        status_description="",
+        attributes={},
+        source="synthetic",
+    )
+
+
+class TestBuildTrees:
+    def test_single_root(self):
+        spans = [_processed("a", "1", name="root", kind="workflow")]
+        trees = build_trees(spans)
+        assert len(trees) == 1
+        assert trees[0].trace_id == "a"
+        assert len(trees[0].roots) == 1
+        assert trees[0].count() == 1
+
+    def test_nested_tree(self):
+        spans = [
+            _processed("a", "1", name="root", kind="workflow"),
+            _processed("a", "2", parent="1", name="child", kind="chain"),
+            _processed("a", "3", parent="2", name="grand", kind="tool"),
+        ]
+        trees = build_trees(spans)
+        assert len(trees) == 1
+        root = trees[0].roots[0]
+        assert root.span.name == "root"
+        assert len(root.children) == 1
+        assert root.children[0].span.name == "child"
+        assert root.children[0].children[0].span.name == "grand"
+        assert trees[0].count() == 3
+
+    def test_multiple_traces(self):
+        spans = [
+            _processed("a", "1", name="trace-a"),
+            _processed("b", "1", name="trace-b"),
+        ]
+        trees = build_trees(spans)
+        assert len(trees) == 2
+        assert {t.trace_id for t in trees} == {"a", "b"}
+
+    def test_multiple_roots_in_one_trace(self):
+        spans = [
+            _processed("a", "1", name="root1"),
+            _processed("a", "2", name="root2"),
+        ]
+        trees = build_trees(spans)
+        assert len(trees) == 1
+        assert len(trees[0].roots) == 2
+
+    def test_orphan_becomes_synthetic_root(self):
+        spans = [
+            _processed("a", "1", name="root"),
+            _processed("a", "2", parent="DEAD", name="orphan"),
+        ]
+        buf = io.StringIO()
+        trees = build_trees(spans, warn_stream=buf)
+        assert len(trees) == 1
+        # Two roots: the real root + a synthetic _orphan root.
+        assert len(trees[0].roots) == 2
+        names = [r.span.name for r in trees[0].roots]
+        assert "root" in names
+        assert "_orphan" in names
+        # The orphan span lives under the synthetic root.
+        orphan_root = next(r for r in trees[0].roots if r.span.name == "_orphan")
+        assert len(orphan_root.children) == 1
+        assert orphan_root.children[0].span.name == "orphan"
+        # Warning surfaces the missing parent id.
+        assert "DEAD" in buf.getvalue()
+
+    def test_no_warn_when_warn_stream_is_none(self):
+        spans = [_processed("a", "1", parent="DEAD", name="orphan")]
+        # Default warn_stream is stderr; we just confirm no exception is raised.
+        trees = build_trees(spans, warn_stream=io.StringIO())
+        assert len(trees) == 1
+
+    def test_parent_in_different_trace_becomes_root(self):
+        spans = [
+            _processed("a", "1", name="root-a"),
+            _processed("b", "2", parent="1", name="wrong-parent"),
+        ]
+        trees = build_trees(spans)
+        # Two traces, each with one root.
+        assert len(trees) == 2
+        for t in trees:
+            assert len(t.roots) == 1
+            assert t.roots[0].span.parent_span_id is None or t.roots[0].span.parent_span_id not in (
+                s.span_id for s in spans if s.trace_id == t.trace_id
+            )
+
+
+# ---------------------------------------------------------------------------
+# format_tree (text)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatText:
+    def test_empty_trees(self):
+        out = format_tree([], style="text", use_color=False)
+        assert "no spans found" in out
+
+    def test_basic_tree(self):
+        spans = [
+            _processed("a", "1", name="root", kind="workflow"),
+            _processed("a", "2", parent="1", name="llm-call", kind="llm"),
+        ]
+        trees = build_trees(spans)
+        out = format_tree(trees, style="text", use_color=False)
+        assert "trace a" in out
+        assert "[WORKFLOW] root" in out
+        assert "  [LLM    ] llm-call" in out
+        assert "2 spans" in out
+
+    def test_max_depth_truncates(self):
+        spans = [
+            _processed("a", "1", name="root", kind="workflow"),
+            _processed("a", "2", parent="1", name="child", kind="chain"),
+            _processed("a", "3", parent="2", name="grand", kind="tool"),
+        ]
+        trees = build_trees(spans)
+        out = format_tree(trees, style="text", use_color=False, max_depth=1)
+        assert "[WORKFLOW] root" in out
+        assert "child" in out
+        # grand is below the max_depth cutoff.
+        assert "grand" not in out
+
+    def test_filter_kind(self):
+        spans = [
+            _processed("a", "1", name="root", kind="workflow"),
+            _processed("a", "2", parent="1", name="llm-call", kind="llm"),
+            _processed("a", "3", parent="2", name="tool-call", kind="tool"),
+        ]
+        trees = build_trees(spans)
+        out = format_tree(trees, style="text", use_color=False, filter_kind="llm")
+        assert "llm-call" in out
+        # tool-call sits below the LLM but is excluded by filter; root renders too.
+        assert "tool-call" not in out
+
+    def test_no_color_when_disabled(self):
+        spans = [_processed("a", "1", name="root", kind="workflow")]
+        trees = build_trees(spans)
+        out = format_tree(trees, style="text", use_color=False)
+        # No ANSI escape codes.
+        assert "\033[" not in out
+
+    def test_color_when_enabled(self):
+        spans = [_processed("a", "1", name="root", kind="workflow")]
+        trees = build_trees(spans)
+        out = format_tree(trees, style="text", use_color=True)
+        # ANSI escape codes are present (the kind uses color code 33 for workflow).
+        assert "\033[" in out
+
+
+# ---------------------------------------------------------------------------
+# format_tree (json)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatJson:
+    def test_single_trace(self):
+        spans = [
+            _processed("a", "1", name="root", kind="workflow"),
+            _processed("a", "2", parent="1", name="child", kind="llm"),
+        ]
+        trees = build_trees(spans)
+        out = format_tree(trees, style="json")
+        lines = out.strip().split("\n")
+        assert len(lines) == 1
+        obj = json.loads(lines[0])
+        assert obj["trace_id"] == "a"
+        assert obj["span_count"] == 2
+        assert obj["roots"][0]["name"] == "root"
+        assert obj["roots"][0]["children"][0]["name"] == "child"
+        assert obj["roots"][0]["children"][0]["kind"] == "llm"
+
+    def test_empty_trees(self):
+        out = format_tree([], style="json")
+        assert out == ""
+
+    def test_unknown_style_raises(self):
+        with pytest.raises(ValueError):
+            format_tree([], style="bogus")
+
+
+# ---------------------------------------------------------------------------
+# replay (top-level API)
+# ---------------------------------------------------------------------------
+
+
+class TestReplay:
+    def test_end_to_end(self, tmp_path: Path):
+        spans = [
+            _processed("a", "1", name="root", kind="workflow"),
+            _processed("a", "2", parent="1", name="llm", kind="llm"),
+        ]
+        p = tmp_path / "spans.jsonl"
+        p.write_text("\n".join(json.dumps(_to_d(s)) for s in spans))
+        trees = replay(p, warn_stream=io.StringIO())
+        assert len(trees) == 1
+        assert trees[0].count() == 2
+
+    def test_accepts_single_path_string(self, tmp_path: Path):
+        p = tmp_path / "s.jsonl"
+        p.write_text(json.dumps(_to_d(_processed("a", "1"))))
+        trees = replay(str(p), warn_stream=io.StringIO())
+        assert len(trees) == 1
+
+    def test_accepts_list(self, tmp_path: Path):
+        p1 = tmp_path / "a.jsonl"
+        p2 = tmp_path / "b.jsonl"
+        p1.write_text(json.dumps(_to_d(_processed("a", "1"))))
+        p2.write_text(json.dumps(_to_d(_processed("b", "1"))))
+        trees = replay([p1, p2], warn_stream=io.StringIO())
+        assert len(trees) == 2
+
+    def test_max_depth_passed_through(self, tmp_path: Path):
+        spans = [
+            _processed("a", "1", name="root", kind="workflow"),
+            _processed("a", "2", parent="1", name="child", kind="chain"),
+        ]
+        p = tmp_path / "s.jsonl"
+        p.write_text("\n".join(json.dumps(_to_d(s)) for s in spans))
+        trees = replay(p, max_depth=0, warn_stream=io.StringIO())
+        out = format_tree(trees, style="text", use_color=False, max_depth=0)
+        assert "child" not in out
+
+
+def _to_d(s: SpanRecord) -> dict:
+    return {
+        "trace_id": s.trace_id,
+        "span_id": s.span_id,
+        "parent_span_id": s.parent_span_id,
+        "name": s.name,
+        "kind": s.kind,
+        "start_time": s.start_time,
+        "end_time": s.end_time,
+        "duration_ns": s.duration_ns,
+        "attributes": s.attributes,
+        "resource": {"attributes": {}},
+        "status": {"code": s.status_code, "description": s.status_description},
+        "events": [],
+    }

--- a/tests/unit/test_replay.py
+++ b/tests/unit/test_replay.py
@@ -84,15 +84,12 @@ class TestNormalizeKind:
         assert _normalize_kind("SpanKind.CLIENT") == "CLIENT"
 
     def test_spankind_uppercase_prefix(self):
-        # Defensive: the raw exporter always writes "SpanKind." but other
-        # sources might uppercase the prefix.
         assert _normalize_kind("SPANKIND.SERVER") == "SERVER"
 
     def test_empty(self):
         assert _normalize_kind("") == "?"
 
     def test_none_safe(self):
-        # Build paths pass strings, but be defensive.
         assert _normalize_kind("") == "?"
         assert _normalize_kind("   ") == "?"
 
@@ -143,7 +140,6 @@ class TestIterJsonObjects:
     def test_malformed_object_is_skipped(self):
         text = '{"a": 1}\n{not valid json}\n{"b": 2}'
         objs = list(_iter_json_objects(text))
-        # The malformed object is silently dropped by the brace-balanced parser.
         assert len(objs) >= 1
         assert {"a": 1} in objs
         assert {"b": 2} in objs
@@ -244,7 +240,6 @@ class TestParseLineProcessed:
         d = _processed_span_dict(parent_span_id="0000000000000000", span_id="1111", trace_id="aaaa")
         record = parse_line(json.dumps(d))
         assert record is not None
-        # The processor already strips zero parent_ids; replay is defensive.
         assert record.parent_span_id in (None, "0000000000000000")
 
     def test_empty_line(self):
@@ -441,21 +436,17 @@ class TestBuildTrees:
         buf = io.StringIO()
         trees = build_trees(spans, warn_stream=buf)
         assert len(trees) == 1
-        # Two roots: the real root + a synthetic _orphan root.
         assert len(trees[0].roots) == 2
         names = [r.span.name for r in trees[0].roots]
         assert "root" in names
         assert "_orphan" in names
-        # The orphan span lives under the synthetic root.
         orphan_root = next(r for r in trees[0].roots if r.span.name == "_orphan")
         assert len(orphan_root.children) == 1
         assert orphan_root.children[0].span.name == "orphan"
-        # Warning surfaces the missing parent id.
         assert "DEAD" in buf.getvalue()
 
     def test_no_warn_when_warn_stream_is_none(self):
         spans = [_processed("a", "1", parent="DEAD", name="orphan")]
-        # Default warn_stream is stderr; we just confirm no exception is raised.
         trees = build_trees(spans, warn_stream=io.StringIO())
         assert len(trees) == 1
 
@@ -465,7 +456,6 @@ class TestBuildTrees:
             _processed("b", "2", parent="1", name="wrong-parent"),
         ]
         trees = build_trees(spans)
-        # Two traces, each with one root.
         assert len(trees) == 2
         for t in trees:
             assert len(t.roots) == 1
@@ -506,7 +496,6 @@ class TestFormatText:
         out = format_tree(trees, style="text", use_color=False, max_depth=1)
         assert "[WORKFLOW] root" in out
         assert "child" in out
-        # grand is below the max_depth cutoff.
         assert "grand" not in out
 
     def test_filter_kind(self):
@@ -518,21 +507,18 @@ class TestFormatText:
         trees = build_trees(spans)
         out = format_tree(trees, style="text", use_color=False, filter_kind="llm")
         assert "llm-call" in out
-        # tool-call sits below the LLM but is excluded by filter; root renders too.
         assert "tool-call" not in out
 
     def test_no_color_when_disabled(self):
         spans = [_processed("a", "1", name="root", kind="workflow")]
         trees = build_trees(spans)
         out = format_tree(trees, style="text", use_color=False)
-        # No ANSI escape codes.
         assert "\033[" not in out
 
     def test_color_when_enabled(self):
         spans = [_processed("a", "1", name="root", kind="workflow")]
         trees = build_trees(spans)
         out = format_tree(trees, style="text", use_color=True)
-        # ANSI escape codes are present (the kind uses color code 33 for workflow).
         assert "\033[" in out
 
 


### PR DESCRIPTION
## What

Adds a `neatlogs-replay` CLI and a programmatic `neatlogs.replay` API for reading the JSONL span logs the SDK writes when `NEATLOGS_LOG_SPANS=true` or `NEATLOGS_LOG_RAW_SPANS=true` is set.

Closes #51.

## Why

When the span logger is on, one JSON object per span lands in `spans_optimized.log` (or `spans_raw_optimized.log` for the raw OTel export). Today the only way to read those is opening the file in an editor and reconstructing the parent/child tree by hand. The dojo's `dump.py` shows what a useful local tree printer looks like but is wired to in-memory spans only and not importable.

A `neatlogs-doctor` CLI (PR #20) already detects common instrumentation issues; this is the complementary view that shows what the trace actually looked like.

## Usage

```bash
neatlogs-replay spans_optimized.log
neatlogs-replay --format json --max-depth 3 spans_optimized.log
neatlogs-replay spans_a.log spans_b.log
```

Output (text mode, TTY):

```
=== trace 0fa6dc40...  (3 spans) ===
[WORKFLOW] playground  (798.8 ms)
  [LLM    ] openai.chat.completions.create  (793.9 ms)  [model=gpt-4o-mini]
  [CLIENT ] POST  (769.0 ms)
```

## How

- Auto-detect: sniffs the first object's keys to pick between the processed `span_data` shape and the raw `ReadableSpan.to_json()` shape. Same command works on either log without flags.
- Brace-balanced parser instead of line-splitting, so newlines inside string values are tolerated (the raw OTel export can produce them in event payloads).
- Orphans: spans whose `parent_id` points to a missing span get wrapped under a synthetic `_orphan` root with a stderr warning naming the missing parent. The trace still renders end-to-end instead of dropping the span silently.
- Pure stdlib, no new dependencies.
- Backward compatible: adds a new module, a new `[project.scripts]` entry point, and re-exports `replay` from `neatlogs` (the latter is a soft addition; `from neatlogs.replay import replay` also works).

## Files

- `neatlogs/replay.py` (new, 859 lines): parser, tree builder, text+JSON formatters, CLI.
- `tests/unit/test_replay.py` (new, 627 lines): 60 unit tests covering hex normalization, brace-balanced parsing, both span shapes, multi-file parsing, malformed-line counting, tree building (including orphans and cross-trace parents), text and JSON output, and the top-level `replay()` API.
- `pyproject.toml` (modified): adds a `[project.scripts]` block with `neatlogs-replay = "neatlogs.replay:_cli"`.

## Testing

```
pytest -q tests/unit/test_replay.py     # 60 passed
black --check neatlogs tests             # clean
isort --check-only neatlogs tests        # clean
```

Manually verified on `logs/spans_raw_optimized.log` (37 spans, 13 traces): the rendered tree matches the OTel hierarchy and the summary lines (per-trace kind breakdown) match `ReadableSpan.kind` after stripping the `SpanKind.` prefix the raw exporter writes.

## Risks

- The auto-detect between processed and raw shapes relies on JSON keys (`context.trace_id` vs top-level `trace_id`). Both shapes are stable, but if the SDK changes the on-disk format, this needs a matching update. Covered with unit tests.
- Orphans are surfaced as a stderr warning plus a synthetic root in the tree; users who ignore stderr will see a slightly different tree than what the OTel pipeline actually emitted. The warning names the missing parent span id so the cause is recoverable.