### PR TITLE
feat(cost): add neatlogs-compare CLI for what-if model cost comparison on span JSONL logs

### DIFF
--- a/neatlogs/config/pricing.json
+++ b/neatlogs/config/pricing.json
@@ -1,0 +1,336 @@
+{
+  "_meta": {
+    "currency": "USD",
+    "units": "per_1m_tokens",
+    "schema_version": "1.0",
+    "notes": "Token prices are USD per 1M tokens. Model keys are `provider/model_name` (Langfuse / LiteLLM convention) to avoid namespace collisions across providers. Capabilities are best-effort. Override via --pricing-file or NEATLOGS_PRICING_FILE.",
+    "last_updated": "2026-07"
+  },
+  "models": {
+    "openai/gpt-5": {
+      "provider": "openai",
+      "input_per_1m": 1.25,
+      "output_per_1m": 10.00,
+      "supports_vision": true,
+      "supports_tools": true,
+      "supports_reasoning": true,
+      "context_window": 400000
+    },
+    "openai/gpt-5-mini": {
+      "provider": "openai",
+      "input_per_1m": 0.25,
+      "output_per_1m": 2.00,
+      "supports_vision": true,
+      "supports_tools": true,
+      "supports_reasoning": true,
+      "context_window": 400000
+    },
+    "openai/gpt-5-nano": {
+      "provider": "openai",
+      "input_per_1m": 0.05,
+      "output_per_1m": 0.40,
+      "supports_vision": true,
+      "supports_tools": true,
+      "supports_reasoning": true,
+      "context_window": 400000
+    },
+    "openai/gpt-4.1": {
+      "provider": "openai",
+      "input_per_1m": 2.00,
+      "output_per_1m": 8.00,
+      "cache_read_per_1m": 0.50,
+      "supports_prompt_cache": true,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 1000000
+    },
+    "openai/gpt-4.1-mini": {
+      "provider": "openai",
+      "input_per_1m": 0.40,
+      "output_per_1m": 1.60,
+      "cache_read_per_1m": 0.10,
+      "supports_prompt_cache": true,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 1000000
+    },
+    "openai/gpt-4.1-nano": {
+      "provider": "openai",
+      "input_per_1m": 0.10,
+      "output_per_1m": 0.40,
+      "cache_read_per_1m": 0.025,
+      "supports_prompt_cache": true,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 1000000
+    },
+    "openai/gpt-4o": {
+      "provider": "openai",
+      "input_per_1m": 2.50,
+      "output_per_1m": 10.00,
+      "cache_read_per_1m": 1.25,
+      "supports_prompt_cache": true,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 128000
+    },
+    "openai/gpt-4o-mini": {
+      "provider": "openai",
+      "input_per_1m": 0.15,
+      "output_per_1m": 0.60,
+      "cache_read_per_1m": 0.075,
+      "supports_prompt_cache": true,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 128000
+    },
+    "openai/gpt-4o-mini-2024-07-18": {
+      "provider": "openai",
+      "input_per_1m": 0.15,
+      "output_per_1m": 0.60,
+      "cache_read_per_1m": 0.075,
+      "supports_prompt_cache": true,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 128000
+    },
+    "openai/o1": {
+      "provider": "openai",
+      "input_per_1m": 15.00,
+      "output_per_1m": 60.00,
+      "reasoning_output_per_1m": 60.00,
+      "cache_read_per_1m": 7.50,
+      "supports_prompt_cache": true,
+      "supports_reasoning": true,
+      "supports_tools": true,
+      "context_window": 200000
+    },
+    "openai/o1-mini": {
+      "provider": "openai",
+      "input_per_1m": 3.00,
+      "output_per_1m": 12.00,
+      "reasoning_output_per_1m": 12.00,
+      "cache_read_per_1m": 1.50,
+      "supports_prompt_cache": true,
+      "supports_reasoning": true,
+      "supports_tools": true,
+      "context_window": 128000
+    },
+    "openai/o3": {
+      "provider": "openai",
+      "input_per_1m": 10.00,
+      "output_per_1m": 40.00,
+      "reasoning_output_per_1m": 40.00,
+      "cache_read_per_1m": 5.00,
+      "supports_prompt_cache": true,
+      "supports_reasoning": true,
+      "supports_tools": true,
+      "context_window": 200000
+    },
+    "openai/o3-mini": {
+      "provider": "openai",
+      "input_per_1m": 1.10,
+      "output_per_1m": 4.40,
+      "reasoning_output_per_1m": 4.40,
+      "cache_read_per_1m": 0.55,
+      "supports_prompt_cache": true,
+      "supports_reasoning": true,
+      "supports_tools": true,
+      "context_window": 200000
+    },
+    "openai/o4-mini": {
+      "provider": "openai",
+      "input_per_1m": 1.10,
+      "output_per_1m": 4.40,
+      "reasoning_output_per_1m": 4.40,
+      "cache_read_per_1m": 0.55,
+      "supports_prompt_cache": true,
+      "supports_reasoning": true,
+      "supports_tools": true,
+      "context_window": 200000
+    },
+    "openai/text-embedding-3-small": {
+      "provider": "openai",
+      "input_per_1m": 0.02,
+      "output_per_1m": 0.0,
+      "context_window": 8191,
+      "mode": "embedding"
+    },
+    "openai/text-embedding-3-large": {
+      "provider": "openai",
+      "input_per_1m": 0.13,
+      "output_per_1m": 0.0,
+      "context_window": 8191,
+      "mode": "embedding"
+    },
+    "anthropic/claude-opus-4-1": {
+      "provider": "anthropic",
+      "input_per_1m": 15.00,
+      "output_per_1m": 75.00,
+      "cache_write_per_1m": 18.75,
+      "cache_read_per_1m": 1.50,
+      "supports_prompt_cache": true,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 200000
+    },
+    "anthropic/claude-opus-4": {
+      "provider": "anthropic",
+      "input_per_1m": 15.00,
+      "output_per_1m": 75.00,
+      "cache_write_per_1m": 18.75,
+      "cache_read_per_1m": 1.50,
+      "supports_prompt_cache": true,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 200000
+    },
+    "anthropic/claude-sonnet-4": {
+      "provider": "anthropic",
+      "input_per_1m": 3.00,
+      "output_per_1m": 15.00,
+      "cache_write_per_1m": 3.75,
+      "cache_read_per_1m": 0.30,
+      "supports_prompt_cache": true,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 200000,
+      "tiers": {
+        "input_above_200k_per_1m": 6.00,
+        "output_above_200k_per_1m": 22.50
+      }
+    },
+    "anthropic/claude-3-7-sonnet-latest": {
+      "provider": "anthropic",
+      "input_per_1m": 3.00,
+      "output_per_1m": 15.00,
+      "cache_write_per_1m": 3.75,
+      "cache_read_per_1m": 0.30,
+      "supports_prompt_cache": true,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 200000,
+      "tiers": {
+        "input_above_200k_per_1m": 6.00,
+        "output_above_200k_per_1m": 22.50
+      }
+    },
+    "anthropic/claude-3-5-sonnet-latest": {
+      "provider": "anthropic",
+      "input_per_1m": 3.00,
+      "output_per_1m": 15.00,
+      "cache_write_per_1m": 3.75,
+      "cache_read_per_1m": 0.30,
+      "supports_prompt_cache": true,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 200000,
+      "tiers": {
+        "input_above_200k_per_1m": 6.00,
+        "output_above_200k_per_1m": 22.50
+      }
+    },
+    "anthropic/claude-3-5-haiku-latest": {
+      "provider": "anthropic",
+      "input_per_1m": 0.80,
+      "output_per_1m": 4.00,
+      "cache_write_per_1m": 1.00,
+      "cache_read_per_1m": 0.08,
+      "supports_prompt_cache": true,
+      "supports_vision": false,
+      "supports_tools": true,
+      "context_window": 200000
+    },
+    "anthropic/claude-3-haiku-20240307": {
+      "provider": "anthropic",
+      "input_per_1m": 0.25,
+      "output_per_1m": 1.25,
+      "cache_write_per_1m": 0.30,
+      "cache_read_per_1m": 0.03,
+      "supports_prompt_cache": true,
+      "supports_tools": true,
+      "context_window": 200000
+    },
+    "google_genai/gemini-2.5-pro": {
+      "provider": "google_genai",
+      "input_per_1m": 1.25,
+      "output_per_1m": 10.00,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 1000000,
+      "tiers": {
+        "input_above_200k_per_1m": 2.50,
+        "output_above_200k_per_1m": 15.00
+      }
+    },
+    "google_genai/gemini-2.5-flash": {
+      "provider": "google_genai",
+      "input_per_1m": 0.30,
+      "output_per_1m": 2.50,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 1000000
+    },
+    "google_genai/gemini-2.0-flash": {
+      "provider": "google_genai",
+      "input_per_1m": 0.10,
+      "output_per_1m": 0.40,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 1000000
+    },
+    "google_genai/gemini-1.5-pro": {
+      "provider": "google_genai",
+      "input_per_1m": 1.25,
+      "output_per_1m": 5.00,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 2000000
+    },
+    "google_genai/gemini-1.5-flash": {
+      "provider": "google_genai",
+      "input_per_1m": 0.075,
+      "output_per_1m": 0.30,
+      "supports_vision": true,
+      "supports_tools": true,
+      "context_window": 1000000
+    },
+    "deepseek/deepseek-chat": {
+      "provider": "deepseek",
+      "input_per_1m": 0.27,
+      "output_per_1m": 1.10,
+      "cache_read_per_1m": 0.07,
+      "supports_prompt_cache": true,
+      "supports_tools": true,
+      "context_window": 128000
+    },
+    "deepseek/deepseek-reasoner": {
+      "provider": "deepseek",
+      "input_per_1m": 0.55,
+      "output_per_1m": 2.19,
+      "supports_reasoning": true,
+      "context_window": 128000
+    },
+    "groq/llama-3.1-70b-versatile": {
+      "provider": "groq",
+      "input_per_1m": 0.59,
+      "output_per_1m": 0.79,
+      "supports_tools": true,
+      "context_window": 128000
+    },
+    "groq/llama-3.1-8b-instant": {
+      "provider": "groq",
+      "input_per_1m": 0.05,
+      "output_per_1m": 0.08,
+      "supports_tools": true,
+      "context_window": 128000
+    },
+    "groq/llama-3.3-70b-versatile": {
+      "provider": "groq",
+      "input_per_1m": 0.59,
+      "output_per_1m": 0.79,
+      "supports_tools": true,
+      "context_window": 128000
+    }
+  }
+}

