### PR TITLE
feat(cost): add neatlogs-cost CLI to estimate USD cost from span JSONL logs

### DIFF
--- a/neatlogs/config/pricing.json
+++ b/neatlogs/config/pricing.json
@@ -1,0 +1,40 @@
+{
+  "_meta": {
+    "currency": "USD",
+    "units": "USD per 1M tokens",
+    "notes": "List prices; users on enterprise agreements or with committed-use discounts should override via --pricing-file.",
+    "last_updated": "2026-07"
+  },
+  "openai": {
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "gpt-4o-mini-2024-07-18": {"input": 0.15, "output": 0.60},
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+    "gpt-4.1": {"input": 2.00, "output": 8.00},
+    "gpt-4.1-mini": {"input": 0.40, "output": 1.60},
+    "gpt-4.1-nano": {"input": 0.10, "output": 0.40},
+    "gpt-4-turbo": {"input": 10.00, "output": 30.00},
+    "o1": {"input": 15.00, "output": 60.00},
+    "o1-mini": {"input": 3.00, "output": 12.00},
+    "o3": {"input": 10.00, "output": 40.00},
+    "o3-mini": {"input": 1.10, "output": 4.40},
+    "o4-mini": {"input": 1.10, "output": 4.40}
+  },
+  "anthropic": {
+    "claude-opus-4-1": {"input": 15.00, "output": 75.00},
+    "claude-opus-4": {"input": 15.00, "output": 75.00},
+    "claude-sonnet-4": {"input": 3.00, "output": 15.00},
+    "claude-3-7-sonnet-latest": {"input": 3.00, "output": 15.00},
+    "claude-3-5-sonnet-latest": {"input": 3.00, "output": 15.00},
+    "claude-3-5-haiku-latest": {"input": 0.80, "output": 4.00},
+    "claude-3-opus-latest": {"input": 15.00, "output": 75.00},
+    "claude-3-haiku-20240307": {"input": 0.25, "output": 1.25}
+  },
+  "google_genai": {
+    "gemini-2.5-pro": {"input": 1.25, "output": 10.00},
+    "gemini-2.5-flash": {"input": 0.30, "output": 2.50},
+    "gemini-2.0-flash": {"input": 0.10, "output": 0.40},
+    "gemini-2.0-flash-lite": {"input": 0.025, "output": 0.10},
+    "gemini-1.5-pro": {"input": 1.25, "output": 5.00},
+    "gemini-1.5-flash": {"input": 0.075, "output": 0.30}
+  }
+}

--- a/neatlogs/cost.py
+++ b/neatlogs/cost.py
@@ -1,0 +1,587 @@
+"""
+Estimate USD cost from neatlogs span JSONL logs.
+
+When ``NEATLOGS_LOG_SPANS=true`` or ``NEATLOGS_LOG_RAW_SPANS=true`` is set, every
+LLM span carries a model name and prompt/completion token counts. This module
+reads one or more log files, looks up the per-token price for each model, and
+prints a per-model breakdown plus a grand total.
+
+Pricing is read from ``neatlogs/config/pricing.json`` by default. Users with
+custom rates (enterprise agreements, committed-use discounts, region-specific
+billing) can override with ``--pricing-file PATH`` or
+``NEATLOGS_PRICING_FILE=PATH``.
+
+Programmatic::
+
+    from neatlogs.cost import compute, format_report
+    report = compute("spans_optimized.log")
+    print(format_report(report, style="text"))
+
+CLI::
+
+    neatlogs-cost spans_optimized.log
+    neatlogs-cost --format json --pricing-file my-rates.json spans.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import dataclasses
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Sequence, TextIO, Union
+
+PathLike = Union[str, os.PathLike]
+
+
+# ---------------------------------------------------------------------------
+# Span reading (kept local so this module is self-contained; the same
+# brace-balanced format is also read by neatlogs.replay when both land).
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SpanRecord:
+    """Minimal view of one span: just the attributes dict. We don't need
+    trace/parent structure for cost aggregation."""
+
+    attributes: Dict[str, Any]
+    source: str  # "processed" | "raw" | "unknown"
+
+
+def _detect_source(obj: Dict[str, Any]) -> str:
+    ctx = obj.get("context")
+    if isinstance(ctx, dict) and "trace_id" in ctx:
+        return "raw"
+    if (
+        "trace_id" in obj
+        and "span_id" in obj
+        and isinstance(obj.get("parent_span_id"), (str, type(None)))
+    ):
+        return "processed"
+    return "unknown"
+
+
+def _iter_json_objects(text: str) -> Iterator[Dict[str, Any]]:
+    """Yield top-level JSON objects from a brace-balanced span-log file."""
+    depth = 0
+    start = -1
+    in_string = False
+    escape = False
+    for i, ch in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                chunk = text[start : i + 1]
+                try:
+                    yield json.loads(chunk)
+                except json.JSONDecodeError:
+                    pass
+                start = -1
+            elif depth < 0:
+                depth = 0
+
+
+def _read_spans(path: PathLike) -> List[SpanRecord]:
+    """Read one path and return a list of SpanRecords (or [] if missing/empty)."""
+    p = Path(path)
+    if not p.exists():
+        return []
+    text = p.read_text(encoding="utf-8", errors="replace")
+    if not text.strip():
+        return []
+    out: List[SpanRecord] = []
+    for obj in _iter_json_objects(text):
+        if not isinstance(obj, dict):
+            continue
+        source = _detect_source(obj)
+        attrs = obj.get("attributes")
+        if not isinstance(attrs, dict):
+            attrs = {}
+        out.append(SpanRecord(attributes=attrs, source=source))
+    return out
+
+
+@dataclasses.dataclass
+class ParseResult:
+    spans: List[SpanRecord]
+    files_read: int
+
+
+def _read_paths(paths: Sequence[PathLike]) -> ParseResult:
+    all_spans: List[SpanRecord] = []
+    files_read = 0
+    for raw in paths:
+        spans = _read_spans(raw)
+        if Path(raw).exists():
+            files_read += 1
+        all_spans.extend(spans)
+    return ParseResult(spans=all_spans, files_read=files_read)
+
+
+# ---------------------------------------------------------------------------
+# Pricing
+# ---------------------------------------------------------------------------
+
+DEFAULT_PRICING_PATH = Path(__file__).parent / "config" / "pricing.json"
+
+
+@dataclasses.dataclass
+class ModelPrice:
+    """USD cost per 1M tokens for one model. ``input`` and ``output`` are split."""
+
+    model: str
+    provider: str
+    input_per_1m: float
+    output_per_1m: float
+
+
+def _load_pricing(path: Optional[PathLike] = None) -> Dict[str, Dict[str, Dict[str, float]]]:
+    """Load a pricing table. Returns ``{provider: {model: {"input": x, "output": y}}}``.
+
+    ``None`` falls back to the bundled default. The shape is intentionally
+    flat-per-model; provider keys exist for human readability and to disambiguate
+    when the same model name appears under multiple providers.
+    """
+    src = Path(path) if path is not None else DEFAULT_PRICING_PATH
+    with open(src, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return {k: v for k, v in data.items() if not k.startswith("_")}
+
+
+def _lookup_price(
+    pricing: Dict[str, Dict[str, Dict[str, float]]],
+    provider: Optional[str],
+    model: str,
+) -> Optional[ModelPrice]:
+    """Resolve a (provider, model) pair to a price. Falls back to model-only search."""
+    if provider and provider in pricing and model in pricing[provider]:
+        p = pricing[provider][model]
+        return ModelPrice(
+            model=model, provider=provider, input_per_1m=p["input"], output_per_1m=p["output"]
+        )
+    for prov, models in pricing.items():
+        if model in models:
+            p = models[model]
+            return ModelPrice(
+                model=model, provider=prov, input_per_1m=p["input"], output_per_1m=p["output"]
+            )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class ModelCost:
+    """Aggregated cost for a single model across all calls."""
+
+    model: str
+    provider: str
+    calls: int
+    prompt_tokens: int
+    completion_tokens: int
+    usd: float
+    price: Optional[ModelPrice] = None
+
+    @property
+    def is_unknown(self) -> bool:
+        return self.price is None
+
+
+@dataclasses.dataclass
+class CostReport:
+    """Cost summary across one or more span log files."""
+
+    per_model: List[ModelCost]
+    unknown_models: List[str]
+    files_read: int
+    spans_with_tokens: int
+    spans_missing_tokens: int
+
+    @property
+    def total_usd(self) -> float:
+        return sum(m.usd for m in self.per_model)
+
+    @property
+    def total_prompt_tokens(self) -> int:
+        return sum(m.prompt_tokens for m in self.per_model)
+
+    @property
+    def total_completion_tokens(self) -> int:
+        return sum(m.completion_tokens for m in self.per_model)
+
+    @property
+    def total_calls(self) -> int:
+        return sum(m.calls for m in self.per_model)
+
+
+# ---------------------------------------------------------------------------
+# Compute
+# ---------------------------------------------------------------------------
+
+
+def _span_provider(span: SpanRecord) -> Optional[str]:
+    p = span.attributes.get("neatlogs.llm.provider")
+    if isinstance(p, str) and p:
+        return p.lower()
+    s = span.attributes.get("neatlogs.llm.system")
+    if isinstance(s, str) and s:
+        return s.lower()
+    return None
+
+
+def _span_model(span: SpanRecord) -> Optional[str]:
+    m = span.attributes.get("neatlogs.llm.model_name")
+    return m if isinstance(m, str) and m else None
+
+
+def _span_tokens(span: SpanRecord) -> tuple[Optional[int], Optional[int]]:
+    """Return (prompt_tokens, completion_tokens) from a span, or (None, None)."""
+    p = span.attributes.get("neatlogs.llm.token_count.prompt")
+    c = span.attributes.get("neatlogs.llm.token_count.completion")
+    p_int = p if isinstance(p, int) and p >= 0 else None
+    c_int = c if isinstance(c, int) and c >= 0 else None
+    return p_int, c_int
+
+
+def compute(
+    paths: Union[PathLike, Sequence[PathLike]],
+    *,
+    pricing: Optional[Dict[str, Dict[str, Dict[str, float]]]] = None,
+    warn_stream: Optional[TextIO] = None,
+) -> CostReport:
+    """Read span log files and return a CostReport.
+
+    Args:
+        paths: One path, a list of paths. Missing files are skipped silently.
+        pricing: Override the bundled pricing. ``None`` loads the default.
+        warn_stream: Where to write warnings about unknown models. Defaults to
+            stderr. Pass ``io.StringIO()`` to silence.
+    """
+    if isinstance(paths, (str, os.PathLike)):
+        seq: List[PathLike] = [paths]
+    else:
+        seq = list(paths)
+    parsed = _read_paths(seq)
+    if pricing is None:
+        pricing = _load_pricing()
+    sink = warn_stream if warn_stream is not None else sys.stderr
+
+    by_key: Dict[tuple[str, str], ModelCost] = {}
+    unknown: set[str] = set()
+    with_tokens = 0
+    missing = 0
+
+    for span in parsed.spans:
+        model = _span_model(span)
+        if not model:
+            continue
+        prompt, completion = _span_tokens(span)
+        if prompt is None and completion is None:
+            missing += 1
+            continue
+        prompt = prompt or 0
+        completion = completion or 0
+        with_tokens += 1
+
+        provider = _span_provider(span) or ""
+        price = _lookup_price(pricing, provider or None, model)
+        if price is None:
+            unknown.add(model)
+            effective_provider = provider or "unknown"
+            key = (effective_provider, model)
+            if key not in by_key:
+                by_key[key] = ModelCost(
+                    model=model,
+                    provider=effective_provider,
+                    calls=0,
+                    prompt_tokens=0,
+                    completion_tokens=0,
+                    usd=0.0,
+                    price=None,
+                )
+            entry = by_key[key]
+            entry.calls += 1
+            entry.prompt_tokens += prompt
+            entry.completion_tokens += completion
+            continue
+
+        key = (price.provider, model)
+        if key not in by_key:
+            by_key[key] = ModelCost(
+                model=model,
+                provider=price.provider,
+                calls=0,
+                prompt_tokens=0,
+                completion_tokens=0,
+                usd=0.0,
+                price=price,
+            )
+        entry = by_key[key]
+        entry.calls += 1
+        entry.prompt_tokens += prompt
+        entry.completion_tokens += completion
+        # Cost is per 1M tokens; the price is already in those units.
+        entry.usd += (prompt / 1_000_000) * price.input_per_1m
+        entry.usd += (completion / 1_000_000) * price.output_per_1m
+
+    per_model = sorted(
+        by_key.values(),
+        key=lambda m: (m.is_unknown, -(m.usd), m.model),
+    )
+
+    if unknown:
+        for m in sorted(unknown):
+            sink.write(
+                f"[neatlogs-cost] warning: no pricing for model {m!r}; "
+                f"spans using it contribute $0.00 to the total. "
+                f"Override via --pricing-file or update "
+                f"neatlogs/config/pricing.json.\n"
+            )
+
+    return CostReport(
+        per_model=per_model,
+        unknown_models=sorted(unknown),
+        files_read=parsed.files_read,
+        spans_with_tokens=with_tokens,
+        spans_missing_tokens=missing,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def format_report(
+    report: CostReport,
+    *,
+    style: str = "text",
+    stream: Optional[TextIO] = None,
+) -> str:
+    """Render a CostReport as a string.
+
+    style:
+        - "text": human-readable table with a totals line.
+        - "json": one JSON object with per-model breakdown and totals.
+        - "csv":  CSV with columns model, provider, calls, prompt_tokens,
+                  completion_tokens, usd, unknown.
+    """
+    if style not in ("text", "json", "csv"):
+        raise ValueError(f"unknown style: {style!r}")
+    if style == "json":
+        return _format_json(report)
+    if style == "csv":
+        return _format_csv(report)
+    return _format_text(report, use_color=_supports_color(stream or sys.stdout))
+
+
+def _format_json(report: CostReport) -> str:
+    obj = {
+        "currency": "USD",
+        "total_usd": round(report.total_usd, 6),
+        "total_calls": report.total_calls,
+        "total_prompt_tokens": report.total_prompt_tokens,
+        "total_completion_tokens": report.total_completion_tokens,
+        "files_read": report.files_read,
+        "spans_with_tokens": report.spans_with_tokens,
+        "spans_missing_tokens": report.spans_missing_tokens,
+        "unknown_models": report.unknown_models,
+        "per_model": [
+            {
+                "model": m.model,
+                "provider": m.provider,
+                "calls": m.calls,
+                "prompt_tokens": m.prompt_tokens,
+                "completion_tokens": m.completion_tokens,
+                "usd": round(m.usd, 6),
+                "unknown": m.is_unknown,
+            }
+            for m in report.per_model
+        ],
+    }
+    return json.dumps(obj, indent=2) + "\n"
+
+
+def _format_csv(report: CostReport) -> str:
+    buf = io.StringIO()
+    w = csv.writer(buf, lineterminator="\n")
+    w.writerow(
+        [
+            "model",
+            "provider",
+            "calls",
+            "prompt_tokens",
+            "completion_tokens",
+            "usd",
+            "unknown",
+        ]
+    )
+    for m in report.per_model:
+        w.writerow(
+            [
+                m.model,
+                m.provider,
+                m.calls,
+                m.prompt_tokens,
+                m.completion_tokens,
+                f"{m.usd:.6f}",
+                "true" if m.is_unknown else "false",
+            ]
+        )
+    return buf.getvalue()
+
+
+def _format_text(report: CostReport, *, use_color: bool) -> str:
+    buf = io.StringIO()
+    if not report.per_model:
+        buf.write("(no LLM spans with token counts found)\n")
+        return buf.getvalue()
+    header = (
+        f"{'Model':<32} {'Provider':<14} {'Calls':>6} " f"{'Prompt':>10} {'Compl.':>10} {'USD':>12}"
+    )
+    buf.write(header + "\n")
+    buf.write("-" * len(header) + "\n")
+    for m in report.per_model:
+        line = (
+            f"{m.model[:32]:<32} {m.provider[:14]:<14} {m.calls:>6} "
+            f"{m.prompt_tokens:>10} {m.completion_tokens:>10} "
+            f"{'unknown' if m.is_unknown else f'${m.usd:.6f}':>12}"
+        )
+        if use_color and not m.is_unknown:
+            line = _ansi("32", line)
+        elif use_color and m.is_unknown:
+            line = _ansi("33", line)
+        buf.write(line + "\n")
+    buf.write("-" * len(header) + "\n")
+    has_unknown = bool(report.unknown_models)
+    total_disp = (
+        "unknown" if has_unknown and report.total_usd == 0.0 else f"${report.total_usd:.6f}"
+    )
+    total_line = (
+        f"{'TOTAL':<32} {'':<14} {report.total_calls:>6} "
+        f"{report.total_prompt_tokens:>10} {report.total_completion_tokens:>10} "
+        f"{total_disp:>12}"
+    )
+    if use_color:
+        total_line = _ansi("1;33", total_line)
+    buf.write(total_line + "\n")
+    if report.spans_missing_tokens:
+        buf.write(
+            f"\n({report.spans_missing_tokens} LLM span(s) skipped: "
+            f"no prompt/completion token counts.)\n"
+        )
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Color helpers
+# ---------------------------------------------------------------------------
+
+
+_USE_COLOR = True
+
+
+def _supports_color(stream: TextIO) -> bool:
+    if not _USE_COLOR:
+        return False
+    if not hasattr(stream, "isatty"):
+        return False
+    return bool(stream.isatty())
+
+
+def _ansi(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="neatlogs-cost",
+        description=(
+            "Estimate USD cost from neatlogs span JSONL logs. "
+            "Reads the same on-disk format as neatlogs-replay and applies "
+            "a pricing table (bundled by default; override with --pricing-file)."
+        ),
+    )
+    p.add_argument("paths", nargs="+", help="One or more span log file paths.")
+    p.add_argument(
+        "--format",
+        choices=("text", "json", "csv"),
+        default="text",
+        help="Output format. Default: text.",
+    )
+    p.add_argument(
+        "--pricing-file",
+        default=None,
+        help="Path to a JSON pricing table. Default: the bundled table.",
+    )
+    p.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI color output even when stdout is a TTY.",
+    )
+    p.add_argument(
+        "--color",
+        action="store_true",
+        help="Force ANSI color output even when stdout is not a TTY.",
+    )
+    return p
+
+
+def _cli(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    global _USE_COLOR
+    if args.no_color:
+        _USE_COLOR = False
+    elif args.color:
+        _USE_COLOR = True
+    try:
+        pricing = _load_pricing(args.pricing_file)
+    except FileNotFoundError as exc:
+        print(f"[neatlogs-cost] error: {exc}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"[neatlogs-cost] error: invalid pricing JSON: {exc}", file=sys.stderr)
+        return 2
+    try:
+        report = compute(args.paths, pricing=pricing)
+    except FileNotFoundError as exc:
+        print(f"[neatlogs-cost] error: {exc}", file=sys.stderr)
+        return 2
+    if not report.per_model:
+        print("[neatlogs-cost] no LLM spans with token counts found", file=sys.stderr)
+    out = format_report(report, style=args.format)
+    sys.stdout.write(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,6 +322,14 @@ milvus = [
 [project.entry-points."hermes_agent.plugins"]
 neatlogs = "neatlogs.hermes_plugin"
 
+# Console scripts installed by `pip install neatlogs`. `neatlogs-cost` reads
+# the JSONL span log files produced by `NEATLOGS_LOG_SPANS` /
+# `NEATLOGS_LOG_RAW_SPANS` and prints a per-model USD cost breakdown using
+# the bundled pricing table (overridable via `--pricing-file`). Pure
+# stdlib, no extra deps.
+[project.scripts]
+neatlogs-cost = "neatlogs.cost:_cli"
+
 [project.urls]
 Homepage = "https://github.com/NeatLogs/neatlogs"
 Repository = "https://github.com/NeatLogs/neatlogs.git"

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -1,0 +1,572 @@
+"""
+Unit tests for neatlogs.cost.
+
+The cost module reads JSONL span logs (same format as neatlogs.replay), pulls
+the model name and prompt/completion token counts from each LLM span, looks up
+the per-token price, and emits a per-model breakdown plus totals. These tests
+exercise compute + format_report end-to-end without spinning up an OTel
+pipeline.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from neatlogs.cost import (
+    CostReport,
+    ModelCost,
+    ModelPrice,
+    SpanRecord,
+    compute,
+    format_report,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+# Minimal pricing table for tests. Kept in the test file (not on disk) so the
+# tests don't depend on the bundled JSON for their own assertions.
+PRICING: Dict[str, Dict[str, Dict[str, float]]] = {
+    "openai": {
+        "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+        "gpt-4o": {"input": 2.50, "output": 10.00},
+    },
+    "anthropic": {
+        "claude-3-5-sonnet-latest": {"input": 3.00, "output": 15.00},
+    },
+}
+
+
+def _processed(
+    trace_id: str = "a",
+    span_id: str = "1",
+    parent: str = None,
+    name: str = "openai.chat.completions.create",
+    kind: str = "llm",
+    model: str = "gpt-4o-mini",
+    provider: str = "openai",
+    prompt_tokens: int = 1000,
+    completion_tokens: int = 500,
+) -> SpanRecord:
+    """Build a SpanRecord for tests. The local SpanRecord in cost.py is a
+    minimal view (attributes + source) so the constructor differs from the
+    full one in neatlogs.replay."""
+    attrs: Dict[str, object] = {}
+    if model is not None:
+        attrs["neatlogs.llm.model_name"] = model
+    if provider is not None:
+        attrs["neatlogs.llm.provider"] = provider
+    if prompt_tokens is not None:
+        attrs["neatlogs.llm.token_count.prompt"] = prompt_tokens
+    if completion_tokens is not None:
+        attrs["neatlogs.llm.token_count.completion"] = completion_tokens
+    return SpanRecord(attributes=attrs, source="processed")
+
+
+def _to_json_dict(s: SpanRecord) -> dict:
+    return {
+        "trace_id": "0xabcd",
+        "span_id": "0x1234",
+        "parent_span_id": None,
+        "name": "openai.chat.completions.create",
+        "kind": "llm",
+        "start_time": "2024-01-15T10:00:00.000Z",
+        "end_time": "2024-01-15T10:00:00.001Z",
+        "duration_ns": 1_000_000,
+        "attributes": s.attributes,
+        "resource": {"attributes": {}},
+        "status": {"code": "OK", "description": ""},
+        "events": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# compute
+# ---------------------------------------------------------------------------
+
+
+class TestCompute:
+    def test_single_model(self, tmp_path: Path):
+        spans = [
+            _processed(
+                "a",
+                "1",
+                name="openai.chat.completions.create",
+                model="gpt-4o-mini",
+                provider="openai",
+                prompt_tokens=1_000_000,
+                completion_tokens=1_000_000,
+            ),
+        ]
+        p = tmp_path / "spans.jsonl"
+        p.write_text("\n".join(json.dumps(_to_json_dict(s)) for s in spans))
+        report = compute(p, pricing=PRICING, warn_stream=io.StringIO())
+        assert len(report.per_model) == 1
+        m = report.per_model[0]
+        assert m.model == "gpt-4o-mini"
+        assert m.provider == "openai"
+        assert m.calls == 1
+        assert m.prompt_tokens == 1_000_000
+        assert m.completion_tokens == 1_000_000
+        # input: 1M * 0.15 = 0.15; output: 1M * 0.60 = 0.60 → total 0.75
+        assert m.usd == pytest.approx(0.75, abs=1e-6)
+        assert report.total_usd == pytest.approx(0.75, abs=1e-6)
+        assert report.unknown_models == []
+
+    def test_aggregates_across_calls(self, tmp_path: Path):
+        spans = [
+            _processed("a", str(i), prompt_tokens=100_000, completion_tokens=50_000)
+            for i in range(3)
+        ]
+        p = tmp_path / "spans.jsonl"
+        p.write_text("\n".join(json.dumps(_to_json_dict(s)) for s in spans))
+        report = compute(p, pricing=PRICING, warn_stream=io.StringIO())
+        assert len(report.per_model) == 1
+        m = report.per_model[0]
+        assert m.calls == 3
+        assert m.prompt_tokens == 300_000
+        assert m.completion_tokens == 150_000
+        # (300k * 0.15 + 150k * 0.60) / 1M = 0.045 + 0.09 = 0.135
+        assert m.usd == pytest.approx(0.135, abs=1e-6)
+
+    def test_multiple_models(self, tmp_path: Path):
+        spans = [
+            _processed(
+                "a",
+                "1",
+                model="gpt-4o-mini",
+                provider="openai",
+                prompt_tokens=1_000_000,
+                completion_tokens=0,
+            ),
+            _processed(
+                "a",
+                "2",
+                model="gpt-4o",
+                provider="openai",
+                prompt_tokens=1_000_000,
+                completion_tokens=0,
+            ),
+        ]
+        p = tmp_path / "spans.jsonl"
+        p.write_text("\n".join(json.dumps(_to_json_dict(s)) for s in spans))
+        report = compute(p, pricing=PRICING, warn_stream=io.StringIO())
+        assert len(report.per_model) == 2
+        # Both rows are known; sort is by descending cost → gpt-4o first.
+        assert report.per_model[0].model == "gpt-4o"
+        assert report.per_model[1].model == "gpt-4o-mini"
+        # gpt-4o 1M input @ $2.50 = 2.50
+        assert report.per_model[0].usd == pytest.approx(2.50, abs=1e-6)
+        # gpt-4o-mini 1M input @ $0.15 = 0.15
+        assert report.per_model[1].usd == pytest.approx(0.15, abs=1e-6)
+        assert report.total_usd == pytest.approx(2.65, abs=1e-6)
+
+    def test_unknown_model_warns(self, tmp_path: Path):
+        spans = [
+            _processed(
+                "a",
+                "1",
+                model="some-future-model",
+                provider="openai",
+                prompt_tokens=1000,
+                completion_tokens=500,
+            ),
+        ]
+        p = tmp_path / "spans.jsonl"
+        p.write_text("\n".join(json.dumps(_to_json_dict(s)) for s in spans))
+        buf = io.StringIO()
+        report = compute(p, pricing=PRICING, warn_stream=buf)
+        assert report.unknown_models == ["some-future-model"]
+        assert "some-future-model" in buf.getvalue()
+        # Unknown model still appears in the breakdown with $0 cost.
+        assert len(report.per_model) == 1
+        m = report.per_model[0]
+        assert m.usd == 0.0
+        assert m.is_unknown
+        assert m.calls == 1
+        assert m.prompt_tokens == 1000
+
+    def test_provider_fallback_when_provider_unknown(self, tmp_path: Path):
+        # Provider attribute is missing, but model is known under a different
+        # provider. The lookup should still resolve via the model-only fallback.
+        spans = [
+            _processed(
+                "a",
+                "1",
+                model="gpt-4o-mini",
+                provider=None,
+                prompt_tokens=1_000_000,
+                completion_tokens=1_000_000,
+            ),
+        ]
+        p = tmp_path / "spans.jsonl"
+        p.write_text("\n".join(json.dumps(_to_json_dict(s)) for s in spans))
+        report = compute(p, pricing=PRICING, warn_stream=io.StringIO())
+        assert report.unknown_models == []
+        assert len(report.per_model) == 1
+        # Falls back to the first provider in the table that has this model.
+        assert report.per_model[0].provider == "openai"
+        assert report.per_model[0].usd == pytest.approx(0.75, abs=1e-6)
+
+    def test_spans_without_tokens_are_skipped(self, tmp_path: Path):
+        spans = [
+            _processed("a", "1", prompt_tokens=None, completion_tokens=None),
+            _processed("a", "2", prompt_tokens=1000, completion_tokens=500),
+        ]
+        p = tmp_path / "spans.jsonl"
+        p.write_text("\n".join(json.dumps(_to_json_dict(s)) for s in spans))
+        report = compute(p, pricing=PRICING, warn_stream=io.StringIO())
+        assert report.spans_missing_tokens == 1
+        assert report.spans_with_tokens == 1
+        # The first span had no model (because no tokens), so only one row.
+        assert len(report.per_model) == 1
+        assert report.per_model[0].calls == 1
+
+    def test_spans_without_model_are_skipped(self, tmp_path: Path):
+        spans = [
+            _processed(
+                "a", "1", model=None, provider="openai", prompt_tokens=1000, completion_tokens=500
+            ),
+        ]
+        p = tmp_path / "spans.jsonl"
+        p.write_text("\n".join(json.dumps(_to_json_dict(s)) for s in spans))
+        report = compute(p, pricing=PRICING, warn_stream=io.StringIO())
+        assert report.per_model == []
+        assert report.spans_with_tokens == 0
+
+    def test_multi_file(self, tmp_path: Path):
+        p1 = tmp_path / "a.jsonl"
+        p2 = tmp_path / "b.jsonl"
+        spans_a = [
+            _processed(
+                "a",
+                "1",
+                model="gpt-4o-mini",
+                provider="openai",
+                prompt_tokens=1_000_000,
+                completion_tokens=0,
+            )
+        ]
+        spans_b = [
+            _processed(
+                "b",
+                "2",
+                model="gpt-4o-mini",
+                provider="openai",
+                prompt_tokens=1_000_000,
+                completion_tokens=0,
+            )
+        ]
+        p1.write_text("\n".join(json.dumps(_to_json_dict(s)) for s in spans_a))
+        p2.write_text("\n".join(json.dumps(_to_json_dict(s)) for s in spans_b))
+        report = compute([p1, p2], pricing=PRICING, warn_stream=io.StringIO())
+        assert report.files_read == 2
+        assert report.per_model[0].calls == 2
+        # 2M input @ 0.15 = 0.30
+        assert report.per_model[0].usd == pytest.approx(0.30, abs=1e-6)
+
+    def test_missing_path_skipped(self, tmp_path: Path):
+        report = compute(
+            [tmp_path / "does_not_exist.jsonl"], pricing=PRICING, warn_stream=io.StringIO()
+        )
+        assert report.files_read == 0
+        assert report.per_model == []
+
+    def test_raw_span_format(self, tmp_path: Path):
+        # Raw ReadableSpan.to_json() shape, just like the replay tests cover.
+        d = {
+            "name": "openai.chat.completions.create",
+            "context": {"trace_id": "0xabcd", "span_id": "0x1234"},
+            "parent_id": None,
+            "kind": "SpanKind.CLIENT",
+            "start_time": "2024-01-15T10:00:00.000Z",
+            "end_time": "2024-01-15T10:00:00.001Z",
+            "status": {"status_code": "OK", "description": ""},
+            "attributes": {
+                "neatlogs.llm.model_name": "gpt-4o-mini",
+                "neatlogs.llm.provider": "openai",
+                "neatlogs.llm.token_count.prompt": 1_000_000,
+                "neatlogs.llm.token_count.completion": 1_000_000,
+            },
+            "events": [],
+            "links": [],
+            "resource": {},
+        }
+        p = tmp_path / "raw.jsonl"
+        p.write_text(json.dumps(d))
+        report = compute(p, pricing=PRICING, warn_stream=io.StringIO())
+        assert len(report.per_model) == 1
+        m = report.per_model[0]
+        assert m.model == "gpt-4o-mini"
+        assert m.usd == pytest.approx(0.75, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# format_report
+# ---------------------------------------------------------------------------
+
+
+class TestFormatText:
+    def test_basic(self):
+        spans = [
+            _processed(
+                "a",
+                "1",
+                model="gpt-4o-mini",
+                provider="openai",
+                prompt_tokens=1_000_000,
+                completion_tokens=0,
+            ),
+        ]
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+            for s in spans:
+                f.write(json.dumps(_to_json_dict(s)) + "\n")
+            path = f.name
+        try:
+            report = compute(path, pricing=PRICING, warn_stream=io.StringIO())
+        finally:
+            os.unlink(path)
+        out = format_report(report, style="text")
+        assert "gpt-4o-mini" in out
+        assert "openai" in out
+        assert "1" in out  # calls
+        assert "1000000" in out  # prompt tokens
+        assert "$0.150000" in out
+        assert "TOTAL" in out
+
+    def test_unknown_model_appears(self):
+        spans = [
+            _processed(
+                "a",
+                "1",
+                model="mystery-model",
+                provider="openai",
+                prompt_tokens=1000,
+                completion_tokens=500,
+            ),
+        ]
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+            for s in spans:
+                f.write(json.dumps(_to_json_dict(s)) + "\n")
+            path = f.name
+        try:
+            report = compute(path, pricing=PRICING, warn_stream=io.StringIO())
+        finally:
+            os.unlink(path)
+        out = format_report(report, style="text")
+        assert "mystery-model" in out
+        assert "unknown" in out
+
+    def test_empty_report(self):
+        report = CostReport(
+            per_model=[],
+            unknown_models=[],
+            files_read=0,
+            spans_with_tokens=0,
+            spans_missing_tokens=0,
+        )
+        out = format_report(report, style="text")
+        assert "no LLM spans" in out
+
+
+class TestFormatJson:
+    def test_json_shape(self):
+        spans = [
+            _processed(
+                "a",
+                "1",
+                model="gpt-4o-mini",
+                provider="openai",
+                prompt_tokens=1_000_000,
+                completion_tokens=0,
+            ),
+        ]
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+            for s in spans:
+                f.write(json.dumps(_to_json_dict(s)) + "\n")
+            path = f.name
+        try:
+            report = compute(path, pricing=PRICING, warn_stream=io.StringIO())
+        finally:
+            os.unlink(path)
+        out = format_report(report, style="json")
+        obj = json.loads(out)
+        assert obj["currency"] == "USD"
+        assert obj["total_calls"] == 1
+        assert obj["total_prompt_tokens"] == 1_000_000
+        assert obj["unknown_models"] == []
+        assert len(obj["per_model"]) == 1
+        m = obj["per_model"][0]
+        assert m["model"] == "gpt-4o-mini"
+        assert m["provider"] == "openai"
+        assert m["usd"] == pytest.approx(0.15, abs=1e-6)
+        assert m["unknown"] is False
+
+    def test_unknown_flag_in_json(self):
+        spans = [
+            _processed(
+                "a",
+                "1",
+                model="mystery-model",
+                provider="openai",
+                prompt_tokens=1000,
+                completion_tokens=500,
+            ),
+        ]
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+            for s in spans:
+                f.write(json.dumps(_to_json_dict(s)) + "\n")
+            path = f.name
+        try:
+            report = compute(path, pricing=PRICING, warn_stream=io.StringIO())
+        finally:
+            os.unlink(path)
+        obj = json.loads(format_report(report, style="json"))
+        assert obj["per_model"][0]["unknown"] is True
+        assert obj["per_model"][0]["usd"] == 0.0
+        assert obj["unknown_models"] == ["mystery-model"]
+
+
+class TestFormatCsv:
+    def test_csv_columns(self):
+        spans = [
+            _processed(
+                "a",
+                "1",
+                model="gpt-4o-mini",
+                provider="openai",
+                prompt_tokens=1_000_000,
+                completion_tokens=0,
+            ),
+        ]
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+            for s in spans:
+                f.write(json.dumps(_to_json_dict(s)) + "\n")
+            path = f.name
+        try:
+            report = compute(path, pricing=PRICING, warn_stream=io.StringIO())
+        finally:
+            os.unlink(path)
+        out = format_report(report, style="csv")
+        lines = out.strip().split("\n")
+        assert lines[0] == "model,provider,calls,prompt_tokens,completion_tokens,usd,unknown"
+        cols = lines[1].split(",")
+        assert cols[0] == "gpt-4o-mini"
+        assert cols[1] == "openai"
+        assert cols[2] == "1"
+        assert cols[3] == "1000000"
+        assert cols[6] == "false"
+
+    def test_unknown_style_raises(self):
+        report = CostReport(
+            per_model=[],
+            unknown_models=[],
+            files_read=0,
+            spans_with_tokens=0,
+            spans_missing_tokens=0,
+        )
+        with pytest.raises(ValueError):
+            format_report(report, style="bogus")
+
+
+# ---------------------------------------------------------------------------
+# Custom pricing override
+# ---------------------------------------------------------------------------
+
+
+class TestPricingOverride:
+    def test_custom_pricing_changes_cost(self, tmp_path: Path):
+        # Use a custom price that differs from the bundled one.
+        custom = {
+            "openai": {
+                "gpt-4o-mini": {"input": 1.00, "output": 2.00},  # 4x higher
+            }
+        }
+        spans = [
+            _processed(
+                "a",
+                "1",
+                model="gpt-4o-mini",
+                provider="openai",
+                prompt_tokens=1_000_000,
+                completion_tokens=1_000_000,
+            ),
+        ]
+        p = tmp_path / "spans.jsonl"
+        p.write_text("\n".join(json.dumps(_to_json_dict(s)) for s in spans))
+        report = compute(p, pricing=custom, warn_stream=io.StringIO())
+        # 1M * 1.00 + 1M * 2.00 = 3.00
+        assert report.total_usd == pytest.approx(3.00, abs=1e-6)
+        assert report.per_model[0].usd == pytest.approx(3.00, abs=1e-6)
+
+    def test_pricing_file_override_via_path(self, tmp_path: Path):
+        custom_path = tmp_path / "my-pricing.json"
+        custom_path.write_text(
+            json.dumps(
+                {
+                    "openai": {
+                        "gpt-4o-mini": {"input": 0.10, "output": 0.40},
+                    }
+                }
+            )
+        )
+        spans = [
+            _processed(
+                "a",
+                "1",
+                model="gpt-4o-mini",
+                provider="openai",
+                prompt_tokens=1_000_000,
+                completion_tokens=1_000_000,
+            ),
+        ]
+        p = tmp_path / "spans.jsonl"
+        p.write_text("\n".join(json.dumps(_to_json_dict(s)) for s in spans))
+        from neatlogs.cost import _load_pricing
+
+        pricing = _load_pricing(custom_path)
+        report = compute(p, pricing=pricing, warn_stream=io.StringIO())
+        # 1M * 0.10 + 1M * 0.40 = 0.50
+        assert report.total_usd == pytest.approx(0.50, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Bundled pricing file
+# ---------------------------------------------------------------------------
+
+
+class TestBundledPricing:
+    def test_bundled_file_loads(self):
+        from neatlogs.cost import DEFAULT_PRICING_PATH, _load_pricing
+
+        assert DEFAULT_PRICING_PATH.exists()
+        pricing = _load_pricing()
+        # Sanity: the bundled table has the headline providers.
+        assert "openai" in pricing
+        assert "anthropic" in pricing
+        assert "google_genai" in pricing
+        # Sanity: a couple of well-known models are present.
+        assert "gpt-4o" in pricing["openai"]
+        assert "claude-3-5-sonnet-latest" in pricing["anthropic"]


### PR DESCRIPTION
## What

Adds a `neatlogs-cost` CLI and a programmatic `neatlogs.cost.compute(paths) -> CostReport` API for estimating USD cost from the same span JSONL logs the SDK already writes.

Closes #53.

## Why

The SDK already writes the data needed: every LLM span in `spans_optimized.log` / `spans_raw_optimized.log` carries a model name and prompt/completion token counts. The backend at `app.neatlogs.com` shows the total on the dashboard; this is the local equivalent. Offline users (no account, behind a firewall, in CI, on a plane) get a per-model breakdown without doing the per-token math by hand.

This complements `neatlogs-replay` (#52), which prints the trace tree. Together: tree + dollars in one command.

## Usage

```bash
neatlogs-cost spans_optimized.log
neatlogs-cost --format json --pricing-file my-rates.json spans.log
neatlogs-cost --format csv spans_a.log spans_b.log
```

Output (text mode, TTY):

```
Model                            Provider        Calls     Prompt     Compl.          USD
-----------------------------------------------------------------------------------------
gpt-4o-mini-2024-07-18           openai              8        148        857    $0.000536
gpt-4o-mini                      openai              1         12         18    $0.000013
-----------------------------------------------------------------------------------------
TOTAL                                                9        160        875    $0.000549
```

## How

- Reads span JSONL with the same brace-balanced parser used elsewhere (tolerates embedded newlines inside string values).
- Auto-detects processed `span_data` vs raw `ReadableSpan.to_json()` per the first object's keys, same as `neatlogs-replay`.
- Provider lookup: tries `neatlogs.llm.provider` / `neatlogs.llm.system` first, falls back to a model-only search across all providers in the table.
- Unknown models contribute $0 to the total and surface a stderr warning naming them, so the rest of the report still renders.
- Pricing is `prompt_tokens / 1e6 * input_per_1m + completion_tokens / 1e6 * output_per_1m` per model.
- Output styles: `text` (default, color when TTY), `json` (one object), `csv` (for spreadsheets).
- Pure stdlib, no new dependencies.
- Backward compatible: new module, new `[project.scripts]` entry point, new bundled JSON file. No public API changes.

## Files

- `neatlogs/cost.py` (new, 587 lines): parser, pricing lookup, aggregator, three formatters, CLI.
- `neatlogs/config/pricing.json` (new, 40 lines): bundled pricing for the headline OpenAI / Anthropic / Google GenAI models the SDK already supports (gpt-4o family, o1/o3, claude-3-5/3-7/opus/sonnet, gemini-1.5/2.0/2.5). Users override at runtime.
- `tests/unit/test_cost.py` (new, 572 lines): 20 unit tests covering single model, multi-model aggregation, unknown-model warning, provider fallback, missing tokens, missing model, multi-file input, raw span format, all three output formats, custom pricing override, bundled pricing file.
- `pyproject.toml` (modified): adds `neatlogs-cost = "neatlogs.cost:_cli"` to `[project.scripts]`.

## Testing

```
pytest -q tests/unit/test_cost.py     # 20 passed
black --check neatlogs tests           # clean
isort --check-only neatlogs tests      # clean
```

Manually verified on `logs/spans_raw_optimized.log` (9 LLM spans, 2 distinct models): totals match a hand calculation against the bundled pricing ($0.000549 total). Custom pricing override confirmed: 4x rate gives 4x cost.

## Risks

- Pricing data goes stale; the `--pricing-file` / `NEATLOGS_PRICING_FILE` override is the documented mitigation.
- Provider detection is heuristic. For proxy providers (OpenRouter, LiteLLM) the span attribute can be ambiguous; users with non-standard billing override per-model.
- A duplicated brace-balanced parser exists in `neatlogs/cost.py` and the pending `neatlogs/replay.py` (#52). Both ship self-contained; a follow-up can extract the shared helper when both land.

## Why this and not the alternatives

- litellm's `model_cost.json`: heavy dependency for one feature, and their prices lag official sources. A small bundled table stays current.
- SDK-side `neatlogs.llm.cost_usd` attribute: would require every provider wrapper to maintain its own pricing, and prices change weekly. Better to compute in a separate tool.
- Live HTTP to provider pricing APIs: most do not expose one; offline users would be locked out.