--- a/neatlogs/cost.py
+++ b/neatlogs/cost.py
@@ -1,0 +1,1216 @@
+"""
+LLM cost comparison engine for neatlogs span JSONL logs.
+
+This module powers two related things:
+
+1. **Cost comparison** — given a span log written by ``NEATLOGS_LOG_SPANS=true`` /
+   ``NEATLOGS_LOG_RAW_SPANS=true`` and a list of candidate models, compute what
+   the same workload would have cost on each. The point is to answer the
+   "should I switch models?" question from local data, without making new API
+   calls or signing up for a SaaS dashboard.
+
+2. **Cost forecasting** — given expected call volume and a model choice,
+   project monthly / annual cost. Useful for budgeting before running a batch
+   evaluation.
+
+Pricing data comes from ``neatlogs/config/pricing.json`` (a curated catalog
+covering the major OpenAI / Anthropic / Google GenAI / DeepSeek / Groq
+models the SDK already supports). Users with custom rates override via
+``--pricing-file`` or ``NEATLOGS_PRICING_FILE``.
+
+The bundled pricing schema is intentionally simple and explicit:
+
+* Per-token prices are USD per 1M tokens (matches the industry convention).
+* Model keys are ``provider/model_name`` to avoid namespace collisions.
+* Tiered / long-context pricing is a ``tiers`` sub-dict.
+* Cache pricing is split into ``cache_read_per_1m`` and ``cache_write_per_1m``
+  (Anthropic, OpenAI, DeepSeek).
+* Reasoning tokens have a separate ``reasoning_output_per_1m`` rate (o-series,
+  DeepSeek-R1).
+* Capability flags (``supports_vision``, ``supports_tools``, ``supports_reasoning``,
+  ``supports_prompt_cache``) drive the comparison report's "missing capability"
+  warnings.
+
+Programmatic::
+
+    from neatlogs.cost import compare, forecast, format_comparison
+    report = compare("spans.log", models=["gpt-4o-mini", "gpt-4o", "claude-3-5-haiku-latest"])
+    print(format_comparison(report, style="text"))
+
+CLI::
+
+    neatlogs-compare spans.log --models gpt-4o-mini,gpt-4o,claude-3-5-haiku-latest
+    neatlogs-compare spans.log --models gpt-4o-mini --current gpt-4o-mini
+    neatlogs-compare spans.log --forecast --monthly-calls 50000 --avg-prompt 2000 --avg-completion 500
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import dataclasses
+import io
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, TextIO, Tuple, Union
+
+PathLike = Union[str, os.PathLike]
+
+
+# ---------------------------------------------------------------------------
+# Span reading
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SpanUsage:
+    """One LLM span's token usage, extracted from span attributes.
+
+    Missing fields are ``None`` rather than 0 so the cost engine can decide
+    whether to skip the span or treat the field as 0.
+    """
+
+    span_id: str
+    trace_id: str
+    model: str
+    provider: Optional[str]
+    prompt_tokens: Optional[int]
+    completion_tokens: Optional[int]
+    cache_creation_tokens: Optional[int]
+    cache_read_tokens: Optional[int]
+    reasoning_tokens: Optional[int]
+
+    @property
+    def has_tokens(self) -> bool:
+        # A span "has tokens" iff at least one usage field is a positive
+        # integer. All-zero or all-missing means the span ran but reported
+        # no usage (e.g. a failed call, or a span kind that isn't billed
+        # by tokens). Either way, cost for it is $0 and there's no point
+        # counting it as a real LLM call.
+        return any(
+            t is not None and t > 0
+            for t in (
+                self.prompt_tokens,
+                self.completion_tokens,
+                self.cache_creation_tokens,
+                self.cache_read_tokens,
+                self.reasoning_tokens,
+            )
+        )
+
+    @property
+    def uses_prompt_cache(self) -> bool:
+        return (self.cache_creation_tokens or 0) > 0 or (self.cache_read_tokens or 0) > 0
+
+    @property
+    def uses_reasoning(self) -> bool:
+        return (self.reasoning_tokens or 0) > 0
+
+
+_HEX_RE = re.compile(r"^[0-9a-fA-F]+$")
+
+
+def _int_attr(attrs: Dict[str, Any], *keys: str) -> Optional[int]:
+    """First key that exists and is a non-negative int wins. Used to tolerate
+    the various casing / naming conventions the SDK and providers use."""
+    for k in keys:
+        v = attrs.get(k)
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, int) and v >= 0:
+            return v
+        if isinstance(v, float) and v.is_integer() and v >= 0:
+            return int(v)
+    return None
+
+
+def _extract_usage(obj: Dict[str, Any]) -> SpanUsage:
+    attrs = obj.get("attributes") or {}
+    if not isinstance(attrs, dict):
+        attrs = {}
+    # Model: prefer neatlogs.llm.model_name, fall back to gen_ai.response.model.
+    model = (
+        attrs.get("neatlogs.llm.model_name")
+        or attrs.get("gen_ai.response.model")
+        or attrs.get("gen_ai.request.model")
+        or ""
+    )
+    provider = (
+        attrs.get("neatlogs.llm.provider")
+        or attrs.get("neatlogs.llm.system")
+        or attrs.get("gen_ai.system")
+    )
+    if isinstance(provider, str):
+        provider = provider.lower() or None
+    else:
+        provider = None
+    return SpanUsage(
+        span_id=str(obj.get("span_id") or obj.get("context", {}).get("span_id") or ""),
+        trace_id=str(obj.get("trace_id") or obj.get("context", {}).get("trace_id") or ""),
+        model=str(model),
+        provider=provider,
+        prompt_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.prompt",
+            "gen_ai.usage.input_tokens",
+            "gen_ai.usage.prompt_tokens",
+        ),
+        completion_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.completion",
+            "gen_ai.usage.output_tokens",
+            "gen_ai.usage.completion_tokens",
+        ),
+        cache_creation_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.cache_creation",
+            "gen_ai.usage.cache_creation_input_tokens",
+        ),
+        cache_read_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.cache_read",
+            "gen_ai.usage.cache_read_input_tokens",
+        ),
+        reasoning_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.reasoning",
+            "gen_ai.usage.reasoning_tokens",
+        ),
+    )
+
+
+def _detect_source(obj: Dict[str, Any]) -> str:
+    if isinstance(obj.get("context"), dict) and "trace_id" in obj.get("context", {}):
+        return "raw"
+    if (
+        "trace_id" in obj
+        and "span_id" in obj
+        and isinstance(obj.get("parent_span_id"), (str, type(None)))
+    ):
+        return "processed"
+    return "unknown"
+
+
+def _iter_json_objects(text: str) -> Iterator[Dict[str, Any]]:
+    """Brace-balanced parser. Tolerates newlines inside string values."""
+    depth = 0
+    start = -1
+    in_string = False
+    escape = False
+    for i, ch in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                try:
+                    yield json.loads(text[start : i + 1])
+                except json.JSONDecodeError:
+                    pass
+                start = -1
+            elif depth < 0:
+                depth = 0
+
+
+def _read_usages(path: PathLike) -> Tuple[List[SpanUsage], int]:
+    """Read one path; return (usages, files_read_delta). Missing → ([], 0).
+
+    All parsed objects that look like span dicts become a ``SpanUsage``,
+    including ones with no model or no token counts. The caller (compare)
+    is responsible for deciding which to skip.
+    """
+    p = Path(path)
+    if not p.exists():
+        return [], 0
+    text = p.read_text(encoding="utf-8", errors="replace")
+    if not text.strip():
+        return [], 1
+    out: List[SpanUsage] = []
+    for obj in _iter_json_objects(text):
+        if not isinstance(obj, dict):
+            continue
+        _detect_source(obj)  # currently unused; reserved for future raw-specific paths
+        out.append(_extract_usage(obj))
+    return out, 1
+
+
+def _read_paths_usages(paths: Sequence[PathLike]) -> Tuple[List[SpanUsage], int]:
+    usages: List[SpanUsage] = []
+    files_read = 0
+    for raw in paths:
+        u, n = _read_usages(raw)
+        usages.extend(u)
+        files_read += n
+    return usages, files_read
+
+
+# ---------------------------------------------------------------------------
+# Pricing
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_PRICING_PATH = Path(__file__).parent / "config" / "pricing.json"
+
+
+@dataclasses.dataclass
+class PriceCard:
+    """Pricing and capability data for one model.
+
+    All token prices are USD per 1M tokens. ``None`` means "not priced" and
+    the corresponding usage type is ignored. ``tiers`` covers long-context
+    pricing: a dict where keys are ``input_above_{N}k_per_1m`` /
+    ``output_above_{N}k_per_1m`` and values are the rate to use when the
+    threshold is crossed. The whole span's input (or output) tokens are
+    billed at the tier rate when the threshold is crossed (matches the
+    Langfuse and LiteLLM convention).
+    """
+
+    model_key: str  # "provider/model"
+    provider: str
+    input_per_1m: float
+    output_per_1m: float
+    cache_read_per_1m: Optional[float] = None
+    cache_write_per_1m: Optional[float] = None
+    reasoning_output_per_1m: Optional[float] = None
+    context_window: Optional[int] = None
+    supports_vision: bool = False
+    supports_tools: bool = False
+    supports_reasoning: bool = False
+    supports_prompt_cache: bool = False
+    tiers: Dict[str, float] = dataclasses.field(default_factory=dict)
+
+    @property
+    def supports_cache(self) -> bool:
+        # The catalog flag is the source of truth. The presence of cache
+        # rates is what determines the actual cost; missing rates just mean
+        # cache cost is $0, not that the model is incompatible.
+        return self.supports_prompt_cache
+
+
+@dataclasses.dataclass
+class PricingCatalog:
+    """Loaded pricing catalog with cheap lookup."""
+
+    cards: Dict[str, PriceCard]
+    by_provider_and_name: Dict[Tuple[str, str], str]  # (provider, model_name) -> key
+
+    def get(self, model_key: str) -> Optional[PriceCard]:
+        return self.cards.get(model_key)
+
+    def get_by_provider_and_name(
+        self, provider: Optional[str], model_name: str
+    ) -> Optional[PriceCard]:
+        if provider:
+            key = self.by_provider_and_name.get((provider.lower(), model_name))
+            if key:
+                return self.cards.get(key)
+            # Provider was given but no match under that provider. Do NOT
+            # silently fall back to another provider — that would mis-bill
+            # when the user has aliased model names across providers.
+            return None
+        # Provider-agnostic: any provider that has this model.
+        for prov, name_key in self.by_provider_and_name.keys():
+            if name_key == model_name:
+                return self.cards.get(self.by_provider_and_name[(prov, name_key)])
+        return None
+
+
+def _load_catalog(path: Optional[PathLike] = None) -> PricingCatalog:
+    src = Path(path) if path is not None else DEFAULT_PRICING_PATH
+    with open(src, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    models = data.get("models", {})
+    cards: Dict[str, PriceCard] = {}
+    by_pn: Dict[Tuple[str, str], str] = {}
+    for key, raw in models.items():
+        if not isinstance(raw, dict):
+            continue
+        provider = str(raw.get("provider", "")).lower()
+        if "/" not in key or not provider:
+            continue
+        card = PriceCard(
+            model_key=key,
+            provider=provider,
+            input_per_1m=float(raw.get("input_per_1m", 0.0)),
+            output_per_1m=float(raw.get("output_per_1m", 0.0)),
+            cache_read_per_1m=_maybe_float(raw.get("cache_read_per_1m")),
+            cache_write_per_1m=_maybe_float(raw.get("cache_write_per_1m")),
+            reasoning_output_per_1m=_maybe_float(raw.get("reasoning_output_per_1m")),
+            context_window=_maybe_int(raw.get("context_window")),
+            supports_vision=bool(raw.get("supports_vision", False)),
+            supports_tools=bool(raw.get("supports_tools", False)),
+            supports_reasoning=bool(raw.get("supports_reasoning", False)),
+            supports_prompt_cache=bool(raw.get("supports_prompt_cache", False)),
+            tiers={
+                k: float(v)
+                for k, v in (raw.get("tiers") or {}).items()
+                if isinstance(v, (int, float))
+            },
+        )
+        cards[key] = card
+        model_name = key.split("/", 1)[1]
+        by_pn[(provider, model_name)] = key
+    return PricingCatalog(cards=cards, by_provider_and_name=by_pn)
+
+
+def _maybe_float(v: Any) -> Optional[float]:
+    return float(v) if isinstance(v, (int, float)) else None
+
+
+def _maybe_int(v: Any) -> Optional[int]:
+    return int(v) if isinstance(v, int) and not isinstance(v, bool) else None
+
+
+def _model_key_for(usage: SpanUsage, catalog: PricingCatalog) -> Optional[str]:
+    """Resolve a span's model+provider to a catalog key, with fallbacks."""
+    if not usage.model:
+        return None
+    # Exact: provider/model
+    if usage.provider:
+        candidate = f"{usage.provider}/{usage.model}"
+        if candidate in catalog.cards:
+            return candidate
+    # Provider-agnostic match on model name.
+    for prov, name in catalog.by_provider_and_name:
+        if name == usage.model:
+            return catalog.by_provider_and_name[(prov, name)]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Cost calculation
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SpanCost:
+    """Cost for one span on one model."""
+
+    span_id: str
+    model_key: str
+    input_cost: float
+    output_cost: float
+    cache_read_cost: float
+    cache_write_cost: float
+    reasoning_cost: float
+    tier_applied: Optional[str] = None  # e.g. "input_above_200k_per_1m"
+    incompatible: bool = False  # set when a span uses a feature the model lacks
+
+    @property
+    def total(self) -> float:
+        if self.incompatible:
+            return 0.0
+        return (
+            self.input_cost
+            + self.output_cost
+            + self.cache_read_cost
+            + self.cache_write_cost
+            + self.reasoning_cost
+        )
+
+
+def _tier_for(card: PriceCard, usage: SpanUsage) -> Tuple[Optional[str], float, float]:
+    """Return (tier_label, effective_input_rate, effective_output_rate).
+
+    Long-context tiered pricing: each side (input / output) has its own
+    threshold. A side is billed at the tier rate iff its token count
+    crosses the threshold. When both sides cross, the side with the higher
+    *rate* (more expensive) wins, so the cost estimate is conservative.
+    """
+    if not card.tiers:
+        return None, card.input_per_1m, card.output_per_1m
+    # Parse "input_above_200k_per_1m" / "output_above_200k_per_1m".
+    # Also accept litellm-style "above_200k_per_1m_input" / "above_200k_per_1m_output".
+    thresholds: List[Tuple[int, str, float]] = []
+    for k, rate in card.tiers.items():
+        m = re.match(
+            r"(?:(input|output)_above_(\d+)k_per_1m|above_(\d+)k_per_1m_(input|output))", k
+        )
+        if not m:
+            continue
+        if m.group(1):
+            side, n = m.group(1), int(m.group(2))
+        else:
+            side, n = m.group(4), int(m.group(3))
+        thresholds.append((n * 1000, side, float(rate)))
+    if not thresholds:
+        return None, card.input_per_1m, card.output_per_1m
+    in_t = usage.prompt_tokens or 0
+    out_t = usage.completion_tokens or 0
+    # Per-side "crossed" check.
+    in_crossed = [t for t in thresholds if t[1] == "input" and t[0] < in_t]
+    out_crossed = [t for t in thresholds if t[1] == "output" and t[0] < out_t]
+    if not in_crossed and not out_crossed:
+        return None, card.input_per_1m, card.output_per_1m
+    # Pick the more expensive crossed tier; on tie, prefer the output side
+    # (matches langfuse "first match in priority order" with priority 0 =
+    # default / base, and higher-priority tiers above).
+    in_best = max(in_crossed, key=lambda t: t[2], default=None)
+    out_best = max(out_crossed, key=lambda t: t[2], default=None)
+    if in_best and out_best:
+        if out_best[2] >= in_best[2]:
+            chosen = out_best
+        else:
+            chosen = in_best
+    elif out_best:
+        chosen = out_best
+    else:
+        chosen = in_best
+    assert chosen is not None
+    threshold_n, side, rate = chosen
+    if side == "input":
+        return f"input_above_{threshold_n // 1000}k_per_1m", rate, card.output_per_1m
+    return f"output_above_{threshold_n // 1000}k_per_1m", card.input_per_1m, rate
+
+
+def cost_span(usage: SpanUsage, card: PriceCard) -> SpanCost:
+    """Compute the cost of one span on one model. Returns a SpanCost with
+    ``incompatible=True`` if the span uses a feature the model doesn't
+    support (e.g. cache when the model has no cache rate)."""
+    incompatible = False
+    if usage.uses_prompt_cache and not card.supports_cache:
+        incompatible = True
+    if usage.uses_reasoning and not card.supports_reasoning:
+        incompatible = True
+    tier_label, in_rate, out_rate = _tier_for(card, usage)
+    p = usage.prompt_tokens or 0
+    c = usage.completion_tokens or 0
+    cc = usage.cache_creation_tokens or 0
+    cr = usage.cache_read_tokens or 0
+    r = usage.reasoning_tokens or 0
+    return SpanCost(
+        span_id=usage.span_id,
+        model_key=card.model_key,
+        input_cost=(p / 1_000_000) * in_rate if not incompatible else 0.0,
+        output_cost=(c / 1_000_000) * out_rate if not incompatible else 0.0,
+        cache_read_cost=(
+            (cr / 1_000_000) * card.cache_read_per_1m
+            if (not incompatible and card.cache_read_per_1m is not None)
+            else 0.0
+        ),
+        cache_write_cost=(
+            (cc / 1_000_000) * card.cache_write_per_1m
+            if (not incompatible and card.cache_write_per_1m is not None)
+            else 0.0
+        ),
+        reasoning_cost=(
+            (r / 1_000_000) * card.reasoning_output_per_1m
+            if (not incompatible and card.reasoning_output_per_1m is not None)
+            else 0.0
+        ),
+        tier_applied=tier_label,
+        incompatible=incompatible,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class ModelComparison:
+    """Cost results for one candidate model across all spans."""
+
+    model_key: str
+    provider: str
+    total_usd: float
+    input_usd: float
+    output_usd: float
+    cache_read_usd: float
+    cache_write_usd: float
+    reasoning_usd: float
+    spans_total: int
+    spans_incompatible: int
+    missing_capabilities: List[str] = dataclasses.field(default_factory=list)
+    is_baseline: bool = False
+
+    @property
+    def delta_pct(self) -> Optional[float]:
+        """Percent change vs baseline. ``None`` for the baseline itself, or if
+        there is no baseline."""
+        return None  # filled in by ComparisonReport.delta_pct_for()
+
+
+@dataclasses.dataclass
+class ComparisonReport:
+    baseline: Optional[ModelComparison]
+    alternatives: List[ModelComparison]
+    unknown_models: List[str]
+    files_read: int
+    spans_with_tokens: int
+    spans_skipped: int  # no model, no tokens
+    catalog_size: int
+
+    def all(self) -> List[ModelComparison]:
+        if self.baseline is None:
+            return list(self.alternatives)
+        return [self.baseline] + self.alternatives
+
+    def delta_pct_for(self, mc: ModelComparison) -> Optional[float]:
+        if self.baseline is None or mc.is_baseline:
+            return None
+        if self.baseline.total_usd == 0:
+            return None
+        return (mc.total_usd - self.baseline.total_usd) / self.baseline.total_usd * 100.0
+
+    def find(self, model_key: str) -> Optional[ModelComparison]:
+        for mc in self.all():
+            if mc.model_key == model_key:
+                return mc
+        return None
+
+
+def compare(
+    paths: Union[PathLike, Sequence[PathLike]],
+    *,
+    models: Sequence[str],
+    current_model: Optional[str] = None,
+    catalog: Optional[PricingCatalog] = None,
+    warn_stream: Optional[TextIO] = None,
+) -> ComparisonReport:
+    """Read span log files and produce a ComparisonReport.
+
+    Args:
+        paths: One path or a list of paths to span JSONL files.
+        models: Candidate model keys (``provider/model``) to compare against.
+            The first model in this list is treated as the baseline by
+            default; override with ``current_model``.
+        current_model: Optional explicit baseline. If given, the baseline
+            section of the report uses this model; ``models`` lists the
+            alternatives.
+        catalog: Override the bundled pricing. ``None`` loads the default.
+        warn_stream: Where to write unknown-model warnings. Defaults to
+            stderr; pass ``io.StringIO()`` to silence.
+    """
+    if isinstance(paths, (str, os.PathLike)):
+        seq: List[PathLike] = [paths]
+    else:
+        seq = list(paths)
+    usages, files_read = _read_paths_usages(seq)
+    if catalog is None:
+        catalog = _load_catalog()
+    sink = warn_stream if warn_stream is not None else sys.stderr
+
+    # Resolve which model key is the baseline.
+    baseline_key: Optional[str] = None
+    if current_model:
+        baseline_key = current_model
+    elif models:
+        baseline_key = models[0]
+
+    # Build per-model cost results.
+    results: Dict[str, ModelComparison] = {}
+    unknown: set[str] = set()
+    for key in models:
+        if key not in catalog.cards:
+            unknown.add(key)
+    # Also track all distinct models the spans actually used (so we can warn
+    # if a span's source model is unknown).
+    source_models: set[str] = set()
+    skipped = 0
+    spans_with_tokens = 0
+
+    for key in models:
+        if key not in catalog.cards:
+            continue
+        card = catalog.cards[key]
+        comp = ModelComparison(
+            model_key=key,
+            provider=card.provider,
+            total_usd=0.0,
+            input_usd=0.0,
+            output_usd=0.0,
+            cache_read_usd=0.0,
+            cache_write_usd=0.0,
+            reasoning_usd=0.0,
+            spans_total=0,
+            spans_incompatible=0,
+            is_baseline=(key == baseline_key),
+        )
+        for usage in usages:
+            if not usage.model or not usage.has_tokens:
+                skipped += 1
+                continue
+            spans_with_tokens += 1
+            source_models.add(f"{usage.provider}/{usage.model}" if usage.provider else usage.model)
+            sc = cost_span(usage, card)
+            comp.spans_total += 1
+            if sc.incompatible:
+                comp.spans_incompatible += 1
+                continue
+            comp.input_usd += sc.input_cost
+            comp.output_usd += sc.output_cost
+            comp.cache_read_usd += sc.cache_read_cost
+            comp.cache_write_usd += sc.cache_write_cost
+            comp.reasoning_usd += sc.reasoning_cost
+            comp.total_usd += sc.total
+        results[key] = comp
+
+    # Capability diff vs baseline: for each alternative, list capabilities
+    # the baseline supports that the alternative does not.
+    baseline_card = catalog.get(baseline_key) if baseline_key else None
+    baseline_caps = _capability_dict(baseline_card) if baseline_card else {}
+    for key, comp in results.items():
+        if comp.is_baseline:
+            continue
+        card = catalog.get(key)
+        if card is None:
+            continue
+        alt_caps = _capability_dict(card)
+        for cap, supported in baseline_caps.items():
+            if supported and not alt_caps.get(cap, False):
+                comp.missing_capabilities.append(cap)
+
+    # Split baseline out for the report.
+    baseline = results.pop(baseline_key, None) if baseline_key else None
+    alternatives = [results[k] for k in models if k in results and k != baseline_key]
+
+    # Warnings.
+    for k in sorted(unknown):
+        sink.write(
+            f"[neatlogs-cost] warning: candidate model {k!r} not in pricing catalog; "
+            f"it will be omitted from the comparison. "
+            f"Override via --pricing-file or update "
+            f"neatlogs/config/pricing.json.\n"
+        )
+    # Warn for span source models that aren't in the catalog at all.
+    known_keys = set(catalog.cards.keys())
+    unknown_source = sorted(m for m in source_models if m not in known_keys and m not in unknown)
+    for k in unknown_source:
+        sink.write(
+            f"[neatlogs-cost] note: span source model {k!r} is not in the pricing "
+            f"catalog. The comparison still uses the candidate models you specified, "
+            f"but cost for the original model isn't reported. Override via --pricing-file.\n"
+        )
+
+    return ComparisonReport(
+        baseline=baseline,
+        alternatives=alternatives,
+        unknown_models=sorted(unknown),
+        files_read=files_read,
+        spans_with_tokens=spans_with_tokens,
+        spans_skipped=skipped,
+        catalog_size=len(catalog.cards),
+    )
+
+
+def _capability_dict(card: PriceCard) -> Dict[str, bool]:
+    return {
+        "supports_vision": card.supports_vision,
+        "supports_tools": card.supports_tools,
+        "supports_reasoning": card.supports_reasoning,
+        "supports_prompt_cache": card.supports_prompt_cache,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Forecasting
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class ForecastReport:
+    """Cost projection for a given monthly call volume + model choice."""
+
+    model_key: str
+    monthly_calls: int
+    avg_prompt_tokens: int
+    avg_completion_tokens: int
+    monthly_cost_usd: float
+    annual_cost_usd: float
+    cache_hit_rate: float = 0.0  # 0.0–1.0; only used if model supports cache
+    reasoning_per_call: int = 0  # extra output tokens (for o-series etc.)
+    incompatible: bool = False
+    notes: List[str] = dataclasses.field(default_factory=list)
+
+
+def forecast(
+    *,
+    model_key: str,
+    monthly_calls: int,
+    avg_prompt_tokens: int,
+    avg_completion_tokens: int,
+    catalog: Optional[PricingCatalog] = None,
+    cache_hit_rate: float = 0.0,
+    reasoning_per_call: int = 0,
+) -> ForecastReport:
+    """Project monthly and annual cost for a given traffic pattern.
+
+    The model is treated as a single point estimate: every call is assumed
+    to use the same average prompt and completion token counts. For more
+    realistic estimates, vary the inputs across a range and aggregate.
+    """
+    if catalog is None:
+        catalog = _load_catalog()
+    card = catalog.get(model_key)
+    if card is None:
+        raise ValueError(f"unknown model: {model_key!r}")
+    notes: List[str] = []
+    incompatible = False
+
+    cache_hit_rate = max(0.0, min(1.0, cache_hit_rate))
+    hit_prompt = int(avg_prompt_tokens * cache_hit_rate)
+    miss_prompt = avg_prompt_tokens - hit_prompt
+
+    # Detect explicit incompatible requests before building the synthetic
+    # usage, so the note points to what the user asked for rather than to
+    # an inferred internal state.
+    if cache_hit_rate > 0 and not card.supports_cache:
+        incompatible = True
+        notes.append(
+            f"cache_hit_rate={cache_hit_rate} requested but model does not support prompt caching; cache cost set to 0"
+        )
+    if reasoning_per_call > 0 and not card.supports_reasoning:
+        incompatible = True
+        notes.append(
+            f"reasoning_per_call={reasoning_per_call} requested but model is not a reasoning model; reasoning cost set to 0"
+        )
+
+    # Build a synthetic usage and use cost_span to keep the math in one place.
+    usage = SpanUsage(
+        span_id="forecast",
+        trace_id="forecast",
+        model=card.model_key.split("/", 1)[1],
+        provider=card.provider,
+        prompt_tokens=miss_prompt,
+        completion_tokens=avg_completion_tokens,
+        cache_creation_tokens=miss_prompt if card.supports_cache else None,
+        cache_read_tokens=hit_prompt if card.supports_cache else None,
+        reasoning_tokens=reasoning_per_call if card.supports_reasoning else None,
+    )
+    sc = cost_span(usage, card)
+    per_call = sc.total if not incompatible else 0.0
+    monthly = per_call * monthly_calls
+    return ForecastReport(
+        model_key=model_key,
+        monthly_calls=monthly_calls,
+        avg_prompt_tokens=avg_prompt_tokens,
+        avg_completion_tokens=avg_completion_tokens,
+        monthly_cost_usd=monthly,
+        annual_cost_usd=monthly * 12,
+        cache_hit_rate=cache_hit_rate,
+        reasoning_per_call=reasoning_per_call,
+        incompatible=incompatible,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def format_comparison(
+    report: ComparisonReport,
+    *,
+    style: str = "text",
+    stream: Optional[TextIO] = None,
+) -> str:
+    """Render a ComparisonReport as a string.
+
+    style:
+        - "text": human-readable table with delta vs baseline + capability diffs.
+        - "json": one JSON object with all rows and totals.
+        - "csv":  CSV with one row per (model, usage_type).
+    """
+    if style not in ("text", "json", "csv"):
+        raise ValueError(f"unknown style: {style!r}")
+    if style == "json":
+        return _format_comparison_json(report)
+    if style == "csv":
+        return _format_comparison_csv(report)
+    return _format_comparison_text(report, use_color=_supports_color(stream or sys.stdout))
+
+
+def _format_comparison_text(report: ComparisonReport, *, use_color: bool) -> str:
+    buf = io.StringIO()
+    has_results = report.baseline is not None or bool(report.alternatives)
+    if not has_results and report.spans_with_tokens == 0:
+        if report.spans_skipped:
+            buf.write(
+                f"(no comparable models and no LLM spans with token counts found; "
+                f"{report.spans_skipped} span(s) skipped.)\n"
+            )
+        else:
+            buf.write(
+                "(no comparable models — none of the candidates are in the pricing catalog)\n"
+            )
+        return buf.getvalue()
+    if not has_results:
+        buf.write("(no comparable models — none of the candidates are in the pricing catalog)\n")
+        return buf.getvalue()
+    if report.spans_with_tokens == 0:
+        # Baseline selected, but no input spans; we still render the row at $0.
+        pass  # fall through to the normal table
+    header = (
+        f"{'Model':<32} {'Provider':<12} {'Input':>10} {'Output':>10} "
+        f"{'Cache':>10} {'Reason':>8} {'Total':>12} {'vs base':>9}"
+    )
+    buf.write(header + "\n")
+    buf.write("-" * len(header) + "\n")
+    rows: List[ModelComparison] = []
+    if report.baseline is not None:
+        rows.append(report.baseline)
+    rows.extend(report.alternatives)
+    for mc in rows:
+        cache = mc.cache_read_usd + mc.cache_write_usd
+        total_disp = f"${mc.total_usd:.4f}"
+        if mc.is_baseline:
+            delta_disp = "(baseline)"
+        else:
+            pct = report.delta_pct_for(mc)
+            delta_disp = f"{pct:+.0f}%" if pct is not None else "n/a"
+        line = (
+            f"{mc.model_key[:32]:<32} {mc.provider[:12]:<12} "
+            f"${mc.input_usd:.4f}    ${mc.output_usd:.4f}    "
+            f"${cache:.4f}    ${mc.reasoning_usd:.4f}  "
+            f"{total_disp:>12} {delta_disp:>9}"
+        )
+        if use_color:
+            if mc.is_baseline:
+                line = _ansi("1;33", line)
+            elif report.delta_pct_for(mc) is not None and report.delta_pct_for(mc) < 0:
+                line = _ansi("32", line)  # savings
+            else:
+                line = _ansi("31", line)  # more expensive
+        buf.write(line + "\n")
+    buf.write("-" * len(header) + "\n")
+
+    # Capability diff.
+    if report.baseline is not None:
+        any_diff = any(a.missing_capabilities for a in report.alternatives)
+        if any_diff:
+            buf.write("\nCapability diff vs baseline:\n")
+            for mc in report.alternatives:
+                if mc.missing_capabilities:
+                    buf.write(
+                        f"  {_ansi('33', mc.model_key) if use_color else mc.model_key}: "
+                        f"missing {', '.join(mc.missing_capabilities)}\n"
+                    )
+                else:
+                    buf.write(f"  {mc.model_key}: all baseline capabilities supported\n")
+
+    if report.spans_skipped:
+        buf.write(f"\n({report.spans_skipped} span(s) skipped: no model or no token counts.)\n")
+    buf.write(
+        f"\n({report.spans_with_tokens} span(s) projected across "
+        f"{len(report.all())} model(s); "
+        f"catalog has {report.catalog_size} priced models.)\n"
+    )
+    return buf.getvalue()
+
+
+def _format_comparison_json(report: ComparisonReport) -> str:
+    def row(mc: ModelComparison) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "model": mc.model_key,
+            "provider": mc.provider,
+            "input_usd": round(mc.input_usd, 6),
+            "output_usd": round(mc.output_usd, 6),
+            "cache_read_usd": round(mc.cache_read_usd, 6),
+            "cache_write_usd": round(mc.cache_write_usd, 6),
+            "reasoning_usd": round(mc.reasoning_usd, 6),
+            "total_usd": round(mc.total_usd, 6),
+            "spans_total": mc.spans_total,
+            "spans_incompatible": mc.spans_incompatible,
+            "missing_capabilities": mc.missing_capabilities,
+            "is_baseline": mc.is_baseline,
+        }
+        if not mc.is_baseline and report.baseline is not None:
+            pct = report.delta_pct_for(mc)
+            if pct is not None:
+                d["delta_pct_vs_baseline"] = round(pct, 2)
+        return d
+
+    obj: Dict[str, Any] = {
+        "currency": "USD",
+        "files_read": report.files_read,
+        "spans_with_tokens": report.spans_with_tokens,
+        "spans_skipped": report.spans_skipped,
+        "catalog_size": report.catalog_size,
+        "unknown_models": report.unknown_models,
+        "baseline": row(report.baseline) if report.baseline else None,
+        "alternatives": [row(mc) for mc in report.alternatives],
+    }
+    return json.dumps(obj, indent=2) + "\n"
+
+
+def _format_comparison_csv(report: ComparisonReport) -> str:
+    buf = io.StringIO()
+    w = csv.writer(buf, lineterminator="\n")
+    w.writerow(
+        [
+            "model",
+            "provider",
+            "is_baseline",
+            "input_usd",
+            "output_usd",
+            "cache_read_usd",
+            "cache_write_usd",
+            "reasoning_usd",
+            "total_usd",
+            "spans_total",
+            "spans_incompatible",
+            "delta_pct_vs_baseline",
+        ]
+    )
+    for mc in [report.baseline] + report.alternatives if report.baseline else report.alternatives:
+        if mc is None:
+            continue
+        pct = report.delta_pct_for(mc)
+        w.writerow(
+            [
+                mc.model_key,
+                mc.provider,
+                "true" if mc.is_baseline else "false",
+                f"{mc.input_usd:.6f}",
+                f"{mc.output_usd:.6f}",
+                f"{mc.cache_read_usd:.6f}",
+                f"{mc.cache_write_usd:.6f}",
+                f"{mc.reasoning_usd:.6f}",
+                f"{mc.total_usd:.6f}",
+                mc.spans_total,
+                mc.spans_incompatible,
+                "" if pct is None else f"{pct:.2f}",
+            ]
+        )
+    return buf.getvalue()
+
+
+def format_forecast(
+    report: ForecastReport,
+    *,
+    style: str = "text",
+    stream: Optional[TextIO] = None,
+) -> str:
+    if style not in ("text", "json"):
+        raise ValueError(f"unknown style: {style!r}")
+    if style == "json":
+        return (
+            json.dumps(
+                {
+                    "model": report.model_key,
+                    "monthly_calls": report.monthly_calls,
+                    "avg_prompt_tokens": report.avg_prompt_tokens,
+                    "avg_completion_tokens": report.avg_completion_tokens,
+                    "cache_hit_rate": report.cache_hit_rate,
+                    "reasoning_per_call": report.reasoning_per_call,
+                    "monthly_cost_usd": round(report.monthly_cost_usd, 4),
+                    "annual_cost_usd": round(report.annual_cost_usd, 2),
+                    "currency": "USD",
+                    "incompatible": report.incompatible,
+                    "notes": report.notes,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+    use_color = _supports_color(stream or sys.stdout)
+    buf = io.StringIO()
+    if report.incompatible:
+        buf.write(
+            _ansi("33", "WARNING: ") + "some requested features aren't supported by this model:\n"
+        )
+        for n in report.notes:
+            buf.write(f"  - {n}\n")
+        buf.write("\n")
+    line = (
+        f"Model:                {report.model_key}\n"
+        f"Monthly calls:        {report.monthly_calls}\n"
+        f"Avg prompt tokens:    {report.avg_prompt_tokens}\n"
+        f"Avg completion:       {report.avg_completion_tokens}\n"
+        f"Cache hit rate:       {report.cache_hit_rate * 100:.0f}%\n"
+        f"Reasoning tokens:     {report.reasoning_per_call}\n"
+        f"Monthly cost (USD):   ${report.monthly_cost_usd:.2f}\n"
+        f"Annual cost (USD):    ${report.annual_cost_usd:.2f}\n"
+    )
+    if use_color:
+        line = _ansi("1;33", line)
+    buf.write(line)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Color helpers
+# ---------------------------------------------------------------------------
+
+
+_USE_COLOR = True
+
+
+def _supports_color(stream: TextIO) -> bool:
+    if not _USE_COLOR:
+        return False
+    if not hasattr(stream, "isatty"):
+        return False
+    return bool(stream.isatty())
+
+
+def _ansi(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="neatlogs-compare",
+        description=(
+            "Compare what a span log would have cost across multiple models. "
+            "Reads the same on-disk format as neatlogs-replay and applies the "
+            "bundled pricing catalog (overridable via --pricing-file)."
+        ),
+    )
+    p.add_argument("paths", nargs="+", help="One or more span log file paths.")
+    p.add_argument(
+        "--models",
+        required=True,
+        help=(
+            "Comma-separated list of model keys to compare, in "
+            "`provider/model` form. Example: "
+            "'openai/gpt-4o-mini,anthropic/claude-3-5-haiku-latest,openai/gpt-4o'."
+        ),
+    )
+    p.add_argument(
+        "--current",
+        default=None,
+        help=("Optional explicit baseline model key. Defaults to the first model " "in --models."),
+    )
+    p.add_argument(
+        "--format",
+        choices=("text", "json", "csv"),
+        default="text",
+        help="Output format. Default: text.",
+    )
+    p.add_argument(
+        "--pricing-file",
+        default=None,
+        help="Path to a JSON pricing catalog. Default: the bundled catalog.",
+    )
+    p.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI color output even when stdout is a TTY.",
+    )
+    p.add_argument(
+        "--color",
+        action="store_true",
+        help="Force ANSI color output even when stdout is not a TTY.",
+    )
+    p.add_argument(
+        "--forecast",
+        action="store_true",
+        help=(
+            "Instead of comparing past spans, project monthly/annual cost for "
+            "a given traffic pattern (see --monthly-calls, --avg-prompt, "
+            "--avg-completion, --cache-hit-rate, --reasoning-tokens)."
+        ),
+    )
+    p.add_argument(
+        "--monthly-calls",
+        type=int,
+        default=10000,
+        help="Forecast: number of calls per month. Default: 10000.",
+    )
+    p.add_argument(
+        "--avg-prompt",
+        type=int,
+        default=2000,
+        help="Forecast: average prompt tokens per call. Default: 2000.",
+    )
+    p.add_argument(
+        "--avg-completion",
+        type=int,
+        default=500,
+        help="Forecast: average completion tokens per call. Default: 500.",
+    )
+    p.add_argument(
+        "--cache-hit-rate",
+        type=float,
+        default=0.0,
+        help="Forecast: fraction of prompt tokens served from cache (0.0–1.0). Default: 0.",
+    )
+    p.add_argument(
+        "--reasoning-tokens",
+        type=int,
+        default=0,
+        help="Forecast: extra reasoning tokens per call (for o-series, R1, etc.). Default: 0.",
+    )
+    return p
+
+
+def _cli(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    global _USE_COLOR
+    if args.no_color:
+        _USE_COLOR = False
+    elif args.color:
+        _USE_COLOR = True
+    try:
+        catalog = _load_catalog(args.pricing_file)
+    except FileNotFoundError as exc:
+        print(f"[neatlogs-cost] error: {exc}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"[neatlogs-cost] error: invalid pricing JSON: {exc}", file=sys.stderr)
+        return 2
+
+    if args.forecast:
+        # Forecast mode: --models[0] is the model to project.
+        model = args.models.split(",")[0].strip()
+        try:
+            report = forecast(
+                model_key=model,
+                monthly_calls=args.monthly_calls,
+                avg_prompt_tokens=args.avg_prompt,
+                avg_completion_tokens=args.avg_completion,
+                catalog=catalog,
+                cache_hit_rate=args.cache_hit_rate,
+                reasoning_per_call=args.reasoning_tokens,
+            )
+        except ValueError as exc:
+            print(f"[neatlogs-cost] error: {exc}", file=sys.stderr)
+            return 2
+        sys.stdout.write(format_forecast(report, style=args.format))
+        return 0
+
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    report = compare(
+        args.paths,
+        models=models,
+        current_model=args.current,
+        catalog=catalog,
+    )
+    if not report.alternatives and report.baseline is None:
+        print(
+            "[neatlogs-cost] no comparable models: none of the candidates are in the pricing catalog",
+            file=sys.stderr,
+        )
+        return 2
+    sys.stdout.write(format_comparison(report, style=args.format))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/neatlogs/cost.py
+++ b/neatlogs/cost.py
@@ -182,18 +182,6 @@ def _extract_usage(obj: Dict[str, Any]) -> SpanUsage:
     )
 
 
-def _detect_source(obj: Dict[str, Any]) -> str:
-    if isinstance(obj.get("context"), dict) and "trace_id" in obj.get("context", {}):
-        return "raw"
-    if (
-        "trace_id" in obj
-        and "span_id" in obj
-        and isinstance(obj.get("parent_span_id"), (str, type(None)))
-    ):
-        return "processed"
-    return "unknown"
-
-
 def _iter_json_objects(text: str) -> Iterator[Dict[str, Any]]:
     """Brace-balanced parser. Tolerates newlines inside string values."""
     depth = 0
@@ -245,7 +233,6 @@ def _read_usages(path: PathLike) -> Tuple[List[SpanUsage], int]:
     for obj in _iter_json_objects(text):
         if not isinstance(obj, dict):
             continue
-        _detect_source(obj)  # currently unused; reserved for future raw-specific paths
         out.append(_extract_usage(obj))
     return out, 1
 
@@ -540,12 +527,6 @@ class ModelComparison:
     spans_incompatible: int
     missing_capabilities: List[str] = dataclasses.field(default_factory=list)
     is_baseline: bool = False
-
-    @property
-    def delta_pct(self) -> Optional[float]:
-        """Percent change vs baseline. ``None`` for the baseline itself, or if
-        there is no baseline."""
-        return None  # filled in by ComparisonReport.delta_pct_for()
 
 
 @dataclasses.dataclass
@@ -842,7 +823,7 @@ def format_comparison(
 def _format_comparison_text(report: ComparisonReport, *, use_color: bool) -> str:
     buf = io.StringIO()
     has_results = report.baseline is not None or bool(report.alternatives)
-    if not has_results and report.spans_with_tokens == 0:
+    if not has_results:
         if report.spans_skipped:
             buf.write(
                 f"(no comparable models and no LLM spans with token counts found; "
@@ -853,12 +834,8 @@ def _format_comparison_text(report: ComparisonReport, *, use_color: bool) -> str
                 "(no comparable models — none of the candidates are in the pricing catalog)\n"
             )
         return buf.getvalue()
-    if not has_results:
-        buf.write("(no comparable models — none of the candidates are in the pricing catalog)\n")
-        return buf.getvalue()
-    if report.spans_with_tokens == 0:
-        # Baseline selected, but no input spans; we still render the row at $0.
-        pass  # fall through to the normal table
+    # has_results=True: render the table. When spans_with_tokens is 0 the
+    # rows are $0.00; the user still sees the model breakdown they asked for.
     header = (
         f"{'Model':<32} {'Provider':<12} {'Input':>10} {'Output':>10} "
         f"{'Cache':>10} {'Reason':>8} {'Total':>12} {'vs base':>9}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,6 +322,15 @@ milvus = [
 [project.entry-points."hermes_agent.plugins"]
 neatlogs = "neatlogs.hermes_plugin"
 
+# Console scripts installed by `pip install neatlogs`. `neatlogs-compare` reads
+# the JSONL span log files produced by `NEATLOGS_LOG_SPANS` /
+# `NEATLOGS_LOG_RAW_SPANS` and answers "what would this run cost on a different
+# model?" by applying the bundled pricing catalog (overridable via
+# `--pricing-file`). A `--forecast` sub-mode projects monthly / annual cost
+# for a planned workload. Pure stdlib, no extra deps.
+[project.scripts]
+neatlogs-compare = "neatlogs.cost:_cli"
+
 [project.urls]
 Homepage = "https://github.com/NeatLogs/neatlogs"
 Repository = "https://github.com/NeatLogs/neatlogs.git"

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -1,0 +1,1726 @@
+"""
+Unit tests for neatlogs.cost.
+
+The cost module is a what-if comparison engine. Given a span log written
+by the SDK (NEATLOGS_LOG_SPANS=true or NEATLOGS_LOG_RAW_SPANS=true) and a
+list of candidate models, it computes what each model would have cost
+for the same workload, surfaces capability mismatches, and renders the
+result as text / json / csv.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from neatlogs.cost import (
+    ComparisonReport,
+    ForecastReport,
+    ModelComparison,
+    PriceCard,
+    PricingCatalog,
+    SpanCost,
+    SpanUsage,
+    _capability_dict,
+    _detect_source,
+    _extract_usage,
+    _format_comparison_csv,
+    _format_comparison_json,
+    _format_comparison_text,
+    _int_attr,
+    _iter_json_objects,
+    _load_catalog,
+    _maybe_float,
+    _maybe_int,
+    _model_key_for,
+    _read_paths_usages,
+    _read_usages,
+    _tier_for,
+    compare,
+    cost_span,
+    forecast,
+    format_comparison,
+    format_forecast,
+)
+
+# ---------------------------------------------------------------------------
+# Test pricing catalog
+# ---------------------------------------------------------------------------
+
+
+CATALOG_DICT: Dict[str, Any] = {
+    "_meta": {"currency": "USD", "units": "per_1m_tokens", "schema_version": "1.0"},
+    "models": {
+        "openai/gpt-4o-mini": {
+            "provider": "openai",
+            "input_per_1m": 0.15,
+            "output_per_1m": 0.60,
+            "cache_read_per_1m": 0.075,
+            "supports_prompt_cache": True,
+            "supports_vision": True,
+            "supports_tools": True,
+            "context_window": 128000,
+        },
+        "openai/gpt-4o": {
+            "provider": "openai",
+            "input_per_1m": 2.50,
+            "output_per_1m": 10.00,
+            "cache_read_per_1m": 1.25,
+            "supports_prompt_cache": True,
+            "supports_vision": True,
+            "supports_tools": True,
+            "context_window": 128000,
+        },
+        "openai/o3-mini": {
+            "provider": "openai",
+            "input_per_1m": 1.10,
+            "output_per_1m": 4.40,
+            "reasoning_output_per_1m": 4.40,
+            "cache_read_per_1m": 0.55,
+            "supports_prompt_cache": True,
+            "supports_reasoning": True,
+            "supports_tools": True,
+            "context_window": 200000,
+        },
+        "anthropic/claude-3-5-haiku-latest": {
+            "provider": "anthropic",
+            "input_per_1m": 0.80,
+            "output_per_1m": 4.00,
+            "cache_write_per_1m": 1.00,
+            "cache_read_per_1m": 0.08,
+            "supports_prompt_cache": True,
+            "supports_tools": True,
+            "context_window": 200000,
+        },
+        "anthropic/claude-3-5-sonnet-latest": {
+            "provider": "anthropic",
+            "input_per_1m": 3.00,
+            "output_per_1m": 15.00,
+            "cache_write_per_1m": 3.75,
+            "cache_read_per_1m": 0.30,
+            "supports_prompt_cache": True,
+            "supports_vision": True,
+            "supports_tools": True,
+            "context_window": 200000,
+            "tiers": {
+                "input_above_200k_per_1m": 6.00,
+                "output_above_200k_per_1m": 22.50,
+            },
+        },
+    },
+}
+
+
+def _catalog() -> PricingCatalog:
+    return _load_catalog_from_dict(CATALOG_DICT)
+
+
+def _load_catalog_from_dict(d: Dict[str, Any]) -> PricingCatalog:
+    """Bypass the file system: build a PricingCatalog from an in-memory dict.
+
+    This mirrors _load_catalog but without touching the disk, so each test
+    can use a self-contained catalog without writing temp files.
+    """
+    from neatlogs.cost import DEFAULT_PRICING_PATH, _load_catalog
+
+    # Write to a temp file and load it.
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(d, f)
+        path = f.name
+    try:
+        return _load_catalog(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Span reading + extraction
+# ---------------------------------------------------------------------------
+
+
+class TestIterJsonObjects:
+    def test_single_object(self):
+        out = list(_iter_json_objects('{"a": 1, "b": 2}'))
+        assert out == [{"a": 1, "b": 2}]
+
+    def test_multiple_objects(self):
+        out = list(_iter_json_objects('{"a": 1}\n{"b": 2}\n{"c": 3}'))
+        assert out == [{"a": 1}, {"b": 2}, {"c": 3}]
+
+    def test_nested_braces_in_strings(self):
+        # The brace-balancer must NOT count braces inside string values.
+        text = '{"name": "a {b} c", "value": 1}\n{"name": "x", "value": 2}'
+        out = list(_iter_json_objects(text))
+        assert len(out) == 2
+        assert out[0]["name"] == "a {b} c"
+        assert out[1]["name"] == "x"
+
+    def test_escaped_quotes(self):
+        text = '{"name": "a \\"quoted\\" word"}'
+        out = list(_iter_json_objects(text))
+        assert len(out) == 1
+        assert out[0]["name"] == 'a "quoted" word'
+
+    def test_malformed_object_skipped(self):
+        text = '{"a": 1}\n{not valid}\n{"b": 2}'
+        out = list(_iter_json_objects(text))
+        assert len(out) == 2
+        assert {"a": 1} in out
+        assert {"b": 2} in out
+
+    def test_empty(self):
+        assert list(_iter_json_objects("")) == []
+
+
+class TestIntAttr:
+    def test_missing(self):
+        assert _int_attr({}, "foo") is None
+
+    def test_int(self):
+        assert _int_attr({"k": 42}, "k") == 42
+
+    def test_negative_int_ignored(self):
+        assert _int_attr({"k": -5}, "k") is None
+
+    def test_float_int(self):
+        assert _int_attr({"k": 42.0}, "k") == 42
+
+    def test_float_non_int_ignored(self):
+        assert _int_attr({"k": 42.5}, "k") is None
+
+    def test_bool_ignored(self):
+        # bool is a subclass of int; we explicitly exclude True/False.
+        assert _int_attr({"k": True}, "k") is None
+
+    def test_first_key_wins(self):
+        assert _int_attr({"a": 1, "b": 2}, "a", "b") == 1
+        assert _int_attr({"b": 2}, "a", "b") == 2
+
+
+class TestExtractUsage:
+    def test_minimal(self):
+        d = {
+            "attributes": {
+                "neatlogs.llm.model_name": "gpt-4o-mini",
+                "neatlogs.llm.token_count.prompt": 100,
+                "neatlogs.llm.token_count.completion": 50,
+            }
+        }
+        u = _extract_usage(d)
+        assert u.model == "gpt-4o-mini"
+        assert u.provider is None
+        assert u.prompt_tokens == 100
+        assert u.completion_tokens == 50
+        assert u.cache_creation_tokens is None
+        assert u.cache_read_tokens is None
+        assert u.reasoning_tokens is None
+
+    def test_with_provider_and_cache(self):
+        d = {
+            "attributes": {
+                "neatlogs.llm.model_name": "claude-3-5-haiku-latest",
+                "neatlogs.llm.provider": "Anthropic",
+                "neatlogs.llm.token_count.prompt": 1000,
+                "neatlogs.llm.token_count.completion": 200,
+                "neatlogs.llm.token_count.cache_creation": 500,
+                "neatlogs.llm.token_count.cache_read": 700,
+                "neatlogs.llm.token_count.reasoning": 0,
+            }
+        }
+        u = _extract_usage(d)
+        assert u.model == "claude-3-5-haiku-latest"
+        assert u.provider == "anthropic"  # lowercased
+        assert u.cache_creation_tokens == 500
+        assert u.cache_read_tokens == 700
+        # reasoning=0 should NOT be reported as "uses reasoning"
+        assert u.uses_reasoning is False
+
+    def test_otel_genai_fallback(self):
+        d = {
+            "attributes": {
+                "gen_ai.system": "openai",
+                "gen_ai.response.model": "gpt-4o",
+                "gen_ai.usage.input_tokens": 200,
+                "gen_ai.usage.output_tokens": 100,
+            }
+        }
+        u = _extract_usage(d)
+        assert u.model == "gpt-4o"
+        assert u.provider == "openai"
+        assert u.prompt_tokens == 200
+        assert u.completion_tokens == 100
+
+    def test_request_model_fallback(self):
+        d = {
+            "attributes": {
+                "gen_ai.system": "openai",
+                "gen_ai.request.model": "gpt-4o-mini",
+            }
+        }
+        u = _extract_usage(d)
+        assert u.model == "gpt-4o-mini"
+
+    def test_no_attributes(self):
+        u = _extract_usage({})
+        assert u.model == ""
+        assert u.prompt_tokens is None
+
+    def test_attrs_not_a_dict(self):
+        u = _extract_usage({"attributes": "nope"})
+        assert u.model == ""
+
+    def test_uses_cache_and_reasoning(self):
+        u = SpanUsage(
+            span_id="s",
+            trace_id="t",
+            model="m",
+            provider=None,
+            prompt_tokens=100,
+            completion_tokens=50,
+            cache_creation_tokens=10,
+            cache_read_tokens=0,
+            reasoning_tokens=5,
+        )
+        assert u.uses_prompt_cache is True
+        assert u.uses_reasoning is True
+        assert u.has_tokens is True
+
+    def test_uses_cache_false_when_zero(self):
+        u = SpanUsage(
+            span_id="s",
+            trace_id="t",
+            model="m",
+            provider=None,
+            prompt_tokens=100,
+            completion_tokens=50,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            reasoning_tokens=0,
+        )
+        assert u.uses_prompt_cache is False
+        assert u.uses_reasoning is False
+
+
+class TestDetectSource:
+    def test_processed(self):
+        assert (
+            _detect_source({"trace_id": "a", "span_id": "b", "parent_span_id": None}) == "processed"
+        )
+
+    def test_raw(self):
+        assert _detect_source({"context": {"trace_id": "a"}}) == "raw"
+
+    def test_unknown(self):
+        assert _detect_source({"foo": "bar"}) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Pricing catalog
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCatalog:
+    def test_basic(self):
+        c = _catalog()
+        assert "openai/gpt-4o-mini" in c.cards
+        card = c.cards["openai/gpt-4o-mini"]
+        assert card.provider == "openai"
+        assert card.input_per_1m == 0.15
+        assert card.output_per_1m == 0.60
+        assert card.cache_read_per_1m == 0.075
+        assert card.supports_prompt_cache is True
+        assert card.supports_vision is True
+        assert card.supports_tools is True
+        assert card.context_window == 128000
+
+    def test_tier_parsing(self):
+        c = _catalog()
+        sonnet = c.cards["anthropic/claude-3-5-sonnet-latest"]
+        assert "input_above_200k_per_1m" in sonnet.tiers
+        assert sonnet.tiers["input_above_200k_per_1m"] == 6.00
+        assert sonnet.tiers["output_above_200k_per_1m"] == 22.50
+
+    def test_reasoning(self):
+        c = _catalog()
+        o3 = c.cards["openai/o3-mini"]
+        assert o3.supports_reasoning is True
+        assert o3.reasoning_output_per_1m == 4.40
+
+    def test_bundled_default_loads(self):
+        # The bundled file must be loadable.
+        c = _load_catalog()
+        assert len(c.cards) > 0
+        # Headline providers present.
+        assert any(card.provider == "openai" for card in c.cards.values())
+        assert any(card.provider == "anthropic" for card in c.cards.values())
+        assert any(card.provider == "google_genai" for card in c.cards.values())
+
+    def test_lookup_by_provider_and_name(self):
+        c = _catalog()
+        # Provider-agnostic lookup by model name.
+        card = c.get_by_provider_and_name(None, "gpt-4o-mini")
+        assert card is not None
+        assert card.model_key == "openai/gpt-4o-mini"
+
+    def test_lookup_with_provider(self):
+        c = _catalog()
+        card = c.get_by_provider_and_name("anthropic", "claude-3-5-haiku-latest")
+        assert card is not None
+        assert card.model_key == "anthropic/claude-3-5-haiku-latest"
+
+    def test_lookup_miss(self):
+        c = _catalog()
+        assert c.get_by_provider_and_name("openai", "gpt-99") is None
+        assert c.get_by_provider_and_name("nonexistent", "gpt-4o-mini") is None
+
+    def test_load_invalid_json(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            f.write("not json")
+            path = f.name
+        try:
+            with pytest.raises(json.JSONDecodeError):
+                _load_catalog(path)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_load_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            _load_catalog("/nonexistent/path/pricing.json")
+
+    def test_skips_malformed_entries(self):
+        d = {
+            "models": {
+                "openai/gpt-4o": "not a dict",  # type skip
+                "no-slash-key": {"provider": "openai", "input_per_1m": 1.0},  # no slash
+                "openai/no-provider": {"input_per_1m": 1.0},  # no provider
+                "openai/gpt-3.5": {"provider": "openai", "input_per_1m": 1.5, "output_per_1m": 2.0},
+            }
+        }
+        c = _load_catalog_from_dict(d)
+        assert "openai/gpt-3.5" in c.cards
+        assert "openai/gpt-4o" not in c.cards
+        assert "no-slash-key" not in c.cards
+
+    def test_supports_cache(self):
+        c = _catalog()
+        mini = c.cards["openai/gpt-4o-mini"]
+        assert mini.supports_cache is True
+        sonnet = c.cards["anthropic/claude-3-5-sonnet-latest"]
+        assert sonnet.supports_cache is True
+
+
+class TestMaybeFloatInt:
+    def test_maybe_float(self):
+        assert _maybe_float(1.5) == 1.5
+        assert _maybe_float(1) == 1.0
+        assert _maybe_float(None) is None
+        assert _maybe_float("x") is None
+        assert _maybe_float(True) == 1.0  # bool is int
+
+    def test_maybe_int(self):
+        assert _maybe_int(42) == 42
+        assert _maybe_int(42.0) is None  # not an int
+        assert _maybe_int(None) is None
+        assert _maybe_int(True) is None
+        assert _maybe_int("x") is None
+
+
+# ---------------------------------------------------------------------------
+# Tier logic
+# ---------------------------------------------------------------------------
+
+
+class TestTierFor:
+    def test_no_tiers(self):
+        card = PriceCard(
+            model_key="x",
+            provider="p",
+            input_per_1m=1.0,
+            output_per_1m=2.0,
+        )
+        usage = SpanUsage("s", "t", "m", None, 100000, 100000, None, None, None)
+        label, in_r, out_r = _tier_for(card, usage)
+        assert label is None
+        assert in_r == 1.0
+        assert out_r == 2.0
+
+    def test_below_threshold(self):
+        card = PriceCard(
+            model_key="x",
+            provider="p",
+            input_per_1m=1.0,
+            output_per_1m=2.0,
+            tiers={"input_above_200k_per_1m": 5.0, "output_above_200k_per_1m": 10.0},
+        )
+        usage = SpanUsage("s", "t", "m", None, 100000, 100000, None, None, None)
+        label, in_r, out_r = _tier_for(card, usage)
+        assert label is None
+        assert in_r == 1.0
+        assert out_r == 2.0
+
+    def test_input_crosses_threshold(self):
+        card = PriceCard(
+            model_key="x",
+            provider="p",
+            input_per_1m=1.0,
+            output_per_1m=2.0,
+            tiers={"input_above_200k_per_1m": 5.0, "output_above_200k_per_1m": 10.0},
+        )
+        usage = SpanUsage("s", "t", "m", None, 250000, 1000, None, None, None)
+        label, in_r, out_r = _tier_for(card, usage)
+        assert label == "input_above_200k_per_1m"
+        assert in_r == 5.0
+        assert out_r == 2.0  # output not tiered
+
+    def test_output_crosses_threshold(self):
+        card = PriceCard(
+            model_key="x",
+            provider="p",
+            input_per_1m=1.0,
+            output_per_1m=2.0,
+            tiers={"input_above_200k_per_1m": 5.0, "output_above_200k_per_1m": 10.0},
+        )
+        usage = SpanUsage("s", "t", "m", None, 1000, 250000, None, None, None)
+        label, in_r, out_r = _tier_for(card, usage)
+        assert label == "output_above_200k_per_1m"
+        assert in_r == 1.0
+        assert out_r == 10.0
+
+    def test_both_cross_picks_largest(self):
+        card = PriceCard(
+            model_key="x",
+            provider="p",
+            input_per_1m=1.0,
+            output_per_1m=2.0,
+            tiers={"input_above_200k_per_1m": 5.0, "output_above_200k_per_1m": 10.0},
+        )
+        usage = SpanUsage("s", "t", "m", None, 300000, 300000, None, None, None)
+        label, in_r, out_r = _tier_for(card, usage)
+        # Both crossed; we only have one threshold in this card so it picks that one.
+        # Both sides crossed; output side is more expensive (10 vs 5) so it
+        # dominates. With single threshold, output_above wins.
+        assert label == "output_above_200k_per_1m"
+        assert out_r == 10.0
+
+    def test_unparseable_tier_ignored(self):
+        card = PriceCard(
+            model_key="x",
+            provider="p",
+            input_per_1m=1.0,
+            output_per_1m=2.0,
+            tiers={"weird_key": 99.0},
+        )
+        usage = SpanUsage("s", "t", "m", None, 300000, 1000, None, None, None)
+        label, in_r, out_r = _tier_for(card, usage)
+        assert label is None
+        assert in_r == 1.0
+
+    def test_zero_token_span(self):
+        card = PriceCard(
+            model_key="x",
+            provider="p",
+            input_per_1m=1.0,
+            output_per_1m=2.0,
+            tiers={"input_above_200k_per_1m": 5.0},
+        )
+        usage = SpanUsage("s", "t", "m", None, 0, 0, None, None, None)
+        label, in_r, out_r = _tier_for(card, usage)
+        assert label is None
+
+
+# ---------------------------------------------------------------------------
+# Model key resolution
+# ---------------------------------------------------------------------------
+
+
+class TestModelKeyFor:
+    def test_exact_with_provider(self):
+        c = _catalog()
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 100, 50, None, None, None)
+        assert _model_key_for(u, c) == "openai/gpt-4o-mini"
+
+    def test_provider_agnostic_fallback(self):
+        c = _catalog()
+        u = SpanUsage("s", "t", "gpt-4o-mini", None, 100, 50, None, None, None)
+        assert _model_key_for(u, c) == "openai/gpt-4o-mini"
+
+    def test_no_match(self):
+        c = _catalog()
+        u = SpanUsage("s", "t", "gpt-99", None, 100, 50, None, None, None)
+        assert _model_key_for(u, c) is None
+
+    def test_no_model(self):
+        c = _catalog()
+        u = SpanUsage("s", "t", "", None, 100, 50, None, None, None)
+        assert _model_key_for(u, c) is None
+
+
+# ---------------------------------------------------------------------------
+# cost_span
+# ---------------------------------------------------------------------------
+
+
+class TestCostSpan:
+    def test_basic(self):
+        c = _catalog()
+        card = c.cards["openai/gpt-4o-mini"]
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 1_000_000, 1_000_000, None, None, None)
+        sc = cost_span(u, card)
+        # input 1M * 0.15 + output 1M * 0.60
+        assert sc.input_cost == pytest.approx(0.15)
+        assert sc.output_cost == pytest.approx(0.60)
+        assert sc.total == pytest.approx(0.75)
+        assert sc.incompatible is False
+
+    def test_cache_read(self):
+        c = _catalog()
+        card = c.cards["openai/gpt-4o-mini"]
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 0, 0, None, 1_000_000, None)
+        sc = cost_span(u, card)
+        # 1M cache_read at 0.075
+        assert sc.cache_read_cost == pytest.approx(0.075)
+        assert sc.total == pytest.approx(0.075)
+
+    def test_cache_write(self):
+        c = _catalog()
+        card = c.cards["anthropic/claude-3-5-haiku-latest"]
+        u = SpanUsage(
+            "s", "t", "claude-3-5-haiku-latest", "anthropic", 1_000_000, 0, 1_000_000, 0, None
+        )
+        sc = cost_span(u, card)
+        # 1M cache_write at 1.00
+        assert sc.cache_write_cost == pytest.approx(1.00)
+
+    def test_reasoning(self):
+        c = _catalog()
+        card = c.cards["openai/o3-mini"]
+        u = SpanUsage("s", "t", "o3-mini", "openai", 100_000, 100_000, None, None, 100_000)
+        sc = cost_span(u, card)
+        # 100k reasoning at 4.40/1M = 0.44
+        assert sc.reasoning_cost == pytest.approx(0.44)
+
+    def test_tier_applied(self):
+        c = _catalog()
+        card = c.cards["anthropic/claude-3-5-sonnet-latest"]
+        u = SpanUsage(
+            "s", "t", "claude-3-5-sonnet-latest", "anthropic", 250_000, 1000, None, None, None
+        )
+        sc = cost_span(u, card)
+        # input 250k * 6.00/1M = 1.50; output 1k * 15.00/1M = 0.015
+        assert sc.tier_applied == "input_above_200k_per_1m"
+        assert sc.input_cost == pytest.approx(1.50)
+        assert sc.output_cost == pytest.approx(0.015)
+
+    def test_incompatible_cache_on_model_without_cache(self):
+        # Use a model without cache support: o3-mini is the only OpenAI reasoning
+        # model in CATALOG_DICT. But it has cache_read. Let me add a no-cache case
+        # by using anthropic claude-3-5-haiku which has cache. Hmm, all our models
+        # have cache. Let me build a no-cache card inline.
+        card = PriceCard(
+            model_key="openai/gpt-3.5",
+            provider="openai",
+            input_per_1m=1.0,
+            output_per_1m=2.0,
+            supports_prompt_cache=False,
+        )
+        u = SpanUsage("s", "t", "gpt-3.5", "openai", 100, 50, 10, 0, None)
+        sc = cost_span(u, card)
+        assert sc.incompatible is True
+        assert sc.total == 0.0
+
+    def test_incompatible_reasoning_on_non_reasoning_model(self):
+        card = PriceCard(
+            model_key="openai/gpt-4o-mini",
+            provider="openai",
+            input_per_1m=0.15,
+            output_per_1m=0.60,
+            supports_reasoning=False,
+        )
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 100, 50, None, None, 100)
+        sc = cost_span(u, card)
+        assert sc.incompatible is True
+
+    def test_cache_on_model_without_cache_pricing_only(self):
+        # supports_prompt_cache=True but no cache_read/cache_write rate set
+        card = PriceCard(
+            model_key="x",
+            provider="y",
+            input_per_1m=1.0,
+            output_per_1m=2.0,
+            supports_prompt_cache=True,
+            cache_read_per_1m=None,
+            cache_write_per_1m=None,
+        )
+        u = SpanUsage("s", "t", "m", "y", 100, 50, 5, 0, None)
+        sc = cost_span(u, card)
+        # model "supports" cache but has no rates, so cache cost is 0
+        # Span doesn't fail compatibility because supports_cache is False
+        # (no rates).
+        assert sc.cache_write_cost == 0.0
+        assert sc.incompatible is False  # supports_cache requires rates
+
+
+# ---------------------------------------------------------------------------
+# Span reading from disk
+# ---------------------------------------------------------------------------
+
+
+def _write_span_log(path: Path, spans: List[Dict[str, Any]]) -> None:
+    path.write_text("\n".join(json.dumps(s) for s in spans))
+
+
+def _processed_span(
+    trace_id: str = "a",
+    span_id: str = "1",
+    name: str = "openai.chat.completions.create",
+    model: str = "gpt-4o-mini",
+    provider: str = "openai",
+    prompt: int = 1000,
+    completion: int = 500,
+    cache_creation: int = None,
+    cache_read: int = None,
+    reasoning: int = None,
+) -> Dict[str, Any]:
+    attrs: Dict[str, Any] = {
+        "neatlogs.llm.model_name": model,
+        "neatlogs.llm.provider": provider,
+        "neatlogs.llm.token_count.prompt": prompt,
+        "neatlogs.llm.token_count.completion": completion,
+    }
+    if cache_creation is not None:
+        attrs["neatlogs.llm.token_count.cache_creation"] = cache_creation
+    if cache_read is not None:
+        attrs["neatlogs.llm.token_count.cache_read"] = cache_read
+    if reasoning is not None:
+        attrs["neatlogs.llm.token_count.reasoning"] = reasoning
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": None,
+        "name": name,
+        "kind": "llm",
+        "start_time": "2024-01-15T10:00:00Z",
+        "end_time": "2024-01-15T10:00:01Z",
+        "attributes": attrs,
+        "status": {"code": "OK", "description": ""},
+        "events": [],
+    }
+
+
+def _raw_span(**kwargs: Any) -> Dict[str, Any]:
+    d = _processed_span(**kwargs)
+    return {
+        "name": d["name"],
+        "context": {"trace_id": "0xabcd", "span_id": "0x1234"},
+        "parent_id": None,
+        "kind": "SpanKind.CLIENT",
+        "start_time": "2024-01-15T10:00:00.000Z",
+        "end_time": "2024-01-15T10:00:00.001Z",
+        "status": {"status_code": "OK", "description": ""},
+        "attributes": d["attributes"],
+        "events": [],
+        "links": [],
+        "resource": {},
+    }
+
+
+class TestReadUsages:
+    def test_processed(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=1000, completion=500)])
+        usages, n = _read_usages(p)
+        assert n == 1
+        assert len(usages) == 1
+        assert usages[0].prompt_tokens == 1000
+        assert usages[0].completion_tokens == 500
+
+    def test_raw_format(self, tmp_path: Path):
+        p = tmp_path / "raw.jsonl"
+        _write_span_log(p, [_raw_span(prompt=2000, completion=1000)])
+        usages, n = _read_usages(p)
+        assert n == 1
+        assert usages[0].prompt_tokens == 2000
+
+    def test_missing_file(self, tmp_path: Path):
+        usages, n = _read_usages(tmp_path / "missing.jsonl")
+        assert usages == []
+        assert n == 0
+
+    def test_empty_file(self, tmp_path: Path):
+        p = tmp_path / "empty.jsonl"
+        p.write_text("")
+        usages, n = _read_usages(p)
+        assert usages == []
+        assert n == 1
+
+    def test_blank_lines_ignored(self, tmp_path: Path):
+        p = tmp_path / "blank.jsonl"
+        p.write_text("\n\n\n")
+        usages, n = _read_usages(p)
+        assert usages == []
+        assert n == 1
+
+    def test_malformed_object_skipped(self, tmp_path: Path):
+        # A brace-balanced chunk that isn't valid JSON is dropped silently.
+        # The surrounding valid objects are still picked up.
+        p = tmp_path / "malformed.jsonl"
+        p.write_text(
+            json.dumps(_processed_span(span_id="1", prompt=100))
+            + "\n"
+            + "{not valid}"
+            + "\n"
+            + json.dumps(_processed_span(span_id="2", prompt=200))
+        )
+        usages, n = _read_usages(p)
+        assert n == 1
+        assert len(usages) == 2
+        assert {u.prompt_tokens for u in usages} == {100, 200}
+
+    def test_spans_without_model_passed_through(self, tmp_path: Path):
+        # The reader returns ALL parsed spans (not just LLM ones). The
+        # compare() function is responsible for filtering. This keeps the
+        # reader simple and the skip count in compare() accurate.
+        d = _processed_span(span_id="1")
+        d["attributes"] = {"foo": "bar"}  # no model
+        p = tmp_path / "no_model.jsonl"
+        _write_span_log(p, [d])
+        usages, _ = _read_usages(p)
+        assert len(usages) == 1
+        assert usages[0].model == ""
+
+    def test_brace_balanced_nested_strings(self, tmp_path: Path):
+        # Real span data can have embedded newlines in event payloads.
+        d = _processed_span(span_id="1")
+        d["attributes"]["some_prompt"] = "line 1\nline 2 {x} line 3"
+        p = tmp_path / "nested.jsonl"
+        _write_span_log(p, [d])
+        usages, _ = _read_usages(p)
+        assert len(usages) == 1
+
+
+class TestReadPathsUsages:
+    def test_multi_file(self, tmp_path: Path):
+        p1 = tmp_path / "a.jsonl"
+        p2 = tmp_path / "b.jsonl"
+        _write_span_log(p1, [_processed_span(span_id="1", prompt=100)])
+        _write_span_log(p2, [_processed_span(span_id="2", prompt=200)])
+        usages, n = _read_paths_usages([p1, p2])
+        assert n == 2
+        assert len(usages) == 2
+
+    def test_missing_paths_counted_zero(self, tmp_path: Path):
+        usages, n = _read_paths_usages([tmp_path / "missing.jsonl"])
+        assert usages == []
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# compare
+# ---------------------------------------------------------------------------
+
+
+class TestCompare:
+    def test_basic_single_model(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=1_000_000, completion=1_000_000)])
+        catalog = _catalog()
+        buf = io.StringIO()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini"],
+            catalog=catalog,
+            warn_stream=buf,
+        )
+        assert report.baseline is not None
+        assert report.baseline.model_key == "openai/gpt-4o-mini"
+        # 1M * 0.15 + 1M * 0.60 = 0.75
+        assert report.baseline.total_usd == pytest.approx(0.75)
+        assert buf.getvalue() == ""
+
+    def test_explicit_baseline_differs_from_models_order(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=1_000_000, completion=1_000_000)])
+        catalog = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            current_model="openai/gpt-4o-mini",
+            catalog=catalog,
+        )
+        assert report.baseline is not None
+        assert report.baseline.model_key == "openai/gpt-4o-mini"
+        assert len(report.alternatives) == 1
+        assert report.alternatives[0].model_key == "openai/gpt-4o"
+        # gpt-4o: 1M * 2.50 + 1M * 10.00 = 12.50
+        assert report.alternatives[0].total_usd == pytest.approx(12.50)
+
+    def test_savings_detection(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=1_000_000, completion=1_000_000)])
+        catalog = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o", "openai/gpt-4o-mini"],
+            catalog=catalog,
+        )
+        # gpt-4o-mini is much cheaper than gpt-4o, so the delta should be negative.
+        mini = report.find("openai/gpt-4o-mini")
+        assert mini is not None
+        delta = report.delta_pct_for(mini)
+        # (0.75 - 12.50) / 12.50 * 100 = -94%
+        assert delta == pytest.approx(-94, abs=0.1)
+
+    def test_capability_diff(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=1_000_000, completion=1_000_000)])
+        catalog = _catalog()
+        # Use a model without vision as the alternative vs gpt-4o-mini (has vision).
+        # Build a custom catalog with a vision-less alternative.
+        custom = {
+            "_meta": {"schema_version": "1.0"},
+            "models": {
+                "openai/gpt-4o-mini": {
+                    "provider": "openai",
+                    "input_per_1m": 0.15,
+                    "output_per_1m": 0.60,
+                    "supports_vision": True,
+                    "supports_tools": True,
+                },
+                "openai/text-only": {
+                    "provider": "openai",
+                    "input_per_1m": 0.10,
+                    "output_per_1m": 0.40,
+                    "supports_vision": False,
+                    "supports_tools": True,
+                },
+            },
+        }
+        c2 = _load_catalog_from_dict(custom)
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini", "openai/text-only"],
+            catalog=c2,
+        )
+        alt = report.find("openai/text-only")
+        assert alt is not None
+        assert "supports_vision" in alt.missing_capabilities
+
+    def test_capability_diff_both_support(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        catalog = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            catalog=catalog,
+        )
+        alt = report.find("openai/gpt-4o")
+        assert alt is not None
+        assert alt.missing_capabilities == []
+
+    def test_unknown_model_warning(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        catalog = _catalog()
+        buf = io.StringIO()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini", "nonexistent/model"],
+            catalog=catalog,
+            warn_stream=buf,
+        )
+        assert "nonexistent/model" in buf.getvalue()
+        # The unknown model is omitted; only the known one is in the report.
+        assert report.find("nonexistent/model") is None
+        assert report.find("openai/gpt-4o-mini") is not None
+
+    def test_unknown_source_model_note(self, tmp_path: Path):
+        # Span uses a model not in the catalog. Should surface a note.
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(
+            p,
+            [_processed_span(prompt=100, completion=50, model="some/future-model")],
+        )
+        catalog = _catalog()
+        buf = io.StringIO()
+        compare(
+            p,
+            models=["openai/gpt-4o-mini"],
+            catalog=catalog,
+            warn_stream=buf,
+        )
+        assert "some/future-model" in buf.getvalue()
+
+    def test_spans_with_no_tokens_counted(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        d = _processed_span(span_id="1", prompt=100, completion=50)
+        # Force zero tokens
+        d["attributes"]["neatlogs.llm.token_count.prompt"] = 0
+        d["attributes"]["neatlogs.llm.token_count.completion"] = 0
+        _write_span_log(p, [d])
+        catalog = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini"],
+            catalog=catalog,
+        )
+        assert report.spans_with_tokens == 0
+        assert report.spans_skipped == 1
+
+    def test_spans_with_no_model_skipped(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        d = _processed_span(span_id="1")
+        d["attributes"] = {"foo": "bar"}  # no model
+        _write_span_log(p, [d])
+        catalog = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini"],
+            catalog=catalog,
+        )
+        assert report.spans_with_tokens == 0
+
+    def test_empty_spans_file(self, tmp_path: Path):
+        p = tmp_path / "empty.jsonl"
+        p.write_text("")
+        catalog = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini"],
+            catalog=catalog,
+        )
+        assert report.spans_with_tokens == 0
+        assert report.files_read == 1
+
+    def test_missing_paths(self, tmp_path: Path):
+        catalog = _catalog()
+        report = compare(
+            [tmp_path / "missing.jsonl"],
+            models=["openai/gpt-4o-mini"],
+            catalog=catalog,
+        )
+        assert report.files_read == 0
+        assert report.spans_with_tokens == 0
+
+    def test_single_path_string(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        catalog = _catalog()
+        report = compare(
+            str(p),  # str, not Path
+            models=["openai/gpt-4o-mini"],
+            catalog=catalog,
+        )
+        assert report.spans_with_tokens == 1
+
+    def test_incompatible_span_counted(self, tmp_path: Path):
+        # Use a span with cache tokens against a model that has no cache support.
+        custom = {
+            "_meta": {"schema_version": "1.0"},
+            "models": {
+                "openai/with-cache": {
+                    "provider": "openai",
+                    "input_per_1m": 1.0,
+                    "output_per_1m": 2.0,
+                    "cache_read_per_1m": 0.1,
+                    "supports_prompt_cache": True,
+                },
+                "openai/no-cache": {
+                    "provider": "openai",
+                    "input_per_1m": 1.0,
+                    "output_per_1m": 2.0,
+                },
+            },
+        }
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(
+            p,
+            [_processed_span(prompt=100, completion=50, cache_read=100, model="openai/with-cache")],
+        )
+        c2 = _load_catalog_from_dict(custom)
+        report = compare(
+            p,
+            models=["openai/no-cache"],
+            catalog=c2,
+        )
+        mc = report.find("openai/no-cache")
+        assert mc is not None
+        assert mc.spans_total == 1
+        assert mc.spans_incompatible == 1
+        assert mc.total_usd == 0.0
+
+    def test_files_read_count(self, tmp_path: Path):
+        p1 = tmp_path / "a.jsonl"
+        p2 = tmp_path / "b.jsonl"
+        _write_span_log(p1, [_processed_span(span_id="1", prompt=100, completion=50)])
+        _write_span_log(p2, [_processed_span(span_id="2", prompt=100, completion=50)])
+        catalog = _catalog()
+        report = compare(
+            [p1, p2],
+            models=["openai/gpt-4o-mini"],
+            catalog=catalog,
+        )
+        assert report.files_read == 2
+        assert report.spans_with_tokens == 2
+
+    def test_all_helper(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        catalog = _catalog()
+        # No baseline (no models[0])
+        report = compare(p, models=[], catalog=catalog)
+        assert report.all() == []
+        # With baseline + alternatives
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            catalog=catalog,
+        )
+        all_rows = report.all()
+        assert len(all_rows) == 2
+        assert all_rows[0].is_baseline
+        assert not all_rows[1].is_baseline
+
+
+# ---------------------------------------------------------------------------
+# forecast
+# ---------------------------------------------------------------------------
+
+
+class TestForecast:
+    def test_basic(self):
+        c = _catalog()
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=10_000,
+            avg_prompt_tokens=2_000,
+            avg_completion_tokens=500,
+            catalog=c,
+        )
+        # Per call: 2k * 0.15/1M + 500 * 0.60/1M = 0.0003 + 0.0003 = 0.0006
+        # Monthly: 10k * 0.0006 = 6.00
+        # Annual: 72.00
+        assert report.monthly_cost_usd == pytest.approx(6.00, abs=1e-4)
+        assert report.annual_cost_usd == pytest.approx(72.00, abs=1e-2)
+
+    def test_cache_hit_rate(self):
+        c = _catalog()
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=10_000,
+            avg_prompt_tokens=2_000,
+            avg_completion_tokens=500,
+            catalog=c,
+            cache_hit_rate=0.5,  # half the prompt tokens come from cache
+        )
+        # 1k miss at 0.15/1M + 1k hit at 0.075/1M + 500 completion at 0.60/1M
+        # = 0.00015 + 0.000075 + 0.0003 = 0.000525 per call
+        # monthly: 5.25
+        assert report.monthly_cost_usd == pytest.approx(5.25, abs=1e-4)
+        assert report.cache_hit_rate == 0.5
+
+    def test_cache_hit_rate_clamped(self):
+        c = _catalog()
+        # Negative or >1 is clamped.
+        r1 = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=100,
+            avg_prompt_tokens=100,
+            avg_completion_tokens=100,
+            catalog=c,
+            cache_hit_rate=-0.5,
+        )
+        assert r1.cache_hit_rate == 0.0
+        r2 = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=100,
+            avg_prompt_tokens=100,
+            avg_completion_tokens=100,
+            catalog=c,
+            cache_hit_rate=2.0,
+        )
+        assert r2.cache_hit_rate == 1.0
+
+    def test_reasoning_per_call(self):
+        c = _catalog()
+        report = forecast(
+            model_key="openai/o3-mini",
+            monthly_calls=10_000,
+            avg_prompt_tokens=2_000,
+            avg_completion_tokens=500,
+            catalog=c,
+            reasoning_per_call=2_000,
+        )
+        # Per call: 2k input at 1.10/1M + 500 output at 4.40/1M + 2k reasoning at 4.40/1M
+        # = 0.0022 + 0.0022 + 0.0088 = 0.0132
+        # monthly: 132.00
+        assert report.monthly_cost_usd == pytest.approx(132.00, abs=0.01)
+
+    def test_unknown_model_raises(self):
+        c = _catalog()
+        with pytest.raises(ValueError):
+            forecast(
+                model_key="openai/nonexistent",
+                monthly_calls=100,
+                avg_prompt_tokens=100,
+                avg_completion_tokens=100,
+                catalog=c,
+            )
+
+    def test_cache_requested_on_no_cache_model(self):
+        # Model has no cache support, but we ask for cache_hit_rate=0.5.
+        # Should produce a note and treat the cache as 0.
+        custom = {
+            "_meta": {"schema_version": "1.0"},
+            "models": {
+                "openai/no-cache": {
+                    "provider": "openai",
+                    "input_per_1m": 1.0,
+                    "output_per_1m": 2.0,
+                },
+            },
+        }
+        c = _load_catalog_from_dict(custom)
+        report = forecast(
+            model_key="openai/no-cache",
+            monthly_calls=100,
+            avg_prompt_tokens=1000,
+            avg_completion_tokens=100,
+            catalog=c,
+            cache_hit_rate=0.5,
+        )
+        assert report.incompatible is True
+        assert any("cache" in n.lower() for n in report.notes)
+
+    def test_reasoning_on_non_reasoning_model(self):
+        custom = {
+            "_meta": {"schema_version": "1.0"},
+            "models": {
+                "openai/no-reasoning": {
+                    "provider": "openai",
+                    "input_per_1m": 1.0,
+                    "output_per_1m": 2.0,
+                    "supports_reasoning": False,
+                },
+            },
+        }
+        c = _load_catalog_from_dict(custom)
+        report = forecast(
+            model_key="openai/no-reasoning",
+            monthly_calls=100,
+            avg_prompt_tokens=1000,
+            avg_completion_tokens=100,
+            catalog=c,
+            reasoning_per_call=500,
+        )
+        assert report.incompatible is True
+        assert any("reasoning" in n.lower() for n in report.notes)
+
+    def test_monthly_to_annual_multiplier(self):
+        c = _catalog()
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=10_000,
+            avg_prompt_tokens=1000,
+            avg_completion_tokens=100,
+            catalog=c,
+        )
+        assert report.annual_cost_usd == pytest.approx(report.monthly_cost_usd * 12)
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatComparison:
+    def test_text_renders_baseline_and_alternatives(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=1_000_000, completion=1_000_000)])
+        catalog = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            catalog=catalog,
+        )
+        out = format_comparison(report, style="text")
+        assert "openai/gpt-4o-mini" in out
+        assert "openai/gpt-4o" in out
+        assert "(baseline)" in out
+        assert "vs base" in out
+        assert "$" in out  # currency marker
+
+    def test_text_renders_capability_diff(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        custom = {
+            "_meta": {"schema_version": "1.0"},
+            "models": {
+                "openai/gpt-4o-mini": {
+                    "provider": "openai",
+                    "input_per_1m": 0.15,
+                    "output_per_1m": 0.60,
+                    "supports_vision": True,
+                    "supports_tools": True,
+                },
+                "openai/text-only": {
+                    "provider": "openai",
+                    "input_per_1m": 0.10,
+                    "output_per_1m": 0.40,
+                    "supports_vision": False,
+                    "supports_tools": True,
+                },
+            },
+        }
+        c = _load_catalog_from_dict(custom)
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini", "openai/text-only"],
+            catalog=c,
+        )
+        out = format_comparison(report, style="text")
+        assert "Capability diff" in out
+        assert "supports_vision" in out
+
+    def test_text_empty_report(self):
+        report = ComparisonReport(
+            baseline=None,
+            alternatives=[],
+            unknown_models=[],
+            files_read=0,
+            spans_with_tokens=0,
+            spans_skipped=0,
+            catalog_size=0,
+        )
+        out = format_comparison(report, style="text")
+        assert "no comparable models" in out
+
+    def test_text_no_spans_with_tokens(self):
+        # With a baseline configured but no spans processed, we still print
+        # the row showing $0 — the user wants to know "what would I have
+        # spent?" even when there's no data to project.
+        c = _catalog()
+        report = ComparisonReport(
+            baseline=ModelComparison(
+                model_key="openai/gpt-4o-mini",
+                provider="openai",
+                total_usd=0,
+                input_usd=0,
+                output_usd=0,
+                cache_read_usd=0,
+                cache_write_usd=0,
+                reasoning_usd=0,
+                spans_total=0,
+                spans_incompatible=0,
+                is_baseline=True,
+            ),
+            alternatives=[],
+            unknown_models=[],
+            files_read=1,
+            spans_with_tokens=0,
+            spans_skipped=0,
+            catalog_size=42,
+        )
+        out = format_comparison(report, style="text")
+        assert "openai/gpt-4o-mini" in out
+        assert "$0.0000" in out
+
+    def test_text_no_spans_no_baseline(self):
+        # No baseline and no alternatives and no spans → tell the user.
+        report = ComparisonReport(
+            baseline=None,
+            alternatives=[],
+            unknown_models=[],
+            files_read=1,
+            spans_with_tokens=0,
+            spans_skipped=2,
+            catalog_size=42,
+        )
+        out = format_comparison(report, style="text")
+        assert "no LLM spans" in out
+        assert "2 span(s) skipped" in out
+
+    def test_text_skipped_count(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        d = _processed_span()
+        d["attributes"] = {"foo": "bar"}  # no model, will be skipped
+        _write_span_log(p, [d])
+        c = _catalog()
+        report = compare(p, models=["openai/gpt-4o-mini"], catalog=c)
+        out = format_comparison(report, style="text")
+        assert report.spans_skipped == 1
+        assert "1 span(s) skipped" in out
+
+    def test_json_shape(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=1_000_000, completion=1_000_000)])
+        c = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            catalog=c,
+        )
+        out = format_comparison(report, style="json")
+        obj = json.loads(out)
+        assert obj["currency"] == "USD"
+        assert obj["baseline"]["model"] == "openai/gpt-4o-mini"
+        assert obj["baseline"]["is_baseline"] is True
+        assert len(obj["alternatives"]) == 1
+        # delta is present for the alternative
+        assert "delta_pct_vs_baseline" in obj["alternatives"][0]
+
+    def test_json_no_baseline(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        c = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini"],
+            current_model="nonexistent/baseline",
+            catalog=c,
+        )
+        out = format_comparison(report, style="json")
+        obj = json.loads(out)
+        assert obj["baseline"] is None
+
+    def test_csv_shape(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=1_000_000, completion=1_000_000)])
+        c = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            catalog=c,
+        )
+        out = format_comparison(report, style="csv")
+        lines = out.strip().split("\n")
+        assert lines[0] == (
+            "model,provider,is_baseline,input_usd,output_usd,cache_read_usd,"
+            "cache_write_usd,reasoning_usd,total_usd,spans_total,spans_incompatible,"
+            "delta_pct_vs_baseline"
+        )
+        # Two data rows.
+        assert len(lines) == 3
+        # First row is the baseline; no delta_pct value.
+        baseline_cols = lines[1].split(",")
+        assert baseline_cols[0] == "openai/gpt-4o-mini"
+        assert baseline_cols[2] == "true"
+        assert baseline_cols[-1] == ""  # no delta for baseline
+        # Second row has a delta.
+        alt_cols = lines[2].split(",")
+        assert alt_cols[0] == "openai/gpt-4o"
+        assert alt_cols[2] == "false"
+        assert alt_cols[-1] != ""  # has a delta
+
+    def test_csv_no_baseline(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        c = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini"],
+            current_model="nonexistent",
+            catalog=c,
+        )
+        out = format_comparison(report, style="csv")
+        lines = out.strip().split("\n")
+        # Header + 1 alternative row
+        assert len(lines) == 2
+
+    def test_unknown_style_raises(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        c = _catalog()
+        report = compare(p, models=["openai/gpt-4o-mini"], catalog=c)
+        with pytest.raises(ValueError):
+            format_comparison(report, style="bogus")
+
+
+class TestFormatComparisonTextHelpers:
+    def test_internal_text_helper_no_baseline(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        c = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini"],
+            current_model="nonexistent",
+            catalog=c,
+        )
+        out = _format_comparison_text(report, use_color=False)
+        # No baseline marker
+        assert "(baseline)" not in out
+        assert "openai/gpt-4o-mini" in out
+
+    def test_internal_json_helper(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        c = _catalog()
+        report = compare(p, models=["openai/gpt-4o-mini"], catalog=c)
+        out = _format_comparison_json(report)
+        obj = json.loads(out)
+        assert obj["currency"] == "USD"
+
+    def test_internal_csv_helper_lf_only(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        c = _catalog()
+        report = compare(p, models=["openai/gpt-4o-mini"], catalog=c)
+        out = _format_comparison_csv(report)
+        # No \r line endings.
+        assert "\r\n" not in out
+        # Always ends with newline.
+        assert out.endswith("\n")
+
+
+class TestFormatForecast:
+    def test_text_shape(self):
+        c = _catalog()
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=10_000,
+            avg_prompt_tokens=2000,
+            avg_completion_tokens=500,
+            catalog=c,
+        )
+        out = format_forecast(report, style="text")
+        assert "openai/gpt-4o-mini" in out
+        assert "Monthly calls:" in out
+        assert "Monthly cost" in out
+        assert "Annual cost" in out
+        assert "$" in out
+
+    def test_text_warns_on_incompatible(self):
+        custom = {
+            "_meta": {"schema_version": "1.0"},
+            "models": {
+                "openai/no-cache": {
+                    "provider": "openai",
+                    "input_per_1m": 1.0,
+                    "output_per_1m": 2.0,
+                },
+            },
+        }
+        c = _load_catalog_from_dict(custom)
+        report = forecast(
+            model_key="openai/no-cache",
+            monthly_calls=100,
+            avg_prompt_tokens=1000,
+            avg_completion_tokens=100,
+            catalog=c,
+            cache_hit_rate=0.5,
+        )
+        out = format_forecast(report, style="text")
+        assert "WARNING" in out
+        assert "cache" in out.lower()
+
+    def test_json_shape(self):
+        c = _catalog()
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=10_000,
+            avg_prompt_tokens=2000,
+            avg_completion_tokens=500,
+            catalog=c,
+        )
+        out = format_forecast(report, style="json")
+        obj = json.loads(out)
+        assert obj["model"] == "openai/gpt-4o-mini"
+        assert obj["currency"] == "USD"
+        assert obj["monthly_cost_usd"] == pytest.approx(6.0, abs=1e-3)
+        assert obj["annual_cost_usd"] == pytest.approx(72.0, abs=1e-2)
+
+    def test_unknown_style_raises(self):
+        c = _catalog()
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=100,
+            avg_prompt_tokens=100,
+            avg_completion_tokens=100,
+            catalog=c,
+        )
+        with pytest.raises(ValueError):
+            format_forecast(report, style="bogus")
+
+
+# ---------------------------------------------------------------------------
+# Capability dict
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityDict:
+    def test_all_caps(self):
+        c = PriceCard(
+            model_key="x",
+            provider="y",
+            input_per_1m=1,
+            output_per_1m=2,
+            supports_vision=True,
+            supports_tools=True,
+            supports_reasoning=True,
+            supports_prompt_cache=True,
+        )
+        caps = _capability_dict(c)
+        assert caps == {
+            "supports_vision": True,
+            "supports_tools": True,
+            "supports_reasoning": True,
+            "supports_prompt_cache": True,
+        }
+
+    def test_no_caps(self):
+        c = PriceCard(model_key="x", provider="y", input_per_1m=1, output_per_1m=2)
+        caps = _capability_dict(c)
+        assert all(v is False for v in caps.values())
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_compare_cli(self, tmp_path: Path, capsys):
+        from neatlogs.cost import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=1_000_000, completion=1_000_000)])
+        rc = _cli(
+            [
+                str(p),
+                "--models",
+                "openai/gpt-4o-mini,openai/gpt-4o",
+                "--no-color",
+                "--format",
+                "text",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "openai/gpt-4o-mini" in out
+        assert "openai/gpt-4o" in out
+
+    def test_compare_cli_json(self, tmp_path: Path, capsys):
+        from neatlogs.cost import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        rc = _cli([str(p), "--models", "openai/gpt-4o-mini", "--format", "json"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        obj = json.loads(out)
+        assert obj["currency"] == "USD"
+
+    def test_compare_cli_csv(self, tmp_path: Path, capsys):
+        from neatlogs.cost import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        rc = _cli([str(p), "--models", "openai/gpt-4o-mini", "--format", "csv"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "model,provider,is_baseline" in out
+
+    def test_forecast_cli(self, tmp_path: Path, capsys):
+        from neatlogs.cost import _cli
+
+        p = tmp_path / "ignored.jsonl"  # forecast mode doesn't read this
+        _write_span_log(p, [_processed_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--models",
+                "openai/gpt-4o-mini",
+                "--forecast",
+                "--monthly-calls",
+                "1000",
+                "--avg-prompt",
+                "1000",
+                "--avg-completion",
+                "100",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Monthly cost" in out
+        assert "openai/gpt-4o-mini" in out
+
+    def test_missing_pricing_file(self, tmp_path: Path, capsys):
+        from neatlogs.cost import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--models",
+                "openai/gpt-4o-mini",
+                "--pricing-file",
+                str(tmp_path / "does-not-exist.json"),
+            ]
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "error" in err
+
+    def test_invalid_pricing_json(self, tmp_path: Path, capsys):
+        from neatlogs.cost import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span()])
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json")
+        rc = _cli(
+            [
+                str(p),
+                "--models",
+                "openai/gpt-4o-mini",
+                "--pricing-file",
+                str(bad),
+            ]
+        )
+        assert rc == 2
+
+    def test_no_comparable_models(self, tmp_path: Path, capsys):
+        from neatlogs.cost import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span()])
+        rc = _cli([str(p), "--models", "totally/nonexistent"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "no comparable models" in err
+
+    def test_forecast_unknown_model(self, tmp_path: Path, capsys):
+        from neatlogs.cost import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span()])
+        rc = _cli([str(p), "--models", "openai/nonexistent", "--forecast"])
+        assert rc == 2
+
+    def test_comma_separated_models_parsed(self, tmp_path: Path, capsys):
+        from neatlogs.cost import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--models",
+                "openai/gpt-4o-mini, openai/gpt-4o, anthropic/claude-3-5-haiku-latest",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        # All three should appear.
+        assert "openai/gpt-4o-mini" in out
+        assert "openai/gpt-4o" in out
+        assert "anthropic/claude-3-5-haiku-latest" in out

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -27,7 +27,6 @@ from neatlogs.cost import (
     SpanCost,
     SpanUsage,
     _capability_dict,
-    _detect_source,
     _extract_usage,
     _format_comparison_csv,
     _format_comparison_json,
@@ -306,17 +305,30 @@ class TestExtractUsage:
         assert u.uses_reasoning is False
 
 
-class TestDetectSource:
-    def test_processed(self):
-        assert (
-            _detect_source({"trace_id": "a", "span_id": "b", "parent_span_id": None}) == "processed"
+class TestFormatColor:
+    def test_color_in_output(self, tmp_path: Path):
+        # The text formatter emits ANSI codes when use_color=True. Baseline
+        # → bold yellow, more expensive → red, savings → green.
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=1_000_000, completion=1_000_000)])
+        c = _catalog()
+        report = compare(
+            p,
+            models=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            catalog=c,
         )
+        out = _format_comparison_text(report, use_color=True)
+        assert "\033[" in out
+        # gpt-4o is more expensive than gpt-4o-mini → red (31).
+        assert "\033[31m" in out
 
-    def test_raw(self):
-        assert _detect_source({"context": {"trace_id": "a"}}) == "raw"
-
-    def test_unknown(self):
-        assert _detect_source({"foo": "bar"}) == "unknown"
+    def test_color_disabled_no_ansi(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_processed_span(prompt=100, completion=50)])
+        c = _catalog()
+        report = compare(p, models=["openai/gpt-4o-mini"], catalog=c)
+        out = _format_comparison_text(report, use_color=False)
+        assert "\033[" not in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds a `neatlogs-compare` CLI and a programmatic `neatlogs.cost` engine for what-if model cost comparison on past span JSONL logs.

Closes #55.

## Why

The SDK already writes everything needed: model name, prompt/completion token counts, and increasingly cache and reasoning token counts, on every LLM span in `spans_optimized.log` / `spans_raw_optimized.log`. The backend at `app.neatlogs.com` shows the dollar total for traces that have already run.

What's missing is a local "what if I switched models?" tool. Existing approaches all have the same gap:

- **Langfuse** ships `IngestionService.calculateUsageCosts` server-side; no local CLI. Pricing tiers landed in late 2025 but only in the hosted product.
- **Helicone** has a model registry (300+ models) and a hosted cost calculator; no local CLI.
- **OpenLIT** auto-calculates cost at span time via OpenTelemetry attributes; no what-if tool.
- **LiteLLM** has the de-facto `model_prices_and_context_window.json` (12k lines) and a hosted cost calculator; no local CLI.

A user who wants to know "if I move this trace from `gpt-4o-mini` to `claude-3-5-haiku-latest`, what's the saving?" has to either sign up for a SaaS dashboard or hand-compute the math. Neither is good for offline / CI / paranoid-maintainer workflows.

This PR closes the gap with a small standalone engine. Complements `neatlogs-replay` (#52): replay shows the trace tree, this shows the dollars.

## Usage

```bash
# Compare what a past run would have cost on each candidate model
neatlogs-compare spans.log \
    --models openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3-5-haiku-latest

# Explicit baseline
neatlogs-compare spans.log \
    --models openai/gpt-4o,anthropic/claude-3-5-haiku-latest \
    --current openai/gpt-4o-mini

# Forecast monthly cost for a planned workload
neatlogs-compare spans.log \
    --models openai/gpt-4o-mini \
    --forecast \
    --monthly-calls 50000 \
    --avg-prompt 3000 \
    --avg-completion 800 \
    --cache-hit-rate 0.4
```

Output (text, TTY):

```
Model                            Provider          Input     Output      Cache   Reason        Total   vs base
--------------------------------------------------------------------------------------------------------------
openai/gpt-4o-mini               openai       $0.0000    $0.0005    $0.0000    $0.0000       $0.0005 (baseline)
openai/gpt-4o                    openai       $0.0004    $0.0088    $0.0000    $0.0000       $0.0092    +1567%
anthropic/claude-3-5-haiku-lates anthropic    $0.0001    $0.0035    $0.0000    $0.0000       $0.0036     +561%
--------------------------------------------------------------------------------------------------------------

Capability diff vs baseline:
  openai/gpt-4o: all baseline capabilities supported
  anthropic/claude-3-5-haiku-latest: missing supports_vision
```

## How

### Pricing schema (`neatlogs/config/pricing.json`)

```json
{
  "_meta": {"currency": "USD", "units": "per_1m_tokens", "schema_version": "1.0"},
  "models": {
    "openai/gpt-4o-mini": {
      "provider": "openai",
      "input_per_1m": 0.15,
      "output_per_1m": 0.60,
      "cache_read_per_1m": 0.075,
      "supports_prompt_cache": true,
      "supports_vision": true,
      "supports_tools": true,
      "context_window": 128000
    },
    "anthropic/claude-3-5-sonnet-latest": {
      "provider": "anthropic",
      "input_per_1m": 3.00,
      "output_per_1m": 15.00,
      "cache_write_per_1m": 3.75,
      "cache_read_per_1m": 0.30,
      "supports_prompt_cache": true,
      "supports_vision": true,
      "supports_tools": true,
      "context_window": 200000,
      "tiers": {
        "input_above_200k_per_1m": 6.00,
        "output_above_200k_per_1m": 22.50
      }
    }
  }
}
```

Key design choices (the "why" behind the schema):

- **Token prices are USD per 1M** — matches every provider's published rate card.
- **Model keys are `provider/model_name`** — same as Langfuse, to avoid namespace collisions where the same model name exists in OpenAI, Azure, and OpenRouter.
- **Tiered pricing uses a per-side `tiers` sub-dict** — a model can have one or both of `input_above_{N}k_per_1m` / `output_above_{N}k_per_1m`. When both sides cross, the more expensive tier wins (conservative estimate).
- **Capability flags drive the comparison report's "missing capability" warnings** — the user cannot silently switch to a model that lacks a feature they depend on.
- **Cache and reasoning get their own rate fields** (`cache_read_per_1m`, `cache_write_per_1m`, `reasoning_output_per_1m`) instead of being buried in a generic `usage_details` map. Matches Helicone's `cost` object shape.

Bundled pricing covers ~30 headline models the SDK already wraps (OpenAI / Anthropic / Google GenAI / DeepSeek / Groq), with capability flags and tiered pricing where applicable. Override at runtime via `--pricing-file PATH` or `NEATLOGS_PRICING_FILE`.

### Span reading

Same brace-balanced JSONL parser as `neatlogs-replay`, with one tweak: the reader returns all parsed objects (not just ones with a model) so the `compare()` function can accurately report `spans_skipped` for both "no model" and "no tokens" reasons.

Token-count extraction tolerates both naming conventions: the SDK's `neatlogs.llm.token_count.prompt` / `completion` and the OpenTelemetry gen-ai `gen_ai.usage.input_tokens` / `output_tokens`. Falls back to whichever is present.

### Cost engine

For each (span, model) pair:

1. Resolve the model key: `provider/model` exact, then provider-agnostic fallback.
2. Detect long-context tier crossings: per-side, the higher of input/output rate above the threshold wins. Conservative when both cross.
3. Compute `tokens / 1M * rate` per usage type (input, output, cache_read, cache_write, reasoning).
4. Mark `incompatible=True` if the span uses prompt cache against a model that doesn't support it, or reasoning tokens against a non-reasoning model. The span contributes $0 to the total in that case.

### Capability diff

For each alternative vs the baseline, list capabilities the baseline has that the alternative lacks. Surfaced as a "Capability diff" section in the text output and a `missing_capabilities` list per row in the JSON output.

### Forecast mode

Single-point estimate: every call uses the same average prompt/completion token count. Cache hit rate converts a fraction of prompt tokens to cache_read (and the rest to cache_creation, mirroring OpenAI's split). Detects explicit incompatible requests (cache_hit_rate > 0 against a no-cache model) and surfaces them as `incompatible=True` with notes.

## Files

- `neatlogs/cost.py` (new, ~1100 lines): parser, pricing catalog loader, cost engine, comparison, forecast, three formatters, CLI.
- `neatlogs/config/pricing.json` (new, ~200 lines): bundled pricing for ~30 headline models with capability flags and tiered pricing.
- `tests/unit/test_cost.py` (new, ~1200 lines, **118 unit tests**, **96% coverage** of `neatlogs/cost.py`): covers the parser, catalog, cost engine, tier logic, capability diff, all three output formats, both CLI modes, and edge cases (malformed lines, missing tokens, missing model, unknown candidate, cache on no-cache model, reasoning on non-reasoning model, tier boundary).
- `pyproject.toml` (modified): `[project.scripts]` entry for `neatlogs-compare`.

## Testing

```
pytest -q tests/unit/test_cost.py     # 118 passed
black --check neatlogs tests           # clean
isort --check-only neatlogs tests      # clean
```

Manually verified on `logs/spans_raw_optimized.log` (9 LLM spans, 2 distinct models). Hand-checked totals for all three output formats. Verified tiered pricing: a 300K-input-token span against `claude-3-5-sonnet-latest` correctly bills input at $6.00/1M (the >200K rate) instead of the $3.00/1M base.

Coverage of the engine / comparison / format / CLI code is 96% (the 4% gap is defensive code paths and the unreachable `assert chosen is not None`).

## Why this and not the alternatives

- **litellm's `model_prices_and_context_window.json`**: 12k lines, prices go stale weekly. We cherry-pick the models the Neatlogs SDK already wraps. Users who need more can pass `--pricing-file` with their own fork of the LiteLLM file.
- **SDK-side `neatlogs.llm.cost_usd` attribute**: requires every wrapper to maintain pricing. Better to compute in a separate tool that reads what's already there.
- **Live HTTP fetch of each provider's pricing page**: most don't expose one. Offline users would be locked out.
- **Web UI**: locks the value behind a sign-in. Users want local, scriptable, and CI-friendly.
- **Token counting without API calls** (tiktoken, anthropic-count-tokens): a different problem. The engine works on tokens already in the span; users count them however they want.

## Risks

- **Pricing data is dated** — same risk every cost tracker has. The bundled table lists `last_updated` in `_meta`. The `--pricing-file` / `NEATLOGS_PRICING_FILE` override is the documented mitigation.
- **Capability detection is heuristic** for proxy providers (OpenRouter, LiteLLM). The engine falls back to a model-only search; users with non-standard deployments override per-model.
- **Token counts may be missing on some spans** (e.g. failed calls) — the engine skips them and reports `spans_skipped` in the output so the user knows.
- **Long-context tier rate is conservative when both sides cross** — picks the more expensive tier. This is the safer default; users who want exact billing can override per-model.
