### PR TITLE
feat(intel): add neatlogs-eval cost intelligence engine with PricingProvider chain

### DIFF
--- a/neatlogs/config/pricing.json
+++ b/neatlogs/config/pricing.json
@@ -1,0 +1,212 @@
+{
+  "_meta": {
+    "currency": "USD",
+    "units": "per_1m_tokens",
+    "schema_version": "2.0",
+    "notes": "v2 schema: usage_types is a dict mapping usage type → USD per 1M tokens. Capabilities is a list of strings. Tiers are a per-usage-type list of {above_tokens, rate} entries (Langfuse convention). Override via --pricing-file or NEATLOGS_PRICING_FILE.",
+    "last_updated": "2026-07"
+  },
+  "models": {
+    "openai/gpt-5": {
+      "provider": "openai",
+      "context_window": 400000,
+      "capabilities": ["tools", "json_mode", "vision", "reasoning"],
+      "usage_types": {"input": 1.25, "output": 10.00}
+    },
+    "openai/gpt-5-mini": {
+      "provider": "openai",
+      "context_window": 400000,
+      "capabilities": ["tools", "json_mode", "vision", "reasoning"],
+      "usage_types": {"input": 0.25, "output": 2.00}
+    },
+    "openai/gpt-5-nano": {
+      "provider": "openai",
+      "context_window": 400000,
+      "capabilities": ["tools", "json_mode", "vision", "reasoning"],
+      "usage_types": {"input": 0.05, "output": 0.40}
+    },
+    "openai/gpt-4.1": {
+      "provider": "openai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 2.00, "output": 8.00, "cache_read": 0.50}
+    },
+    "openai/gpt-4.1-mini": {
+      "provider": "openai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.40, "output": 1.60, "cache_read": 0.10}
+    },
+    "openai/gpt-4.1-nano": {
+      "provider": "openai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.10, "output": 0.40, "cache_read": 0.025}
+    },
+    "openai/gpt-4o": {
+      "provider": "openai",
+      "context_window": 128000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 2.50, "output": 10.00, "cache_read": 1.25}
+    },
+    "openai/gpt-4o-mini": {
+      "provider": "openai",
+      "context_window": 128000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.15, "output": 0.60, "cache_read": 0.075}
+    },
+    "openai/gpt-4o-mini-2024-07-18": {
+      "provider": "openai",
+      "context_window": 128000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.15, "output": 0.60, "cache_read": 0.075}
+    },
+    "openai/o1": {
+      "provider": "openai",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+      "usage_types": {"input": 15.00, "output": 60.00, "reasoning": 60.00, "cache_read": 7.50}
+    },
+    "openai/o1-mini": {
+      "provider": "openai",
+      "context_window": 128000,
+      "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+      "usage_types": {"input": 3.00, "output": 12.00, "reasoning": 12.00, "cache_read": 1.50}
+    },
+    "openai/o3": {
+      "provider": "openai",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+      "usage_types": {"input": 10.00, "output": 40.00, "reasoning": 40.00, "cache_read": 5.00}
+    },
+    "openai/o3-mini": {
+      "provider": "openai",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+      "usage_types": {"input": 1.10, "output": 4.40, "reasoning": 4.40, "cache_read": 0.55}
+    },
+    "openai/o4-mini": {
+      "provider": "openai",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+      "usage_types": {"input": 1.10, "output": 4.40, "reasoning": 4.40, "cache_read": 0.55}
+    },
+    "openai/text-embedding-3-small": {
+      "provider": "openai",
+      "context_window": 8191,
+      "capabilities": ["embedding"],
+      "usage_types": {"input": 0.02, "output": 0.0}
+    },
+    "openai/text-embedding-3-large": {
+      "provider": "openai",
+      "context_window": 8191,
+      "capabilities": ["embedding"],
+      "usage_types": {"input": 0.13, "output": 0.0}
+    },
+    "anthropic/claude-opus-4-1": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 15.00, "output": 75.00, "cache_write": 18.75, "cache_read": 1.50}
+    },
+    "anthropic/claude-opus-4": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 15.00, "output": 75.00, "cache_write": 18.75, "cache_read": 1.50}
+    },
+    "anthropic/claude-sonnet-4": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 3.00, "output": 15.00, "cache_write": 3.75, "cache_read": 0.30},
+      "tiers": {"input": [{"above_tokens": 200000, "rate": 6.00}], "output": [{"above_tokens": 200000, "rate": 22.50}]}
+    },
+    "anthropic/claude-3-7-sonnet-latest": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 3.00, "output": 15.00, "cache_write": 3.75, "cache_read": 0.30},
+      "tiers": {"input": [{"above_tokens": 200000, "rate": 6.00}], "output": [{"above_tokens": 200000, "rate": 22.50}]}
+    },
+    "anthropic/claude-3-5-sonnet-latest": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 3.00, "output": 15.00, "cache_write": 3.75, "cache_read": 0.30}
+    },
+    "anthropic/claude-3-5-haiku-latest": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.80, "output": 4.00, "cache_write": 1.00, "cache_read": 0.08}
+    },
+    "anthropic/claude-3-haiku-20240307": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.25, "output": 1.25, "cache_write": 0.30, "cache_read": 0.03}
+    },
+    "google_genai/gemini-2.5-pro": {
+      "provider": "google_genai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode"],
+      "usage_types": {"input": 1.25, "output": 10.00},
+      "tiers": {"input": [{"above_tokens": 200000, "rate": 2.50}], "output": [{"above_tokens": 200000, "rate": 15.00}]}
+    },
+    "google_genai/gemini-2.5-flash": {
+      "provider": "google_genai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode"],
+      "usage_types": {"input": 0.30, "output": 2.50}
+    },
+    "google_genai/gemini-2.0-flash": {
+      "provider": "google_genai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode"],
+      "usage_types": {"input": 0.10, "output": 0.40}
+    },
+    "google_genai/gemini-1.5-pro": {
+      "provider": "google_genai",
+      "context_window": 2000000,
+      "capabilities": ["vision", "tools", "json_mode"],
+      "usage_types": {"input": 1.25, "output": 5.00}
+    },
+    "google_genai/gemini-1.5-flash": {
+      "provider": "google_genai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode"],
+      "usage_types": {"input": 0.075, "output": 0.30}
+    },
+    "deepseek/deepseek-chat": {
+      "provider": "deepseek",
+      "context_window": 128000,
+      "capabilities": ["tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.27, "output": 1.10, "cache_read": 0.07}
+    },
+    "deepseek/deepseek-reasoner": {
+      "provider": "deepseek",
+      "context_window": 128000,
+      "capabilities": ["reasoning"],
+      "usage_types": {"input": 0.55, "output": 2.19, "reasoning": 2.19}
+    },
+    "groq/llama-3.1-70b-versatile": {
+      "provider": "groq",
+      "context_window": 128000,
+      "capabilities": ["tools", "json_mode"],
+      "usage_types": {"input": 0.59, "output": 0.79}
+    },
+    "groq/llama-3.1-8b-instant": {
+      "provider": "groq",
+      "context_window": 128000,
+      "capabilities": ["tools", "json_mode"],
+      "usage_types": {"input": 0.05, "output": 0.08}
+    },
+    "groq/llama-3.3-70b-versatile": {
+      "provider": "groq",
+      "context_window": 128000,
+      "capabilities": ["tools", "json_mode"],
+      "usage_types": {"input": 0.59, "output": 0.79}
+    }
+  }
+}

--- a/neatlogs/intel.py
+++ b/neatlogs/intel.py
@@ -1,0 +1,1267 @@
+"""
+LLM cost intelligence engine.
+
+Given a historical span log and a list of candidate ``provider/model``
+keys, answer the question finance and engineering teams actually ask:
+
+    "Which of these models is the cheapest one that can still serve
+    the same workload?"
+
+The engine reads span JSONL logs, builds a workload profile (token
+P50/P90/P99, capability usage, cache + reasoning totals), scores every
+candidate model against that profile, and reports:
+
+* per-model cost of replaying the workload
+* capability compatibility (what fraction of spans can be served)
+* the capability gap when a model can't serve the workload
+* ranking: baseline first, then compatible-cheap, then incompatible
+
+Pricing is decoupled from the engine via a ``PricingProvider`` chain,
+so users can override rates per-environment, fetch a remote catalog,
+or plug in LiteLLM's mirror without touching core code.
+
+CLI::
+
+    neatlogs-eval spans.log \\
+        --candidates openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3-5-haiku-latest \\
+        --baseline openai/gpt-4o-mini
+
+Programmatic::
+
+    from neatlogs.intel import (
+        evaluate_workload, BuiltinProvider, CustomProvider, ChainProvider,
+        WorkloadConstraints, format_evaluation,
+    )
+    chain = ChainProvider([CustomProvider("my-rates.json"), BuiltinProvider()])
+    report = evaluate_workload(
+        paths=["spans.log"],
+        candidates=["openai/gpt-4o-mini", "openai/gpt-4o"],
+        baseline="openai/gpt-4o-mini",
+        constraints=WorkloadConstraints(need_capabilities={"vision", "tools"}),
+        pricing=chain,
+    )
+    print(format_evaluation(report, "text"))
+"""
+
+from __future__ import annotations
+
+import abc
+import argparse
+import csv
+import dataclasses
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    TextIO,
+    Tuple,
+    Union,
+)
+
+PathLike = Union[str, os.PathLike]
+
+
+# ---------------------------------------------------------------------------
+# Capabilities
+# ---------------------------------------------------------------------------
+
+
+class Capability:
+    """Standard capability names. The catalog is a free-form set, so
+    third-party providers can extend this without code changes —
+    ``is_compatible`` only fails closed on explicit declarations."""
+
+    VISION = "vision"
+    TOOLS = "tools"
+    JSON_MODE = "json_mode"
+    PROMPT_CACHE = "prompt_cache"
+    REASONING = "reasoning"
+    AUDIO = "audio"
+    IMAGE_INPUT = "image_input"
+    EMBEDDING = "embedding"
+
+
+class UsageType:
+    """Standard usage type names. The ``usage_types`` dict on a
+    ``ModelDefinition`` can contain any string key, so this list is
+    documentation rather than a closed enum."""
+
+    INPUT = "input"
+    OUTPUT = "output"
+    CACHE_READ = "cache_read"
+    CACHE_WRITE = "cache_write"
+    REASONING = "reasoning"
+    IMAGE = "image"
+    AUDIO = "audio"
+
+
+# ---------------------------------------------------------------------------
+# Span reading (lightweight — we only need token counts and model name)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SpanUsage:
+    span_id: str
+    trace_id: str
+    model: str
+    provider: Optional[str]
+    prompt_tokens: int
+    completion_tokens: int
+    cache_creation_tokens: int
+    cache_read_tokens: int
+    reasoning_tokens: int
+
+    @property
+    def input_total(self) -> int:
+        """Total input side: prompt + cache_read + cache_creation."""
+        return self.prompt_tokens + self.cache_creation_tokens + self.cache_read_tokens
+
+    @property
+    def output_total(self) -> int:
+        """Total output side: completion + reasoning."""
+        return self.completion_tokens + self.reasoning_tokens
+
+    @property
+    def has_tokens(self) -> bool:
+        return any(
+            t > 0
+            for t in (
+                self.prompt_tokens,
+                self.completion_tokens,
+                self.cache_creation_tokens,
+                self.cache_read_tokens,
+                self.reasoning_tokens,
+            )
+        )
+
+    @property
+    def uses_prompt_cache(self) -> bool:
+        return self.cache_creation_tokens > 0 or self.cache_read_tokens > 0
+
+    @property
+    def uses_reasoning(self) -> bool:
+        return self.reasoning_tokens > 0
+
+
+def _int_attr(attrs: Dict[str, Any], *keys: str) -> int:
+    for k in keys:
+        v = attrs.get(k)
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, int) and v >= 0:
+            return v
+        if isinstance(v, float) and v.is_integer() and v >= 0:
+            return int(v)
+    return 0
+
+
+def _extract_usage(obj: Dict[str, Any]) -> SpanUsage:
+    attrs = obj.get("attributes") or {}
+    if not isinstance(attrs, dict):
+        attrs = {}
+    model = (
+        attrs.get("neatlogs.llm.model_name")
+        or attrs.get("gen_ai.response.model")
+        or attrs.get("gen_ai.request.model")
+        or ""
+    )
+    provider = (
+        attrs.get("neatlogs.llm.provider")
+        or attrs.get("neatlogs.llm.system")
+        or attrs.get("gen_ai.system")
+    )
+    if isinstance(provider, str):
+        provider = provider.lower() or None
+    return SpanUsage(
+        span_id=str(obj.get("span_id") or obj.get("context", {}).get("span_id") or ""),
+        trace_id=str(obj.get("trace_id") or obj.get("context", {}).get("trace_id") or ""),
+        model=str(model),
+        provider=provider,
+        prompt_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.prompt",
+            "gen_ai.usage.input_tokens",
+            "gen_ai.usage.prompt_tokens",
+        ),
+        completion_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.completion",
+            "gen_ai.usage.output_tokens",
+            "gen_ai.usage.completion_tokens",
+        ),
+        cache_creation_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.cache_creation",
+            "gen_ai.usage.cache_creation_input_tokens",
+        ),
+        cache_read_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.cache_read",
+            "gen_ai.usage.cache_read_input_tokens",
+        ),
+        reasoning_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.reasoning",
+            "gen_ai.usage.reasoning_tokens",
+        ),
+    )
+
+
+def _iter_json_objects(text: str) -> Iterator[Dict[str, Any]]:
+    """Brace-balanced parser; tolerates newlines inside string values."""
+    depth = 0
+    start = -1
+    in_string = False
+    escape = False
+    for i, ch in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                try:
+                    yield json.loads(text[start : i + 1])
+                except json.JSONDecodeError:
+                    pass
+                start = -1
+            elif depth < 0:
+                depth = 0
+
+
+def _read_usages(path: PathLike) -> List[SpanUsage]:
+    p = Path(path)
+    if not p.exists():
+        return []
+    text = p.read_text(encoding="utf-8", errors="replace")
+    if not text.strip():
+        return []
+    return [_extract_usage(obj) for obj in _iter_json_objects(text) if isinstance(obj, dict)]
+
+
+def _read_paths(paths: Sequence[PathLike]) -> List[SpanUsage]:
+    out: List[SpanUsage] = []
+    for raw in paths:
+        out.extend(_read_usages(raw))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Pricing
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class Tier:
+    """A single tiered rate: if the usage count is strictly above
+    ``above_tokens``, use ``rate`` instead of the base rate. A model
+    with multiple tiers picks the largest ``above_tokens`` that is
+    crossed."""
+
+    above_tokens: int
+    rate: float
+
+
+@dataclasses.dataclass
+class ModelDefinition:
+    """Pricing and capability data for one model.
+
+    ``usage_types`` maps a usage type (``"input"``, ``"output"``,
+    ``"cache_read"``, ``"cache_write"``, ``"reasoning"``,
+    ``"image"``, ``"audio"``, ...) to USD per 1M tokens. Missing
+    keys mean that usage type is not billed (or not supported).
+
+    ``tiers`` is a per-usage-type list of ``Tier`` entries. When a
+    span's token count crosses a tier threshold, that tier's rate
+    is used. The largest crossed tier wins.
+    """
+
+    model_key: str  # "provider/model"
+    provider: str
+    context_window: Optional[int] = None
+    capabilities: Set[str] = dataclasses.field(default_factory=set)
+    usage_types: Dict[str, float] = dataclasses.field(default_factory=dict)
+    tiers: Dict[str, List[Tier]] = dataclasses.field(default_factory=dict)
+
+    def rate_for(self, usage_type: str) -> Optional[float]:
+        """Base rate for a usage type, or None if the model doesn't
+        bill for it. Does not consider tiers."""
+        return self.usage_types.get(usage_type)
+
+    def effective_rate(self, usage_type: str, count: int) -> Optional[float]:
+        """Effective rate for a usage type at a given token count,
+        taking tiers into account. ``None`` if not billed."""
+        base = self.rate_for(usage_type)
+        if base is None:
+            return None
+        if count <= 0 or usage_type not in self.tiers:
+            return base
+        crossed = [t for t in self.tiers[usage_type] if t.above_tokens < count]
+        if not crossed:
+            return base
+        return max(crossed, key=lambda t: t.above_tokens).rate
+
+    def has_capability(self, cap: str) -> bool:
+        return cap in self.capabilities
+
+    def has_all_capabilities(self, caps: Iterable[str]) -> bool:
+        return all(c in self.capabilities for c in caps)
+
+    def missing_capabilities(self, caps: Iterable[str]) -> Set[str]:
+        return {c for c in caps if c not in self.capabilities}
+
+
+class PricingProvider(abc.ABC):
+    """Source of ``ModelDefinition`` for a given model key.
+
+    Implementations include ``BuiltinProvider`` (bundled JSON),
+    ``CustomProvider`` (user-supplied override file), and any future
+    HTTP-backed or litellm-mirror provider. ``ChainProvider`` composes
+    multiple providers in priority order.
+    """
+
+    @abc.abstractmethod
+    def lookup(self, model_key: str) -> Optional[ModelDefinition]: ...
+
+    def lookup_by_provider_and_name(
+        self, provider: Optional[str], model_name: str
+    ) -> Optional[ModelDefinition]:
+        return None
+
+
+def _build_def(key: str, raw: Dict[str, Any]) -> Optional[ModelDefinition]:
+    if not isinstance(raw, dict):
+        return None
+    provider = str(raw.get("provider", "")).lower()
+    if "/" not in key or not provider:
+        return None
+    caps_raw = raw.get("capabilities") or []
+    if not isinstance(caps_raw, list):
+        caps_raw = []
+    capabilities = {str(c) for c in caps_raw if isinstance(c, str)}
+    usage_types_raw = raw.get("usage_types") or {}
+    if not isinstance(usage_types_raw, dict):
+        usage_types_raw = {}
+    usage_types = {
+        str(k): float(v) for k, v in usage_types_raw.items() if isinstance(v, (int, float))
+    }
+    tiers_raw = raw.get("tiers") or {}
+    if not isinstance(tiers_raw, dict):
+        tiers_raw = {}
+    tiers: Dict[str, List[Tier]] = {}
+    for usage_type, entries in tiers_raw.items():
+        if not isinstance(entries, list):
+            continue
+        out_entries: List[Tier] = []
+        for e in entries:
+            if (
+                isinstance(e, dict)
+                and isinstance(e.get("above_tokens"), int)
+                and isinstance(e.get("rate"), (int, float))
+            ):
+                out_entries.append(Tier(above_tokens=e["above_tokens"], rate=float(e["rate"])))
+        if out_entries:
+            tiers[str(usage_type)] = out_entries
+    cw_raw = raw.get("context_window")
+    context_window = cw_raw if isinstance(cw_raw, int) and not isinstance(cw_raw, bool) else None
+    return ModelDefinition(
+        model_key=key,
+        provider=provider,
+        context_window=context_window,
+        capabilities=capabilities,
+        usage_types=usage_types,
+        tiers=tiers,
+    )
+
+
+class BuiltinProvider(PricingProvider):
+    """Reads ``neatlogs/config/pricing.json``."""
+
+    def __init__(self, path: Optional[PathLike] = None):
+        src = Path(path) if path is not None else Path(__file__).parent / "config" / "pricing.json"
+        with open(src, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self._models: Dict[str, ModelDefinition] = {}
+        self._by_pn: Dict[Tuple[str, str], str] = {}
+        for key, raw in (data.get("models") or {}).items():
+            d = _build_def(key, raw)
+            if d is not None:
+                self._models[key] = d
+                self._by_pn[(d.provider, key.split("/", 1)[1])] = key
+
+    def lookup(self, model_key: str) -> Optional[ModelDefinition]:
+        return self._models.get(model_key)
+
+    def lookup_by_provider_and_name(
+        self, provider: Optional[str], model_name: str
+    ) -> Optional[ModelDefinition]:
+        if provider:
+            key = self._by_pn.get((provider.lower(), model_name))
+            if key:
+                return self._models.get(key)
+            return None
+        for prov, name in self._by_pn.keys():
+            if name == model_name:
+                return self._models.get(self._by_pn[(prov, name)])
+        return None
+
+
+class CustomProvider(PricingProvider):
+    """A user-supplied override file. Sits on top of the builtin catalog
+    in a ``ChainProvider`` so the override wins for any model it declares
+    and falls through for everything else.
+    """
+
+    def __init__(self, path: PathLike):
+        self._path = Path(path)
+        with open(self._path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self._models: Dict[str, ModelDefinition] = {}
+        self._by_pn: Dict[Tuple[str, str], str] = {}
+        for key, raw in (data.get("models") or {}).items():
+            d = _build_def(key, raw)
+            if d is not None:
+                self._models[key] = d
+                self._by_pn[(d.provider, key.split("/", 1)[1])] = key
+
+    def lookup(self, model_key: str) -> Optional[ModelDefinition]:
+        return self._models.get(model_key)
+
+    def lookup_by_provider_and_name(
+        self, provider: Optional[str], model_name: str
+    ) -> Optional[ModelDefinition]:
+        if provider:
+            key = self._by_pn.get((provider.lower(), model_name))
+            if key:
+                return self._models.get(key)
+            return None
+        for prov, name in self._by_pn.keys():
+            if name == model_name:
+                return self._models.get(self._by_pn[(prov, name)])
+        return None
+
+
+class ChainProvider(PricingProvider):
+    """Composes a list of providers in priority order. The first one
+    to return a non-None result wins. Matches the Langfuse model-
+    definition resolution pattern: custom override first, then bundled
+    catalog, then fallback to provider alias / regex / heuristic.
+    """
+
+    def __init__(self, providers: Sequence[PricingProvider]):
+        self._providers = list(providers)
+
+    def lookup(self, model_key: str) -> Optional[ModelDefinition]:
+        for p in self._providers:
+            r = p.lookup(model_key)
+            if r is not None:
+                return r
+        return None
+
+    def lookup_by_provider_and_name(
+        self, provider: Optional[str], model_name: str
+    ) -> Optional[ModelDefinition]:
+        for p in self._providers:
+            r = p.lookup_by_provider_and_name(provider, model_name)
+            if r is not None:
+                return r
+        return None
+
+
+def default_chain(pricing_file: Optional[PathLike] = None) -> ChainProvider:
+    """Build the default chain: optional user override, then bundled."""
+    providers: List[PricingProvider] = []
+    if pricing_file is not None:
+        providers.append(CustomProvider(pricing_file))
+    elif os.environ.get("NEATLOGS_PRICING_FILE"):
+        providers.append(CustomProvider(os.environ["NEATLOGS_PRICING_FILE"]))
+    providers.append(BuiltinProvider())
+    return ChainProvider(providers)
+
+
+# ---------------------------------------------------------------------------
+# Workload profile
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class TokenStats:
+    """Lightweight summary of a token distribution."""
+
+    p50: int
+    p90: int
+    p99: int
+    max: int
+    total: int
+
+    @classmethod
+    def from_values(cls, values: Sequence[int]) -> "TokenStats":
+        if not values:
+            return cls(0, 0, 0, 0, 0)
+        sorted_vals = sorted(values)
+        n = len(sorted_vals)
+
+        def pct(p: float) -> int:
+            # Floor: "lower" percentile. For [1..100] p50 is 50 (sorted_vals[49]).
+            idx = min(int(p * (n - 1)), n - 1)
+            return sorted_vals[idx]
+
+        return cls(
+            p50=pct(0.50),
+            p90=pct(0.90),
+            p99=pct(0.99),
+            max=sorted_vals[-1],
+            total=sum(sorted_vals),
+        )
+
+
+@dataclasses.dataclass
+class WorkloadProfile:
+    """Summary of a span log, derived once and reused by the evaluator."""
+
+    total_spans: int
+    spans_with_tokens: int
+    spans_skipped: int
+    models_used: Set[str]
+    capabilities_inferred: Set[str]
+    prompt_stats: TokenStats
+    completion_stats: TokenStats
+    cache_read_total: int
+    cache_write_total: int
+    reasoning_total: int
+    files_read: int
+
+    @property
+    def needs_cache(self) -> bool:
+        return (self.cache_read_total + self.cache_write_total) > 0
+
+    @property
+    def needs_reasoning(self) -> bool:
+        return self.reasoning_total > 0
+
+
+def _resolve_definition(usage: SpanUsage, pricing: PricingProvider) -> Optional[ModelDefinition]:
+    if not usage.model:
+        return None
+    if usage.provider:
+        candidate = f"{usage.provider}/{usage.model}"
+        d = pricing.lookup(candidate)
+        if d is not None:
+            return d
+    return pricing.lookup_by_provider_and_name(usage.provider, usage.model)
+
+
+def build_workload_profile(
+    paths: Sequence[PathLike],
+    pricing: PricingProvider,
+    *,
+    auto_infer_capabilities: bool = True,
+) -> Tuple[WorkloadProfile, List[SpanUsage]]:
+    """Read span logs, derive a profile, and return ``(profile, usages)``.
+
+    ``auto_infer_capabilities`` (default True) infers the capability set
+    the workload needs from the source models in the log. A workload
+    that ran on ``gpt-4o-mini`` is assumed to need whatever
+    ``gpt-4o-mini`` supports. The user can override via
+    ``WorkloadConstraints.need_capabilities``.
+    """
+    usages = _read_paths(paths)
+    files_read = sum(1 for p in paths if Path(p).exists())
+    with_tokens = [u for u in usages if u.model and u.has_tokens]
+    skipped = len(usages) - len(with_tokens)
+    models_used: Set[str] = set()
+    capabilities: Set[str] = set()
+    prompt_vals: List[int] = []
+    completion_vals: List[int] = []
+    cache_read_total = 0
+    cache_write_total = 0
+    reasoning_total = 0
+    for u in with_tokens:
+        models_used.add(f"{u.provider}/{u.model}" if u.provider else u.model)
+        prompt_vals.append(u.prompt_tokens)
+        completion_vals.append(u.completion_tokens)
+        cache_read_total += u.cache_read_tokens
+        cache_write_total += u.cache_creation_tokens
+        reasoning_total += u.reasoning_tokens
+        if auto_infer_capabilities:
+            d = _resolve_definition(u, pricing)
+            if d is not None:
+                capabilities.update(d.capabilities)
+    profile = WorkloadProfile(
+        total_spans=len(usages),
+        spans_with_tokens=len(with_tokens),
+        spans_skipped=skipped,
+        models_used=models_used,
+        capabilities_inferred=capabilities,
+        prompt_stats=TokenStats.from_values(prompt_vals),
+        completion_stats=TokenStats.from_values(completion_vals),
+        cache_read_total=cache_read_total,
+        cache_write_total=cache_write_total,
+        reasoning_total=reasoning_total,
+        files_read=files_read,
+    )
+    return profile, with_tokens
+
+
+# ---------------------------------------------------------------------------
+# Constraints
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class WorkloadConstraints:
+    """What a candidate model must satisfy to be considered.
+
+    ``need_capabilities``: set of capability strings the candidate must
+    declare. Missing one is a hard fail.
+    ``min_context_window``: candidate's ``context_window`` must be ``>=``
+    this value. ``0`` (default) means no constraint.
+    ``min_compatibility_pct``: minimum fraction of spans (by count) the
+    candidate can serve. Default 0.95 = "you can switch 95% of the
+    workload to this model".
+    """
+
+    need_capabilities: Set[str] = dataclasses.field(default_factory=set)
+    min_context_window: int = 0
+    min_compatibility_pct: float = 0.95
+
+    def explains(self) -> List[str]:
+        """Human-readable summary of active constraints."""
+        out: List[str] = []
+        if self.need_capabilities:
+            out.append(f"need capabilities: {sorted(self.need_capabilities)}")
+        if self.min_context_window > 0:
+            out.append(f"min context: {self.min_context_window:,} tokens")
+        if self.min_compatibility_pct > 0:
+            out.append(f"min compatibility: {self.min_compatibility_pct * 100:.0f}%")
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SpanVerdict:
+    """One span's compatibility with one candidate model."""
+
+    span_id: str
+    compatible: bool
+    reasons: List[str] = dataclasses.field(default_factory=list)
+    cost: float = 0.0
+
+
+def _span_cost(usage: SpanUsage, model: ModelDefinition) -> float:
+    """Cost of one span on one model. Returns 0 for incompatible spans.
+    Tiered pricing is applied per usage type.
+    """
+    # Required usage type: at least one of input/output must be billed.
+    in_rate = model.effective_rate(UsageType.INPUT, usage.prompt_tokens)
+    out_rate = model.effective_rate(UsageType.OUTPUT, usage.completion_tokens)
+    if in_rate is None and out_rate is None:
+        return 0.0
+    cost = 0.0
+    if in_rate is not None:
+        cost += (usage.prompt_tokens / 1_000_000) * in_rate
+    if out_rate is not None:
+        cost += (usage.completion_tokens / 1_000_000) * out_rate
+    # Cache: model supports it AND user used it.
+    if usage.cache_creation_tokens > 0:
+        rate = model.effective_rate(UsageType.CACHE_WRITE, usage.cache_creation_tokens)
+        if rate is not None:
+            cost += (usage.cache_creation_tokens / 1_000_000) * rate
+    if usage.cache_read_tokens > 0:
+        rate = model.effective_rate(UsageType.CACHE_READ, usage.cache_read_tokens)
+        if rate is not None:
+            cost += (usage.cache_read_tokens / 1_000_000) * rate
+    # Reasoning: model supports it AND user used it.
+    if usage.reasoning_tokens > 0:
+        rate = model.effective_rate(UsageType.REASONING, usage.reasoning_tokens)
+        if rate is not None:
+            cost += (usage.reasoning_tokens / 1_000_000) * rate
+    return cost
+
+
+def _is_span_compatible(
+    usage: SpanUsage, model: ModelDefinition, constraints: WorkloadConstraints
+) -> Tuple[bool, List[str]]:
+    reasons: List[str] = []
+    compatible = True
+    # Context window: prompt tokens must fit (with some headroom for the
+    # response; we don't know the response size at planning time, so use
+    # the request input as a conservative lower bound).
+    if constraints.min_context_window > 0:
+        if model.context_window is None:
+            compatible = False
+            reasons.append(
+                f"min context {constraints.min_context_window:,} required; model has no declared context"
+            )
+        elif model.context_window < usage.input_total:
+            compatible = False
+            reasons.append(f"prompt {usage.input_total:,} > context {model.context_window:,}")
+    # Capabilities the workload needs that the model lacks.
+    missing = model.missing_capabilities(constraints.need_capabilities)
+    if missing:
+        compatible = False
+        reasons.append(f"missing {sorted(missing)}")
+    # Span-specific capability inference: cache used, no cache support.
+    if (
+        usage.uses_prompt_cache
+        and UsageType.CACHE_READ not in model.usage_types
+        and UsageType.CACHE_WRITE not in model.usage_types
+    ):
+        compatible = False
+        reasons.append("used cache; model has no cache rate")
+    if usage.uses_reasoning and UsageType.REASONING not in model.usage_types:
+        compatible = False
+        reasons.append("used reasoning; model has no reasoning rate")
+    return compatible, reasons
+
+
+def _score_model(
+    model: ModelDefinition,
+    usages: List[SpanUsage],
+    constraints: WorkloadConstraints,
+    is_baseline: bool,
+) -> "ScoredModel":
+    """Score one candidate model against the workload."""
+    per_span: List[SpanVerdict] = []
+    for u in usages:
+        ok, reasons = _is_span_compatible(u, model, constraints)
+        cost = _span_cost(u, model) if ok else 0.0
+        per_span.append(SpanVerdict(span_id=u.span_id, compatible=ok, reasons=reasons, cost=cost))
+    compatible_spans = sum(1 for v in per_span if v.compatible)
+    total = sum(v.cost for v in per_span)
+    compat_pct = compatible_spans / len(per_span) if per_span else 0.0
+    meets_pct = compat_pct >= constraints.min_compatibility_pct
+    return ScoredModel(
+        model_key=model.model_key,
+        provider=model.provider,
+        total_cost=total,
+        compatible_spans=compatible_spans,
+        total_spans=len(per_span),
+        compatibility_pct=compat_pct,
+        meets_min_compatibility=meets_pct,
+        missing_capabilities=model.missing_capabilities(constraints.need_capabilities),
+        context_window=model.context_window,
+        per_span=per_span,
+        is_baseline=is_baseline,
+    )
+
+
+@dataclasses.dataclass
+class ScoredModel:
+    """One candidate model's score against the workload."""
+
+    model_key: str
+    provider: str
+    total_cost: float
+    compatible_spans: int
+    total_spans: int
+    compatibility_pct: float
+    meets_min_compatibility: bool
+    missing_capabilities: Set[str]
+    context_window: Optional[int]
+    per_span: List[SpanVerdict]
+    is_baseline: bool = False
+
+    @property
+    def rank_key(self) -> Tuple[int, int, float]:
+        """Lower is better. Sort: baseline first, then compatible by
+        cost (cheap first), then incompatible last."""
+        return (
+            0 if self.is_baseline else 1,
+            0 if self.meets_min_compatibility else 1,
+            self.total_cost,
+        )
+
+    @property
+    def delta_pct_vs_baseline(self) -> Optional[float]:
+        return None  # filled in by EvaluationReport
+
+
+@dataclasses.dataclass
+class EvaluationReport:
+    baseline: Optional[ScoredModel]
+    alternatives: List[ScoredModel]
+    profile: WorkloadProfile
+    constraints: WorkloadConstraints
+    explicit_constraints: WorkloadConstraints
+    unknown_models: List[str]
+    files_read: int
+
+    def all(self) -> List[ScoredModel]:
+        if self.baseline is None:
+            return list(self.alternatives)
+        return [self.baseline] + self.alternatives
+
+    def delta_pct_for(self, sm: ScoredModel) -> Optional[float]:
+        if self.baseline is None or sm.is_baseline:
+            return None
+        if self.baseline.total_cost == 0:
+            return None
+        return (sm.total_cost - self.baseline.total_cost) / self.baseline.total_cost * 100.0
+
+    def ranked(self) -> List[ScoredModel]:
+        """All candidates sorted: baseline first, then compatible by
+        cost, then incompatible last."""
+        return sorted(self.all(), key=lambda s: s.rank_key)
+
+    def find(self, model_key: str) -> Optional[ScoredModel]:
+        for sm in self.all():
+            if sm.model_key == model_key:
+                return sm
+        return None
+
+
+def evaluate_workload(
+    paths: Union[PathLike, Sequence[PathLike]],
+    *,
+    candidates: Sequence[str],
+    baseline: Optional[str] = None,
+    pricing: Optional[PricingProvider] = None,
+    constraints: Optional[WorkloadConstraints] = None,
+    auto_infer_capabilities: bool = True,
+    warn_stream: Optional[TextIO] = None,
+) -> EvaluationReport:
+    """Read span logs, score every candidate model, return a report.
+
+    Args:
+        paths: one path or a list of paths to span JSONL files.
+        candidates: ``provider/model`` keys to evaluate.
+        baseline: explicit baseline. Defaults to the first candidate.
+        pricing: override the default chain. ``None`` builds the default
+            (custom override from ``--pricing-file`` / ``NEATLOGS_PRICING_FILE``
+            if set, then bundled catalog).
+        constraints: capability / context-window filters. ``None`` = no filter.
+        auto_infer_capabilities: when True (default), capability
+            requirements are inferred from the source models in the
+            workload. When False, only ``constraints.need_capabilities``
+            applies.
+        warn_stream: where to write warnings (unknown models, etc.).
+            Defaults to stderr.
+    """
+    if isinstance(paths, (str, os.PathLike)):
+        seq: List[PathLike] = [paths]
+    else:
+        seq = list(paths)
+    if pricing is None:
+        pricing = default_chain()
+    if constraints is None:
+        constraints = WorkloadConstraints()
+    sink = warn_stream if warn_stream is not None else sys.stderr
+
+    profile, usages = build_workload_profile(
+        seq,
+        pricing,
+        auto_infer_capabilities=auto_infer_capabilities,
+    )
+    # When auto-infer is on, merge inferred capabilities with explicit ones.
+    effective_caps = set(constraints.need_capabilities)
+    if auto_infer_capabilities:
+        effective_caps |= profile.capabilities_inferred
+    effective_constraints = WorkloadConstraints(
+        need_capabilities=effective_caps,
+        min_context_window=constraints.min_context_window,
+        min_compatibility_pct=constraints.min_compatibility_pct,
+    )
+
+    baseline_key = baseline or (candidates[0] if candidates else None)
+    unknown: List[str] = []
+    resolved: Dict[str, ModelDefinition] = {}
+    for key in candidates:
+        d = pricing.lookup(key)
+        if d is None:
+            unknown.append(key)
+        else:
+            resolved[key] = d
+
+    # Build scored models.
+    scored: Dict[str, ScoredModel] = {}
+    for key, d in resolved.items():
+        sm = _score_model(
+            d,
+            usages,
+            effective_constraints,
+            is_baseline=(key == baseline_key),
+        )
+        scored[key] = sm
+    baseline_sm = scored.pop(baseline_key, None) if baseline_key else None
+    alternatives = [scored[k] for k in candidates if k in scored and k != baseline_key]
+
+    # Warnings.
+    for k in sorted(unknown):
+        sink.write(
+            f"[neatlogs-eval] warning: candidate model {k!r} not in pricing catalog; "
+            f"it will be omitted from the report. "
+            f"Override via --pricing-file or update "
+            f"neatlogs/config/pricing.json.\n"
+        )
+
+    return EvaluationReport(
+        baseline=baseline_sm,
+        alternatives=alternatives,
+        profile=profile,
+        constraints=effective_constraints,
+        explicit_constraints=constraints,
+        unknown_models=sorted(unknown),
+        files_read=profile.files_read,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def format_evaluation_text(report: EvaluationReport, *, use_color: bool = True) -> str:
+    buf = io.StringIO()
+    if not report.alternatives and report.baseline is None:
+        buf.write("(no candidate models in the pricing catalog)\n")
+        return buf.getvalue()
+    # Header: workload summary.
+    p = report.profile
+    buf.write(
+        f"Workload: {p.spans_with_tokens} spans across {len(p.models_used)} model(s); "
+        f"prompt p50={p.prompt_stats.p50:,} p99={p.prompt_stats.p99:,} max={p.prompt_stats.max:,} "
+        f"completion p50={p.completion_stats.p50:,} max={p.completion_stats.max:,}\n"
+    )
+    buf.write(f"  models: {sorted(p.models_used)}\n")
+    if p.capabilities_inferred:
+        buf.write(f"  capabilities inferred: {sorted(p.capabilities_inferred)}\n")
+    constraints = report.constraints.explains()
+    if constraints:
+        buf.write(f"  constraints: {'; '.join(constraints)}\n")
+    buf.write("\n")
+
+    # Per-model rows.
+    header = f"{'Model':<34} {'Prov':<12} {'Compat':>7} " f"{'Cost':>10} {'vs base':>10}"
+    buf.write(header + "\n")
+    buf.write("-" * len(header) + "\n")
+    for sm in report.ranked():
+        # For an incompatible model, show $0 — the cost is meaningless
+        # because the user can't actually run on it.
+        cost_disp = f"${sm.total_cost:.4f}" if sm.meets_min_compatibility else "incompatible"
+        if sm.is_baseline:
+            delta_disp = "(baseline)"
+        else:
+            pct = report.delta_pct_for(sm)
+            delta_disp = f"{pct:+.0f}%" if pct is not None else "n/a"
+        compat_disp = f"{sm.compatibility_pct * 100:.0f}%"
+        line = (
+            f"{sm.model_key[:34]:<34} {sm.provider[:12]:<12} "
+            f"{compat_disp:>7} {cost_disp:>10} {delta_disp:>10}"
+        )
+        if use_color:
+            if sm.is_baseline:
+                line = _ansi("1;33", line)
+            elif not sm.meets_min_compatibility:
+                line = _ansi("31", line)
+            elif report.delta_pct_for(sm) is not None and report.delta_pct_for(sm) < 0:
+                line = _ansi("32", line)
+        buf.write(line + "\n")
+    buf.write("-" * len(header) + "\n")
+
+    # Capability gap.
+    if report.baseline is not None:
+        any_gap = any(sm.missing_capabilities for sm in report.alternatives)
+        if any_gap:
+            buf.write("\nCapability gap vs inferred workload needs:\n")
+            for sm in report.alternatives:
+                if sm.missing_capabilities:
+                    buf.write(f"  {sm.model_key}: missing {sorted(sm.missing_capabilities)}\n")
+
+    if p.spans_skipped:
+        buf.write(f"\n({p.spans_skipped} span(s) skipped: no model or no token counts.)\n")
+    return buf.getvalue()
+
+
+def format_evaluation_json(report: EvaluationReport) -> str:
+    def row(sm: ScoredModel) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "model": sm.model_key,
+            "provider": sm.provider,
+            "total_cost": round(sm.total_cost, 6),
+            "compatibility_pct": round(sm.compatibility_pct * 100, 2),
+            "meets_min_compatibility": sm.meets_min_compatibility,
+            "missing_capabilities": sorted(sm.missing_capabilities),
+            "context_window": sm.context_window,
+            "is_baseline": sm.is_baseline,
+        }
+        if not sm.is_baseline and report.baseline is not None:
+            pct = report.delta_pct_for(sm)
+            if pct is not None:
+                d["delta_pct_vs_baseline"] = round(pct, 2)
+        return d
+
+    p = report.profile
+    return (
+        json.dumps(
+            {
+                "currency": "USD",
+                "workload": {
+                    "total_spans": p.total_spans,
+                    "spans_with_tokens": p.spans_with_tokens,
+                    "spans_skipped": p.spans_skipped,
+                    "models_used": sorted(p.models_used),
+                    "capabilities_inferred": sorted(p.capabilities_inferred),
+                    "prompt_stats": {
+                        "p50": p.prompt_stats.p50,
+                        "p90": p.prompt_stats.p90,
+                        "p99": p.prompt_stats.p99,
+                        "max": p.prompt_stats.max,
+                        "total": p.prompt_stats.total,
+                    },
+                    "completion_stats": {
+                        "p50": p.completion_stats.p50,
+                        "p90": p.completion_stats.p90,
+                        "p99": p.completion_stats.p99,
+                        "max": p.completion_stats.max,
+                        "total": p.completion_stats.total,
+                    },
+                },
+                "constraints": {
+                    "need_capabilities": sorted(report.constraints.need_capabilities),
+                    "min_context_window": report.constraints.min_context_window,
+                    "min_compatibility_pct": report.constraints.min_compatibility_pct,
+                },
+                "explicit_constraints": {
+                    "need_capabilities": sorted(report.explicit_constraints.need_capabilities),
+                    "min_context_window": report.explicit_constraints.min_context_window,
+                    "min_compatibility_pct": report.explicit_constraints.min_compatibility_pct,
+                },
+                "baseline": row(report.baseline) if report.baseline else None,
+                "alternatives": [row(sm) for sm in report.alternatives],
+                "ranked": [row(sm) for sm in report.ranked()],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def format_evaluation_csv(report: EvaluationReport) -> str:
+    buf = io.StringIO()
+    w = csv.writer(buf, lineterminator="\n")
+    w.writerow(
+        [
+            "model",
+            "provider",
+            "is_baseline",
+            "total_cost",
+            "compatibility_pct",
+            "meets_min_compatibility",
+            "context_window",
+            "missing_capabilities",
+            "delta_pct_vs_baseline",
+        ]
+    )
+    for sm in report.ranked():
+        pct = report.delta_pct_for(sm)
+        w.writerow(
+            [
+                sm.model_key,
+                sm.provider,
+                "true" if sm.is_baseline else "false",
+                f"{sm.total_cost:.6f}",
+                f"{sm.compatibility_pct * 100:.2f}",
+                "true" if sm.meets_min_compatibility else "false",
+                sm.context_window if sm.context_window is not None else "",
+                ";".join(sorted(sm.missing_capabilities)),
+                "" if pct is None else f"{pct:.2f}",
+            ]
+        )
+    return buf.getvalue()
+
+
+def format_evaluation(
+    report: EvaluationReport,
+    *,
+    style: str = "text",
+    stream: Optional[TextIO] = None,
+) -> str:
+    if style not in ("text", "json", "csv"):
+        raise ValueError(f"unknown style: {style!r}")
+    if style == "json":
+        return format_evaluation_json(report)
+    if style == "csv":
+        return format_evaluation_csv(report)
+    use_color = _supports_color(stream or sys.stdout)
+    return format_evaluation_text(report, use_color=use_color)
+
+
+# ---------------------------------------------------------------------------
+# Color
+# ---------------------------------------------------------------------------
+
+
+_USE_COLOR = True
+
+
+def _supports_color(stream: TextIO) -> bool:
+    if not _USE_COLOR:
+        return False
+    if not hasattr(stream, "isatty"):
+        return False
+    return bool(stream.isatty())
+
+
+def _ansi(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="neatlogs-eval",
+        description=(
+            "Evaluate candidate models against a span-log workload. "
+            "For each candidate, computes the cost of running the same "
+            "workload on that model and reports capability compatibility. "
+            "Ranks compatible + cheap first, incompatible last. This is "
+            "the 'Replay + Model Optimizer' for cost: given a past run, "
+            "find the cheapest model that can still serve it."
+        ),
+    )
+    p.add_argument("paths", nargs="+", help="One or more span log file paths.")
+    p.add_argument(
+        "--candidates",
+        required=True,
+        help=(
+            "Comma-separated list of `provider/model` keys to evaluate. "
+            "The first one is the baseline; use --baseline to override."
+        ),
+    )
+    p.add_argument(
+        "--baseline",
+        default=None,
+        help="Explicit baseline model key. Default: first --candidates entry.",
+    )
+    p.add_argument(
+        "--need",
+        action="append",
+        default=[],
+        help=(
+            "Require a capability (repeatable). Values: vision, tools, "
+            "json_mode, prompt_cache, reasoning, audio, image_input, "
+            "embedding. By default the engine infers capability needs "
+            "from the source models in the log; --need adds to the set."
+        ),
+    )
+    p.add_argument(
+        "--min-context",
+        type=int,
+        default=0,
+        help=(
+            "Minimum context window in tokens. Models with a smaller "
+            "context_window (or no context_window declared) are marked "
+            "incompatible for any span that exceeds the constraint. "
+            "Default: 0 (no constraint)."
+        ),
+    )
+    p.add_argument(
+        "--min-compatibility",
+        type=float,
+        default=0.95,
+        help=(
+            "Minimum fraction of spans a candidate must be able to serve "
+            "(0.0–1.0). Candidates below this threshold are reported as "
+            "incompatible. Default: 0.95."
+        ),
+    )
+    p.add_argument(
+        "--format",
+        choices=("text", "json", "csv"),
+        default="text",
+        help="Output format. Default: text.",
+    )
+    p.add_argument(
+        "--pricing-file",
+        default=None,
+        help="Path to a JSON pricing catalog. Default: the bundled catalog.",
+    )
+    p.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI color output even when stdout is a TTY.",
+    )
+    p.add_argument(
+        "--color",
+        action="store_true",
+        help="Force ANSI color output even when stdout is not a TTY.",
+    )
+    p.add_argument(
+        "--no-auto-infer",
+        action="store_true",
+        help=(
+            "Do NOT infer capability needs from the source models. "
+            "Use only --need. Use this when the source model declares "
+            "capabilities the workload does not actually exercise."
+        ),
+    )
+    return p
+
+
+def _cli(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    global _USE_COLOR
+    if args.no_color:
+        _USE_COLOR = False
+    elif args.color:
+        _USE_COLOR = True
+    pricing = default_chain(args.pricing_file)
+    constraints = WorkloadConstraints(
+        need_capabilities=set(args.need or []),
+        min_context_window=args.min_context,
+        min_compatibility_pct=args.min_compatibility,
+    )
+    candidates = [c.strip() for c in args.candidates.split(",") if c.strip()]
+    report = evaluate_workload(
+        args.paths,
+        candidates=candidates,
+        baseline=args.baseline,
+        pricing=pricing,
+        constraints=constraints,
+        auto_infer_capabilities=not args.no_auto_infer,
+    )
+    if not report.alternatives and report.baseline is None:
+        print(
+            "[neatlogs-eval] no candidate models found in the pricing catalog",
+            file=sys.stderr,
+        )
+        return 2
+    sys.stdout.write(format_evaluation(report, style=args.format))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,6 +322,9 @@ milvus = [
 [project.entry-points."hermes_agent.plugins"]
 neatlogs = "neatlogs.hermes_plugin"
 
+[project.scripts]
+neatlogs-eval = "neatlogs.intel:_cli"
+
 [project.urls]
 Homepage = "https://github.com/NeatLogs/neatlogs"
 Repository = "https://github.com/NeatLogs/neatlogs.git"

--- a/tests/unit/test_intel.py
+++ b/tests/unit/test_intel.py
@@ -1,0 +1,1813 @@
+"""
+Unit tests for neatlogs.intel.
+
+The intel module is the "Replay + Model Optimizer" — given a span
+log, evaluate candidate models against the workload and rank them by
+cost under capability / context / compatibility constraints.
+
+The PricingProvider chain, ModelDefinition with usage_types dict, and
+WorkloadConstraints are all covered end-to-end.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from neatlogs.intel import (
+    BuiltinProvider,
+    ChainProvider,
+    CustomProvider,
+    EvaluationReport,
+    ModelDefinition,
+    ScoredModel,
+    SpanUsage,
+    Tier,
+    TokenStats,
+    UsageType,
+    WorkloadConstraints,
+    WorkloadProfile,
+    _build_def,
+    _extract_usage,
+    _is_span_compatible,
+    _iter_json_objects,
+    _read_paths,
+    _read_usages,
+    _resolve_definition,
+    _score_model,
+    _span_cost,
+    build_workload_profile,
+    default_chain,
+    evaluate_workload,
+    format_evaluation,
+    format_evaluation_csv,
+    format_evaluation_json,
+    format_evaluation_text,
+)
+
+# ---------------------------------------------------------------------------
+# Test catalog (in-memory)
+# ---------------------------------------------------------------------------
+
+
+def _make_catalog() -> Dict[str, Any]:
+    """A small in-memory catalog for tests. Each model has a distinct
+    capability set and price profile so capability-matching and tier
+    logic can be exercised."""
+    return {
+        "_meta": {"schema_version": "2.0"},
+        "models": {
+            "openai/gpt-4o-mini": {
+                "provider": "openai",
+                "context_window": 128000,
+                "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+                "usage_types": {"input": 0.15, "output": 0.60, "cache_read": 0.075},
+            },
+            "openai/gpt-4o": {
+                "provider": "openai",
+                "context_window": 128000,
+                "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+                "usage_types": {"input": 2.50, "output": 10.00, "cache_read": 1.25},
+            },
+            "openai/o3-mini": {
+                "provider": "openai",
+                "context_window": 200000,
+                "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+                "usage_types": {
+                    "input": 1.10,
+                    "output": 4.40,
+                    "reasoning": 4.40,
+                    "cache_read": 0.55,
+                },
+            },
+            "openai/text-embedding-3-small": {
+                "provider": "openai",
+                "context_window": 8191,
+                "capabilities": ["embedding"],
+                "usage_types": {"input": 0.02, "output": 0.0},
+            },
+            "anthropic/claude-3-5-haiku-latest": {
+                "provider": "anthropic",
+                "context_window": 200000,
+                "capabilities": ["tools", "json_mode", "prompt_cache"],
+                "usage_types": {
+                    "input": 0.80,
+                    "output": 4.00,
+                    "cache_write": 1.00,
+                    "cache_read": 0.08,
+                },
+            },
+            "anthropic/claude-3-5-sonnet-latest": {
+                "provider": "anthropic",
+                "context_window": 200000,
+                "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+                "usage_types": {
+                    "input": 3.00,
+                    "output": 15.00,
+                    "cache_write": 3.75,
+                    "cache_read": 0.30,
+                },
+                "tiers": {
+                    "input": [{"above_tokens": 200000, "rate": 6.00}],
+                    "output": [{"above_tokens": 200000, "rate": 22.50}],
+                },
+            },
+            "anthropic/claude-3-haiku-20240307": {
+                "provider": "anthropic",
+                "context_window": 200000,
+                "capabilities": ["tools", "json_mode", "prompt_cache"],
+                "usage_types": {
+                    "input": 0.25,
+                    "output": 1.25,
+                    "cache_write": 0.30,
+                    "cache_read": 0.03,
+                },
+            },
+        },
+    }
+
+
+def _write_catalog_to_tmp(catalog: Dict[str, Any]) -> Path:
+    fd, path = tempfile.mkstemp(suffix=".json")
+    Path(path).write_text(json.dumps(catalog))
+    return Path(path)
+
+
+def _build_test_provider(catalog: Dict[str, Any] = None) -> CustomProvider:
+    catalog = catalog if catalog is not None else _make_catalog()
+    return CustomProvider(_write_catalog_to_tmp(catalog))
+
+
+def _write_span_log(path: Path, spans: List[Dict[str, Any]]) -> None:
+    path.write_text("\n".join(json.dumps(s) for s in spans))
+
+
+def _span(
+    trace_id: str = "a",
+    span_id: str = "1",
+    name: str = "openai.chat.completions.create",
+    model: str = "gpt-4o-mini",
+    provider: str = "openai",
+    prompt: int = 1000,
+    completion: int = 500,
+    cache_creation: int = 0,
+    cache_read: int = 0,
+    reasoning: int = 0,
+) -> Dict[str, Any]:
+    attrs: Dict[str, Any] = {
+        "neatlogs.llm.model_name": model,
+        "neatlogs.llm.provider": provider,
+        "neatlogs.llm.token_count.prompt": prompt,
+        "neatlogs.llm.token_count.completion": completion,
+    }
+    if cache_creation:
+        attrs["neatlogs.llm.token_count.cache_creation"] = cache_creation
+    if cache_read:
+        attrs["neatlogs.llm.token_count.cache_read"] = cache_read
+    if reasoning:
+        attrs["neatlogs.llm.token_count.reasoning"] = reasoning
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": None,
+        "name": name,
+        "kind": "llm",
+        "start_time": "2024-01-15T10:00:00Z",
+        "end_time": "2024-01-15T10:00:01Z",
+        "attributes": attrs,
+        "status": {"code": "OK", "description": ""},
+        "events": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Span reading
+# ---------------------------------------------------------------------------
+
+
+class TestIntAttr:
+    def test_zero_value_kept(self):
+        # 0 is a valid value, not "missing".
+        from neatlogs.intel import _int_attr
+
+        assert _int_attr({"k": 0}, "k") == 0
+
+    def test_negative_ignored(self):
+        from neatlogs.intel import _int_attr
+
+        assert _int_attr({"k": -5}, "k") == 0
+
+    def test_bool_ignored(self):
+        from neatlogs.intel import _int_attr
+
+        assert _int_attr({"k": True}, "k") == 0
+
+    def test_first_key_wins(self):
+        from neatlogs.intel import _int_attr
+
+        assert _int_attr({"a": 100, "b": 200}, "a", "b") == 100
+        assert _int_attr({"b": 200}, "a", "b") == 200
+
+
+class TestExtractUsage:
+    def test_basic(self):
+        d = {
+            "attributes": {
+                "neatlogs.llm.model_name": "gpt-4o-mini",
+                "neatlogs.llm.provider": "OpenAI",
+                "neatlogs.llm.token_count.prompt": 100,
+                "neatlogs.llm.token_count.completion": 50,
+            }
+        }
+        u = _extract_usage(d)
+        assert u.model == "gpt-4o-mini"
+        assert u.provider == "openai"  # lowercased
+        assert u.prompt_tokens == 100
+        assert u.completion_tokens == 50
+        assert u.cache_creation_tokens == 0
+        assert u.cache_read_tokens == 0
+        assert u.reasoning_tokens == 0
+
+    def test_otel_fallback(self):
+        d = {
+            "attributes": {
+                "gen_ai.system": "openai",
+                "gen_ai.request.model": "gpt-4o",
+                "gen_ai.usage.input_tokens": 200,
+                "gen_ai.usage.output_tokens": 100,
+            }
+        }
+        u = _extract_usage(d)
+        assert u.model == "gpt-4o"
+        assert u.prompt_tokens == 200
+
+    def test_cache_and_reasoning(self):
+        d = {
+            "attributes": {
+                "neatlogs.llm.model_name": "m",
+                "neatlogs.llm.provider": "p",
+                "neatlogs.llm.token_count.prompt": 1000,
+                "neatlogs.llm.token_count.completion": 500,
+                "neatlogs.llm.token_count.cache_creation": 200,
+                "neatlogs.llm.token_count.cache_read": 800,
+                "neatlogs.llm.token_count.reasoning": 100,
+            }
+        }
+        u = _extract_usage(d)
+        assert u.cache_creation_tokens == 200
+        assert u.cache_read_tokens == 800
+        assert u.reasoning_tokens == 100
+        assert u.uses_prompt_cache is True
+        assert u.uses_reasoning is True
+        assert u.input_total == 2000
+        assert u.output_total == 600
+
+
+class TestIterJsonObjects:
+    def test_basic(self):
+        out = list(_iter_json_objects('{"a": 1}\n{"b": 2}'))
+        assert out == [{"a": 1}, {"b": 2}]
+
+    def test_escaped_quotes(self):
+        text = '{"name": "a \\"quoted\\" word"}'
+        out = list(_iter_json_objects(text))
+        assert out == [{"name": 'a "quoted" word'}]
+
+    def test_nested_braces_in_strings(self):
+        text = '{"name": "a {b} c"}'
+        out = list(_iter_json_objects(text))
+        assert out == [{"name": "a {b} c"}]
+
+    def test_malformed_skipped(self):
+        text = '{"a": 1}\n{not valid}\n{"b": 2}'
+        out = list(_iter_json_objects(text))
+        assert out == [{"a": 1}, {"b": 2}]
+
+
+class TestReadUsages:
+    def test_missing_path(self, tmp_path: Path):
+        usages = _read_usages(tmp_path / "missing.jsonl")
+        assert usages == []
+
+    def test_empty(self, tmp_path: Path):
+        p = tmp_path / "empty.jsonl"
+        p.write_text("")
+        assert _read_usages(p) == []
+
+    def test_basic(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=100, completion=50)])
+        usages = _read_usages(p)
+        assert len(usages) == 1
+        assert usages[0].prompt_tokens == 100
+
+    def test_brace_balanced_nested_strings(self, tmp_path: Path):
+        d = _span()
+        d["attributes"]["event_payload"] = "line 1\nline 2 {x}"
+        p = tmp_path / "nested.jsonl"
+        _write_span_log(p, [d])
+        usages = _read_usages(p)
+        assert len(usages) == 1
+
+
+class TestReadPaths:
+    def test_multi_file(self, tmp_path: Path):
+        p1 = tmp_path / "a.jsonl"
+        p2 = tmp_path / "b.jsonl"
+        _write_span_log(p1, [_span(span_id="1", prompt=100)])
+        _write_span_log(p2, [_span(span_id="2", prompt=200)])
+        usages = _read_paths([p1, p2])
+        assert len(usages) == 2
+        assert {u.prompt_tokens for u in usages} == {100, 200}
+
+
+# ---------------------------------------------------------------------------
+# ModelDefinition + Pricing
+# ---------------------------------------------------------------------------
+
+
+class TestModelDefinition:
+    def test_basic(self):
+        d = ModelDefinition(
+            model_key="openai/gpt-4o-mini",
+            provider="openai",
+            context_window=128000,
+            capabilities={"vision", "tools"},
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        assert d.rate_for(UsageType.INPUT) == 0.15
+        assert d.rate_for(UsageType.OUTPUT) == 0.60
+        assert d.rate_for(UsageType.CACHE_READ) is None
+
+    def test_effective_rate_no_tier(self):
+        d = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 0.15},
+        )
+        assert d.effective_rate(UsageType.INPUT, 1000) == 0.15
+        assert d.effective_rate(UsageType.INPUT, 1_000_000) == 0.15
+
+    def test_effective_rate_tier_crossed(self):
+        d = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 3.00},
+            tiers={"input": [Tier(above_tokens=200_000, rate=6.00)]},
+        )
+        # Below threshold: base rate.
+        assert d.effective_rate(UsageType.INPUT, 100_000) == 3.00
+        # Strictly above threshold: tier rate.
+        assert d.effective_rate(UsageType.INPUT, 200_001) == 6.00
+        assert d.effective_rate(UsageType.INPUT, 1_000_000) == 6.00
+
+    def test_effective_rate_zero_tokens(self):
+        d = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 3.00},
+            tiers={"input": [Tier(above_tokens=200_000, rate=6.00)]},
+        )
+        assert d.effective_rate(UsageType.INPUT, 0) == 3.00
+
+    def test_effective_rate_picks_largest_crossed(self):
+        d = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 1.00},
+            tiers={
+                "input": [
+                    Tier(above_tokens=100_000, rate=2.00),
+                    Tier(above_tokens=500_000, rate=4.00),
+                ]
+            },
+        )
+        assert d.effective_rate(UsageType.INPUT, 50_000) == 1.00
+        assert d.effective_rate(UsageType.INPUT, 200_000) == 2.00
+        assert d.effective_rate(UsageType.INPUT, 1_000_000) == 4.00
+
+    def test_capability_helpers(self):
+        d = ModelDefinition(
+            model_key="m",
+            provider="p",
+            capabilities={"vision", "tools", "json_mode"},
+        )
+        assert d.has_capability("vision")
+        assert not d.has_capability("audio")
+        assert d.has_all_capabilities(["vision", "tools"])
+        assert not d.has_all_capabilities(["vision", "audio"])
+        assert d.missing_capabilities(["vision", "audio", "embedding"]) == {"audio", "embedding"}
+
+
+class TestBuildDef:
+    def test_basic(self):
+        d = _build_def(
+            "openai/gpt-4o-mini",
+            {
+                "provider": "openai",
+                "context_window": 128000,
+                "capabilities": ["vision", "tools"],
+                "usage_types": {"input": 0.15, "output": 0.60},
+            },
+        )
+        assert d is not None
+        assert d.model_key == "openai/gpt-4o-mini"
+        assert d.provider == "openai"
+        assert d.context_window == 128000
+        assert d.capabilities == {"vision", "tools"}
+        assert d.usage_types == {"input": 0.15, "output": 0.60}
+
+    def test_with_tiers(self):
+        d = _build_def(
+            "anthropic/claude-3-5-sonnet-latest",
+            {
+                "provider": "anthropic",
+                "context_window": 200000,
+                "capabilities": ["vision", "tools"],
+                "usage_types": {"input": 3.0, "output": 15.0},
+                "tiers": {
+                    "input": [{"above_tokens": 200000, "rate": 6.0}],
+                    "output": [{"above_tokens": 200000, "rate": 22.5}],
+                },
+            },
+        )
+        assert d is not None
+        assert len(d.tiers["input"]) == 1
+        assert d.tiers["input"][0].above_tokens == 200000
+        assert d.tiers["input"][0].rate == 6.0
+
+    def test_skips_invalid_entry(self):
+        assert _build_def("no-slash", {"provider": "openai", "input": 1.0}) is None
+        assert _build_def("openai/no-provider", {"input": 1.0}) is None
+        assert _build_def("openai/x", "not a dict") is None
+
+    def test_skips_invalid_capabilities(self):
+        d = _build_def(
+            "openai/x",
+            {
+                "provider": "openai",
+                "capabilities": "not a list",  # type skip
+                "usage_types": {"input": 1.0},
+            },
+        )
+        assert d is not None
+        assert d.capabilities == set()
+
+    def test_skips_invalid_tier_entries(self):
+        d = _build_def(
+            "openai/x",
+            {
+                "provider": "openai",
+                "usage_types": {"input": 1.0},
+                "tiers": {
+                    "input": [
+                        {"above_tokens": "not an int", "rate": 2.0},  # skip
+                        {"above_tokens": 100, "rate": 2.0},  # keep
+                        "not a dict",  # skip
+                    ],
+                },
+            },
+        )
+        assert d is not None
+        assert len(d.tiers["input"]) == 1
+        assert d.tiers["input"][0].above_tokens == 100
+
+
+# ---------------------------------------------------------------------------
+# PricingProvider
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinProvider:
+    def test_loads_bundled(self):
+        p = BuiltinProvider()
+        assert p.lookup("openai/gpt-4o-mini") is not None
+        assert p.lookup("openai/gpt-4o") is not None
+        assert p.lookup("anthropic/claude-3-5-haiku-latest") is not None
+
+    def test_miss(self):
+        p = BuiltinProvider()
+        assert p.lookup("openai/gpt-99") is None
+
+    def test_lookup_by_provider_and_name(self):
+        p = BuiltinProvider()
+        d = p.lookup_by_provider_and_name("openai", "gpt-4o-mini")
+        assert d is not None
+        assert d.model_key == "openai/gpt-4o-mini"
+
+    def test_lookup_provider_miss_no_fallback(self):
+        # If the user specifies a provider that doesn't have the model,
+        # don't silently fall back to a different provider.
+        p = BuiltinProvider()
+        assert p.lookup_by_provider_and_name("nonexistent", "gpt-4o-mini") is None
+
+    def test_loads_from_custom_path(self, tmp_path: Path):
+        p = tmp_path / "pricing.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "_meta": {"schema_version": "2.0"},
+                    "models": {
+                        "custom/m1": {
+                            "provider": "custom",
+                            "capabilities": [],
+                            "usage_types": {"input": 1.0, "output": 2.0},
+                        },
+                    },
+                }
+            )
+        )
+        provider = BuiltinProvider(p)
+        assert provider.lookup("custom/m1") is not None
+
+
+class TestCustomProvider:
+    def test_loads(self):
+        path = _write_catalog_to_tmp(_make_catalog())
+        try:
+            p = CustomProvider(path)
+            assert p.lookup("openai/gpt-4o-mini") is not None
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_lookup_by_provider_and_name(self):
+        path = _write_catalog_to_tmp(_make_catalog())
+        try:
+            p = CustomProvider(path)
+            d = p.lookup_by_provider_and_name("anthropic", "claude-3-5-haiku-latest")
+            assert d is not None
+        finally:
+            path.unlink(missing_ok=True)
+
+
+class TestChainProvider:
+    def test_first_match_wins(self):
+        # Custom provider returns one def, builtin returns a different one
+        # for the same key. Custom should win.
+        custom = CustomProvider(
+            _write_catalog_to_tmp(
+                {
+                    "_meta": {"schema_version": "2.0"},
+                    "models": {
+                        "openai/gpt-4o-mini": {
+                            "provider": "openai",
+                            "capabilities": ["vision"],
+                            "usage_types": {"input": 0.10, "output": 0.40},
+                        }
+                    },
+                }
+            )
+        )
+        builtin = _build_test_provider()
+        try:
+            chain = ChainProvider([custom, builtin])
+            d = chain.lookup("openai/gpt-4o-mini")
+            assert d is not None
+            # Custom's rate (0.10) wins over builtin's 0.15.
+            assert d.usage_types["input"] == 0.10
+        finally:
+            custom._path.unlink(missing_ok=True)
+
+    def test_falls_through(self):
+        # Custom doesn't have the model, builtin does. Chain falls through.
+        custom_path = _write_catalog_to_tmp(
+            {
+                "_meta": {"schema_version": "2.0"},
+                "models": {
+                    "openai/gpt-4o": {
+                        "provider": "openai",
+                        "capabilities": ["vision"],
+                        "usage_types": {"input": 0.99},
+                    }
+                },
+            }
+        )
+        try:
+            chain = ChainProvider([CustomProvider(custom_path), _build_test_provider()])
+            d = chain.lookup("openai/gpt-4o-mini")
+            assert d is not None
+            assert d.usage_types["input"] == 0.15  # builtin rate
+        finally:
+            custom_path.unlink(missing_ok=True)
+
+    def test_miss_returns_none(self):
+        chain = ChainProvider([_build_test_provider()])
+        assert chain.lookup("openai/gpt-99") is None
+
+    def test_lookup_by_provider_and_name_falls_through(self):
+        chain = ChainProvider([_build_test_provider()])
+        d = chain.lookup_by_provider_and_name("openai", "gpt-4o-mini")
+        assert d is not None
+
+    def test_empty_chain(self):
+        chain = ChainProvider([])
+        assert chain.lookup("openai/gpt-4o-mini") is None
+        assert chain.lookup_by_provider_and_name("openai", "gpt-4o-mini") is None
+
+
+class TestDefaultChain:
+    def test_default_chain_uses_builtin(self, monkeypatch):
+        monkeypatch.delenv("NEATLOGS_PRICING_FILE", raising=False)
+        chain = default_chain()
+        assert chain.lookup("openai/gpt-4o-mini") is not None
+
+    def test_default_chain_uses_pricing_file(self, tmp_path, monkeypatch):
+        custom = tmp_path / "my.json"
+        custom.write_text(
+            json.dumps(
+                {
+                    "_meta": {"schema_version": "2.0"},
+                    "models": {
+                        "custom/m1": {
+                            "provider": "custom",
+                            "capabilities": [],
+                            "usage_types": {"input": 0.01},
+                        }
+                    },
+                }
+            )
+        )
+        chain = default_chain(custom)
+        # Custom override is loaded.
+        assert chain.lookup("custom/m1") is not None
+        # Builtin catalog is also in the chain (custom is just on top).
+        assert chain.lookup("openai/gpt-4o-mini") is not None
+
+    def test_default_chain_uses_env_var(self, tmp_path, monkeypatch):
+        custom = tmp_path / "env.json"
+        custom.write_text(
+            json.dumps(
+                {
+                    "_meta": {"schema_version": "2.0"},
+                    "models": {
+                        "env/m1": {
+                            "provider": "env",
+                            "capabilities": [],
+                            "usage_types": {"input": 0.01},
+                        }
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("NEATLOGS_PRICING_FILE", str(custom))
+        chain = default_chain()
+        assert chain.lookup("env/m1") is not None
+
+
+# ---------------------------------------------------------------------------
+# Workload profile + TokenStats
+# ---------------------------------------------------------------------------
+
+
+class TestTokenStats:
+    def test_empty(self):
+        s = TokenStats.from_values([])
+        assert s.p50 == 0
+        assert s.max == 0
+        assert s.total == 0
+
+    def test_single(self):
+        s = TokenStats.from_values([42])
+        assert s.p50 == 42
+        assert s.p90 == 42
+        assert s.max == 42
+        assert s.total == 42
+
+    def test_percentiles(self):
+        s = TokenStats.from_values(list(range(1, 101)))  # 1..100
+        assert s.p50 == 50
+        assert s.p90 == 90
+        assert s.p99 == 99
+        assert s.max == 100
+        assert s.total == 5050
+
+
+class TestBuildWorkloadProfile:
+    def test_basic(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(
+            p,
+            [
+                _span(span_id="1", prompt=1000, completion=500),
+                _span(span_id="2", prompt=2000, completion=800),
+            ],
+        )
+        profile, usages = build_workload_profile([p], _build_test_provider())
+        assert profile.total_spans == 2
+        assert profile.spans_with_tokens == 2
+        assert profile.spans_skipped == 0
+        assert profile.files_read == 1
+        assert len(usages) == 2
+        # Models used: only gpt-4o-mini.
+        assert profile.models_used == {"openai/gpt-4o-mini"}
+        # Capabilities inferred from the source model.
+        assert "vision" in profile.capabilities_inferred
+        assert "tools" in profile.capabilities_inferred
+        # Prompt stats.
+        assert profile.prompt_stats.max == 2000
+        assert profile.prompt_stats.total == 3000
+        assert profile.completion_stats.max == 800
+
+    def test_auto_infer_off(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        profile, _ = build_workload_profile(
+            [p],
+            _build_test_provider(),
+            auto_infer_capabilities=False,
+        )
+        assert profile.capabilities_inferred == set()
+
+    def test_skips_no_model_spans(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        d = _span(span_id="1")
+        d["attributes"] = {"foo": "bar"}  # no model
+        _write_span_log(p, [d])
+        profile, usages = build_workload_profile([p], _build_test_provider())
+        assert profile.total_spans == 1
+        assert profile.spans_with_tokens == 0
+        assert profile.spans_skipped == 1
+        assert usages == []
+
+    def test_skips_zero_token_spans(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        d = _span(prompt=0, completion=0)
+        _write_span_log(p, [d])
+        profile, _ = build_workload_profile([p], _build_test_provider())
+        assert profile.spans_with_tokens == 0
+        assert profile.spans_skipped == 1
+
+    def test_needs_cache_when_cache_used(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(
+            p,
+            [
+                _span(span_id="1", prompt=100, completion=50, cache_read=50),
+            ],
+        )
+        profile, _ = build_workload_profile([p], _build_test_provider())
+        assert profile.needs_cache is True
+        assert profile.cache_read_total == 50
+
+    def test_unknown_model_no_crash(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(model="some/future-model")])
+        # The future model isn't in the catalog, so no capabilities get
+        # inferred. The profile still gets built.
+        profile, _ = build_workload_profile([p], _build_test_provider())
+        assert profile.capabilities_inferred == set()
+
+    def test_resolve_definition(self):
+        d = _resolve_definition(
+            SpanUsage("s", "t", "gpt-4o-mini", "openai", 100, 50, 0, 0, 0),
+            _build_test_provider(),
+        )
+        assert d is not None
+        assert d.model_key == "openai/gpt-4o-mini"
+
+    def test_resolve_definition_provider_agnostic(self):
+        d = _resolve_definition(
+            SpanUsage("s", "t", "gpt-4o-mini", None, 100, 50, 0, 0, 0),
+            _build_test_provider(),
+        )
+        assert d is not None
+
+    def test_resolve_definition_no_match(self):
+        d = _resolve_definition(
+            SpanUsage("s", "t", "gpt-99", None, 100, 50, 0, 0, 0),
+            _build_test_provider(),
+        )
+        assert d is None
+
+    def test_resolve_definition_empty_model(self):
+        d = _resolve_definition(
+            SpanUsage("s", "t", "", None, 100, 50, 0, 0, 0),
+            _build_test_provider(),
+        )
+        assert d is None
+
+
+# ---------------------------------------------------------------------------
+# Cost engine: _span_cost + _is_span_compatible
+# ---------------------------------------------------------------------------
+
+
+class TestSpanCost:
+    def test_basic(self):
+        m = _build_test_provider().lookup("openai/gpt-4o-mini")
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 1_000_000, 1_000_000, 0, 0, 0)
+        c = _span_cost(u, m)
+        # input 1M * 0.15 + output 1M * 0.60
+        assert c == pytest.approx(0.75, abs=1e-6)
+
+    def test_cache_read(self):
+        m = _build_test_provider().lookup("openai/gpt-4o-mini")
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 0, 0, 0, 1_000_000, 0)
+        c = _span_cost(u, m)
+        # 1M cache_read at 0.075
+        assert c == pytest.approx(0.075, abs=1e-6)
+
+    def test_cache_write_anthropic(self):
+        m = _build_test_provider().lookup("anthropic/claude-3-5-haiku-latest")
+        # prompt=0 so only the cache_write cost is billed.
+        u = SpanUsage("s", "t", "m", "anthropic", 0, 0, 1_000_000, 0, 0)
+        c = _span_cost(u, m)
+        # 1M cache_write at 1.00
+        assert c == pytest.approx(1.00, abs=1e-6)
+
+    def test_reasoning_o_series(self):
+        m = _build_test_provider().lookup("openai/o3-mini")
+        # completion=0 so only input + reasoning are billed.
+        u = SpanUsage("s", "t", "o3-mini", "openai", 100_000, 0, 0, 0, 100_000)
+        c = _span_cost(u, m)
+        # 100k input @ 1.10/1M = 0.11, 100k reasoning @ 4.40/1M = 0.44
+        assert c == pytest.approx(0.55, abs=1e-6)
+
+    def test_tier_applied(self):
+        m = _build_test_provider().lookup("anthropic/claude-3-5-sonnet-latest")
+        # 300k input crosses the 200k threshold.
+        u = SpanUsage("s", "t", "m", "anthropic", 300_000, 1000, 0, 0, 0)
+        c = _span_cost(u, m)
+        # input 300k * 6.00/1M = 1.80; output 1k * 15.00/1M = 0.015
+        assert c == pytest.approx(1.815, abs=1e-6)
+
+    def test_embedding_model(self):
+        m = _build_test_provider().lookup("openai/text-embedding-3-small")
+        u = SpanUsage("s", "t", "m", "openai", 1_000_000, 0, 0, 0, 0)
+        c = _span_cost(u, m)
+        # 1M input at 0.02/1M = 0.02
+        assert c == pytest.approx(0.02, abs=1e-6)
+
+    def test_no_input_or_output_rate(self):
+        # A model with no input/output rate (edge case): cost is 0.
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"image": 0.10},
+        )
+        u = SpanUsage("s", "t", "m", "p", 100, 50, 0, 0, 0)
+        assert _span_cost(u, m) == 0.0
+
+
+class TestSpanCompatibility:
+    def test_compatible_no_constraints(self):
+        m = _build_test_provider().lookup("openai/gpt-4o-mini")
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 100, 50, 0, 0, 0)
+        ok, reasons = _is_span_compatible(u, m, WorkloadConstraints())
+        assert ok is True
+        assert reasons == []
+
+    def test_cache_used_no_cache_rate_incompatible(self):
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        u = SpanUsage("s", "t", "m", "p", 100, 50, 0, 50, 0)
+        ok, reasons = _is_span_compatible(u, m, WorkloadConstraints())
+        assert ok is False
+        assert any("cache" in r for r in reasons)
+
+    def test_reasoning_used_no_reasoning_rate_incompatible(self):
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        u = SpanUsage("s", "t", "m", "p", 100, 50, 0, 0, 50)
+        ok, reasons = _is_span_compatible(u, m, WorkloadConstraints())
+        assert ok is False
+        assert any("reasoning" in r for r in reasons)
+
+    def test_capability_constraint_missing(self):
+        m = _build_test_provider().lookup("anthropic/claude-3-5-haiku-latest")
+        u = SpanUsage("s", "t", "m", "anthropic", 100, 50, 0, 0, 0)
+        ok, reasons = _is_span_compatible(
+            u,
+            m,
+            WorkloadConstraints(need_capabilities={"vision"}),
+        )
+        assert ok is False
+        assert any("vision" in r for r in reasons)
+
+    def test_capability_constraint_satisfied(self):
+        m = _build_test_provider().lookup("openai/gpt-4o")
+        u = SpanUsage("s", "t", "m", "openai", 100, 50, 0, 0, 0)
+        ok, _ = _is_span_compatible(
+            u,
+            m,
+            WorkloadConstraints(need_capabilities={"vision", "tools"}),
+        )
+        assert ok is True
+
+    def test_context_window_too_small(self):
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            context_window=1000,
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        u = SpanUsage("s", "t", "m", "p", 2000, 50, 0, 0, 0)
+        ok, reasons = _is_span_compatible(
+            u,
+            m,
+            WorkloadConstraints(min_context_window=4000),
+        )
+        assert ok is False
+        assert any("context" in r for r in reasons)
+
+    def test_context_window_no_declaration_incompatible(self):
+        # If the model doesn't declare a context_window, the constraint
+        # is treated as a hard fail.
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            context_window=None,
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        u = SpanUsage("s", "t", "m", "p", 100, 50, 0, 0, 0)
+        ok, _ = _is_span_compatible(
+            u,
+            m,
+            WorkloadConstraints(min_context_window=1000),
+        )
+        assert ok is False
+
+    def test_context_window_zero_means_no_constraint(self):
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            context_window=1000,
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        u = SpanUsage("s", "t", "m", "p", 100_000, 50, 0, 0, 0)
+        ok, _ = _is_span_compatible(u, m, WorkloadConstraints(min_context_window=0))
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# ScoredModel + EvaluationReport
+# ---------------------------------------------------------------------------
+
+
+class TestScoreModel:
+    def test_basic(self):
+        m = _build_test_provider().lookup("openai/gpt-4o-mini")
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 1_000_000, 1_000_000, 0, 0, 0)
+        sm = _score_model(m, [u], WorkloadConstraints(), is_baseline=True)
+        assert sm.total_cost == pytest.approx(0.75, abs=1e-6)
+        assert sm.compatibility_pct == 1.0
+        assert sm.meets_min_compatibility is True
+        assert sm.is_baseline is True
+        assert sm.missing_capabilities == set()
+
+    def test_partial_compatibility(self):
+        m = _build_test_provider().lookup("anthropic/claude-3-5-haiku-latest")
+        u_compat = SpanUsage("1", "t", "m", "anthropic", 100, 50, 0, 0, 0)
+        u_incompat = SpanUsage("2", "t", "m", "anthropic", 100, 50, 0, 0, 0)
+        # Make the second one require vision.
+        m_vision = _build_test_provider().lookup("openai/gpt-4o-mini")
+        u_incompat2 = SpanUsage("3", "t", "m", "openai", 100, 50, 0, 0, 0)
+        # Use constraints to force one span to be incompatible.
+        c = WorkloadConstraints(need_capabilities={"vision"})
+        sm = _score_model(m, [u_compat, u_incompat, u_incompat2], c, is_baseline=False)
+        # 1 of 3 spans compatible (the haiku one is compatible for its own
+        # span, but the constraint forces vision which it lacks).
+        assert sm.compatible_spans == 0
+        assert sm.meets_min_compatibility is False
+
+    def test_rank_key(self):
+        sm_ok = ScoredModel(
+            model_key="a",
+            provider="p",
+            total_cost=0.10,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+        )
+        sm_bad = ScoredModel(
+            model_key="b",
+            provider="p",
+            total_cost=0.0,
+            compatible_spans=0,
+            total_spans=10,
+            compatibility_pct=0.0,
+            meets_min_compatibility=False,
+            missing_capabilities={"vision"},
+            context_window=128000,
+            per_span=[],
+        )
+        # Compatible always ranks first.
+        assert sm_ok.rank_key < sm_bad.rank_key
+
+
+class TestEvaluationReport:
+    def test_delta_pct(self):
+        b = ScoredModel(
+            model_key="b",
+            provider="p",
+            total_cost=1.0,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+            is_baseline=True,
+        )
+        a = ScoredModel(
+            model_key="a",
+            provider="p",
+            total_cost=0.5,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+        )
+        r = EvaluationReport(
+            baseline=b,
+            alternatives=[a],
+            profile=WorkloadProfile(
+                total_spans=10,
+                spans_with_tokens=10,
+                spans_skipped=0,
+                models_used=set(),
+                capabilities_inferred=set(),
+                prompt_stats=TokenStats(0, 0, 0, 0, 0),
+                completion_stats=TokenStats(0, 0, 0, 0, 0),
+                cache_read_total=0,
+                cache_write_total=0,
+                reasoning_total=0,
+                files_read=1,
+            ),
+            constraints=WorkloadConstraints(),
+            explicit_constraints=WorkloadConstraints(),
+            unknown_models=[],
+            files_read=1,
+        )
+        # (0.5 - 1.0) / 1.0 * 100 = -50%
+        assert r.delta_pct_for(a) == pytest.approx(-50, abs=0.1)
+        assert r.delta_pct_for(b) is None  # baseline
+
+    def test_delta_pct_zero_baseline(self):
+        b = ScoredModel(
+            model_key="b",
+            provider="p",
+            total_cost=0.0,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+            is_baseline=True,
+        )
+        a = ScoredModel(
+            model_key="a",
+            provider="p",
+            total_cost=0.5,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+        )
+        r = EvaluationReport(
+            baseline=b,
+            alternatives=[a],
+            profile=WorkloadProfile(
+                total_spans=10,
+                spans_with_tokens=10,
+                spans_skipped=0,
+                models_used=set(),
+                capabilities_inferred=set(),
+                prompt_stats=TokenStats(0, 0, 0, 0, 0),
+                completion_stats=TokenStats(0, 0, 0, 0, 0),
+                cache_read_total=0,
+                cache_write_total=0,
+                reasoning_total=0,
+                files_read=1,
+            ),
+            constraints=WorkloadConstraints(),
+            explicit_constraints=WorkloadConstraints(),
+            unknown_models=[],
+            files_read=1,
+        )
+        # Avoid division by zero.
+        assert r.delta_pct_for(a) is None
+
+    def test_ranked(self):
+        b = ScoredModel(
+            model_key="b",
+            provider="p",
+            total_cost=1.0,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+            is_baseline=True,
+        )
+        a = ScoredModel(
+            model_key="a",
+            provider="p",
+            total_cost=0.5,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+        )
+        c_bad = ScoredModel(
+            model_key="c",
+            provider="p",
+            total_cost=0.0,
+            compatible_spans=0,
+            total_spans=10,
+            compatibility_pct=0.0,
+            meets_min_compatibility=False,
+            missing_capabilities={"vision"},
+            context_window=128000,
+            per_span=[],
+        )
+        r = EvaluationReport(
+            baseline=b,
+            alternatives=[a, c_bad],
+            profile=WorkloadProfile(
+                total_spans=10,
+                spans_with_tokens=10,
+                spans_skipped=0,
+                models_used=set(),
+                capabilities_inferred=set(),
+                prompt_stats=TokenStats(0, 0, 0, 0, 0),
+                completion_stats=TokenStats(0, 0, 0, 0, 0),
+                cache_read_total=0,
+                cache_write_total=0,
+                reasoning_total=0,
+                files_read=1,
+            ),
+            constraints=WorkloadConstraints(),
+            explicit_constraints=WorkloadConstraints(),
+            unknown_models=[],
+            files_read=1,
+        )
+        ranked = r.ranked()
+        assert ranked[0].model_key == "b"  # baseline first
+        assert ranked[1].model_key == "a"  # cheaper alternative
+        assert ranked[2].model_key == "c"  # incompatible last
+
+    def test_find(self):
+        b = ScoredModel(
+            model_key="b",
+            provider="p",
+            total_cost=1.0,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+            is_baseline=True,
+        )
+        r = EvaluationReport(
+            baseline=b,
+            alternatives=[],
+            profile=WorkloadProfile(
+                total_spans=10,
+                spans_with_tokens=10,
+                spans_skipped=0,
+                models_used=set(),
+                capabilities_inferred=set(),
+                prompt_stats=TokenStats(0, 0, 0, 0, 0),
+                completion_stats=TokenStats(0, 0, 0, 0, 0),
+                cache_read_total=0,
+                cache_write_total=0,
+                reasoning_total=0,
+                files_read=1,
+            ),
+            constraints=WorkloadConstraints(),
+            explicit_constraints=WorkloadConstraints(),
+            unknown_models=[],
+            files_read=1,
+        )
+        assert r.find("b") is b
+        assert r.find("missing") is None
+
+
+# ---------------------------------------------------------------------------
+# evaluate_workload (top-level)
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateWorkload:
+    def test_basic(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "openai/gpt-4o",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            baseline="openai/gpt-4o-mini",
+            pricing=chain,
+            auto_infer_capabilities=False,
+        )
+        assert report.baseline is not None
+        assert report.baseline.model_key == "openai/gpt-4o-mini"
+        assert len(report.alternatives) == 2
+        # All three models should be compatible with the workload when
+        # we don't infer capabilities from the source model.
+        for sm in report.all():
+            assert sm.meets_min_compatibility is True
+
+    def test_unknown_candidate_warns(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        buf = io.StringIO()
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "nonexistent/model"],
+            pricing=chain,
+            warn_stream=buf,
+        )
+        assert "nonexistent/model" in buf.getvalue()
+        # The unknown model is omitted; only the known one is in the report.
+        assert report.find("nonexistent/model") is None
+
+    def test_no_candidates_no_baseline(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[],
+            pricing=chain,
+        )
+        assert report.baseline is None
+        assert report.alternatives == []
+
+    def test_capability_constraint_filters_alternatives(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        # The source model is gpt-4o-mini (has vision). We REQUIRE vision.
+        # haiku (no vision) should be incompatible.
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            constraints=WorkloadConstraints(need_capabilities={"vision"}),
+            auto_infer_capabilities=False,  # explicit only
+        )
+        haiku = report.find("anthropic/claude-3-5-haiku-latest")
+        assert haiku is not None
+        assert haiku.meets_min_compatibility is False
+
+    def test_auto_infer_capabilities(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        # Source model is gpt-4o-mini which has vision. The user does
+        # NOT pass --need; we should still require vision (inferred).
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            # No explicit need; auto_infer is on by default.
+        )
+        haiku = report.find("anthropic/claude-3-5-haiku-latest")
+        assert haiku is not None
+        # haiku is incompatible because the workload needs vision.
+        assert haiku.meets_min_compatibility is False
+
+    def test_auto_infer_can_be_disabled(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            auto_infer_capabilities=False,
+        )
+        haiku = report.find("anthropic/claude-3-5-haiku-latest")
+        # Without auto-infer, haiku is compatible (no constraint applied).
+        assert haiku is not None
+        assert haiku.meets_min_compatibility is True
+
+    def test_explicit_baseline(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            baseline="openai/gpt-4o",
+            pricing=chain,
+        )
+        assert report.baseline.model_key == "openai/gpt-4o"
+        assert report.find("openai/gpt-4o-mini") is not None
+
+    def test_single_path_string(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            str(p),  # str, not Path
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        assert report.baseline is not None
+
+    def test_min_compatibility_pct(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        # 5 spans, 1 needs vision (the source model has vision but only
+        # one span will be marked as needing it via explicit constraint).
+        _write_span_log(
+            p,
+            [
+                _span(span_id="1", prompt=100, completion=50),
+                _span(span_id="2", prompt=100, completion=50),
+                _span(span_id="3", prompt=100, completion=50),
+                _span(span_id="4", prompt=100, completion=50),
+                _span(span_id="5", prompt=100, completion=50),
+            ],
+        )
+        chain = ChainProvider([_build_test_provider()])
+        # haiku (no vision) is incompatible on all 5 spans with vision
+        # required → 0% compatibility → fails the 95% threshold.
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            constraints=WorkloadConstraints(
+                need_capabilities={"vision"},
+                min_compatibility_pct=0.95,
+            ),
+            auto_infer_capabilities=False,
+        )
+        haiku = report.find("anthropic/claude-3-5-haiku-latest")
+        assert haiku is not None
+        assert haiku.meets_min_compatibility is False
+
+    def test_min_compatibility_low_threshold(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span() for _ in range(10)])
+        chain = ChainProvider([_build_test_provider()])
+        # 50% threshold: haiku is OK because it's still in the top
+        # for the 10 spans that are the same.
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            constraints=WorkloadConstraints(
+                need_capabilities={"vision"},
+                min_compatibility_pct=0.0,
+            ),
+            auto_infer_capabilities=False,
+        )
+        haiku = report.find("anthropic/claude-3-5-haiku-latest")
+        assert haiku is not None
+        # 0.0 threshold = always passes.
+        assert haiku.meets_min_compatibility is True
+
+    def test_no_spans_with_tokens(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        d = _span()
+        d["attributes"] = {"foo": "bar"}
+        _write_span_log(p, [d])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        assert report.profile.spans_with_tokens == 0
+        assert report.profile.spans_skipped == 1
+        # Baseline is still set even with no input data; cost is $0.
+        assert report.baseline is not None
+        assert report.baseline.total_cost == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatEvaluationText:
+    def test_basic(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "openai/gpt-4o",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+        )
+        out = format_evaluation_text(report, use_color=False)
+        assert "Workload:" in out
+        assert "openai/gpt-4o-mini" in out
+        assert "openai/gpt-4o" in out
+        assert "anthropic/claude-3-5-haiku-latest" in out
+        assert "(baseline)" in out
+        assert "vs base" in out
+
+    def test_incompatible_shown(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            constraints=WorkloadConstraints(need_capabilities={"vision"}),
+            auto_infer_capabilities=False,
+        )
+        out = format_evaluation_text(report, use_color=False)
+        assert "incompatible" in out
+
+    def test_no_results(self):
+        report = EvaluationReport(
+            baseline=None,
+            alternatives=[],
+            profile=WorkloadProfile(
+                total_spans=0,
+                spans_with_tokens=0,
+                spans_skipped=0,
+                models_used=set(),
+                capabilities_inferred=set(),
+                prompt_stats=TokenStats(0, 0, 0, 0, 0),
+                completion_stats=TokenStats(0, 0, 0, 0, 0),
+                cache_read_total=0,
+                cache_write_total=0,
+                reasoning_total=0,
+                files_read=0,
+            ),
+            constraints=WorkloadConstraints(),
+            explicit_constraints=WorkloadConstraints(),
+            unknown_models=[],
+            files_read=0,
+        )
+        out = format_evaluation_text(report, use_color=False)
+        assert "no candidate" in out
+
+    def test_capability_gap_section(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            constraints=WorkloadConstraints(need_capabilities={"vision"}),
+            auto_infer_capabilities=False,
+        )
+        out = format_evaluation_text(report, use_color=False)
+        assert "Capability gap" in out
+        assert "vision" in out
+
+    def test_color_in_output(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            pricing=chain,
+        )
+        out = format_evaluation_text(report, use_color=True)
+        assert "\033[" in out
+
+    def test_color_disabled(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=100, completion=50)])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        out = format_evaluation_text(report, use_color=False)
+        assert "\033[" not in out
+
+
+class TestFormatEvaluationJson:
+    def test_shape(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            pricing=chain,
+        )
+        out = format_evaluation_json(report)
+        obj = json.loads(out)
+        assert obj["currency"] == "USD"
+        assert "workload" in obj
+        assert obj["workload"]["spans_with_tokens"] == 1
+        assert obj["baseline"]["model"] == "openai/gpt-4o-mini"
+        assert obj["baseline"]["is_baseline"] is True
+        assert len(obj["alternatives"]) == 1
+        assert "delta_pct_vs_baseline" in obj["alternatives"][0]
+        # Ranked list is also present.
+        assert "ranked" in obj
+        assert len(obj["ranked"]) == 2
+
+    def test_constraints_in_payload(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(model="text-embedding-3-small")])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+            constraints=WorkloadConstraints(need_capabilities={"vision", "tools"}),
+        )
+        out = format_evaluation_json(report)
+        obj = json.loads(out)
+        assert "constraints" in obj
+        assert "explicit_constraints" in obj
+        assert sorted(obj["explicit_constraints"]["need_capabilities"]) == ["tools", "vision"]
+        assert "embedding" in obj["constraints"]["need_capabilities"]
+        assert "tools" in obj["constraints"]["need_capabilities"]
+        assert "vision" in obj["constraints"]["need_capabilities"]
+
+
+class TestFormatEvaluationCsv:
+    def test_lf_line_endings(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            pricing=chain,
+        )
+        out = format_evaluation_csv(report)
+        assert "\r\n" not in out
+        assert out.endswith("\n")
+        lines = out.strip().split("\n")
+        assert lines[0].startswith("model,provider,is_baseline")
+        # 1 header + 2 data rows.
+        assert len(lines) == 3
+
+
+class TestFormatEvaluationDispatch:
+    def test_dispatch(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        assert "Workload:" in format_evaluation(report, style="text")
+        assert "currency" in format_evaluation(report, style="json")
+        assert "model,provider" in format_evaluation(report, style="csv")
+
+    def test_unknown_style(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        with pytest.raises(ValueError):
+            format_evaluation(report, style="bogus")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_basic(self, tmp_path: Path, capsys):
+        from neatlogs.intel import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3-5-haiku-latest",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "openai/gpt-4o-mini" in out
+        assert "openai/gpt-4o" in out
+        assert "anthropic/claude-3-5-haiku-latest" in out
+        assert "(baseline)" in out
+
+    def test_json(self, tmp_path: Path, capsys):
+        from neatlogs.intel import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        obj = json.loads(out)
+        assert obj["currency"] == "USD"
+
+    def test_csv(self, tmp_path: Path, capsys):
+        from neatlogs.intel import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini",
+                "--format",
+                "csv",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "model,provider" in out
+
+    def test_need_capability(self, tmp_path: Path, capsys):
+        from neatlogs.intel import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini,anthropic/claude-3-5-haiku-latest",
+                "--need",
+                "vision",
+                "--no-color",
+                "--no-auto-infer",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        # haiku is incompatible because no vision.
+        assert "incompatible" in out
+
+    def test_no_candidates_returns_2(self, tmp_path: Path, capsys):
+        from neatlogs.intel import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "totally/nonexistent",
+            ]
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "no candidate" in err
+
+    def test_comma_separated_models(self, tmp_path: Path, capsys):
+        from neatlogs.intel import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini, openai/gpt-4o, anthropic/claude-3-5-haiku-latest",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert all(
+            m in out
+            for m in [
+                "openai/gpt-4o-mini",
+                "openai/gpt-4o",
+                "anthropic/claude-3-5-haiku-latest",
+            ]
+        )
+
+    def test_pricing_file_override(self, tmp_path: Path, capsys):
+        from neatlogs.intel import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        custom = tmp_path / "my.json"
+        custom.write_text(
+            json.dumps(
+                {
+                    "_meta": {"schema_version": "2.0"},
+                    "models": {
+                        "openai/gpt-4o-mini": {
+                            "provider": "openai",
+                            "context_window": 128000,
+                            "capabilities": ["vision", "tools"],
+                            "usage_types": {"input": 0.10, "output": 0.40},
+                        }
+                    },
+                }
+            )
+        )
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini",
+                "--pricing-file",
+                str(custom),
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        # The custom rate is reflected in the output.
+        assert "openai/gpt-4o-mini" in out
+
+    def test_min_context(self, tmp_path: Path, capsys):
+        from neatlogs.intel import _cli
+
+        p = tmp_path / "spans.jsonl"
+        # A 1M-token prompt won't fit in any model in our test catalog.
+        _write_span_log(p, [_span(prompt=1_000_000, completion=50)])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini",
+                "--min-context",
+                "2000000",
+                "--no-color",
+                "--no-auto-infer",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Incompatible because the prompt exceeds the context.
+        assert "incompatible" in out


### PR DESCRIPTION
Closes #57.

## What

`neatlogs-eval` is the "Replay + Model Optimizer" for cost: given a past span log and a list of candidate `provider/model` keys, find the cheapest one that can still serve the workload. It complements `neatlogs-replay` (PR #52, trace tree) and `neatlogs-compare` (PR #56, single-model breakdown) by answering the question neither of them answers: "if I switched from `gpt-4o-mini` to `claude-3-5-haiku-latest` (or `gpt-4.1-mini`, or `gemini-2.5-flash`), what's the saving — and can it actually serve my workload?"

## Why

`neatlogs-compare` (#56) shipped a flat `input_per_1m` / `output_per_1m` schema with boolean capability flags. That breaks down the moment a real user shows up:

- Pricing isn't flat anymore (`cache_read`, `cache_write`, `reasoning`, `image`, `audio`, long-context tiers).
- Capability flags don't compose (adding `supports_audio_input` is a schema + code change).
- Bundled pricing doesn't scale to 800+ models across 40 providers.
- Capability needs are per-workload, not per-user (the user is the one who knows whether they used vision, not the model they happened to call).

This PR ships a small, local, dependency-free engine that fixes all four.

## How

- **`PricingProvider` chain** — `CustomProvider` (user override) → `BuiltinProvider` (bundled `pricing.json`) → future providers. The chain pattern matches Langfuse's model-definition resolution: override wins, fall through to bundled for everything else, pluggable without touching the engine.
- **`usage_types` dict** — `input` / `output` / `cache_read` / `cache_write` / `reasoning` / `image` / `audio` / `embedding` / `...`. Open-ended; adding `per_image` or `gpu_seconds` is a JSON edit, not a code change.
- **`capabilities` as a set of strings** — `vision`, `tools`, `json_mode`, `prompt_cache`, `reasoning`, `audio`, `image_input`, `embedding`. Third-party providers can extend without code changes; the compatibility check fails closed on explicit declarations.
- **Capability auto-infer from source models** — a log that ran on `gpt-4o-mini` is assumed to need whatever `gpt-4o-mini` supports. `--need vision --need tools` overrides. `--no-auto-infer` turns it off entirely.
- **`compatibility_pct` as a first-class metric** — every candidate gets a fraction-of-spans-served score, and a `meets_min_compatibility` flag (default 0.95 = "you can switch 95% of the workload to this model").
- **Per-usage-type tiered pricing** — `claude-3-5-sonnet-latest`'s >200K input/output tier is declared once in JSON and applied per-side. Largest crossed tier wins.
- **Three formatters** — text (colored when stdout is a TTY), JSON, CSV. All three are tested end-to-end.

## Out of scope (deferred per the focused v1 in the issue)

- P50 / P90 / P99 forecasting (the `WorkloadProfile` already carries the percentile data, so this is a follow-up).
- Historical pricing with `effective_from` / `effective_until`.
- Pricing drift detection.
- Auto-suggesting candidate models from the trace.
- Token counting without API calls.
- Currency conversion / batch / committed-use discounts.

## Files

- `neatlogs/intel.py` (new, ~1270 lines): parser, pricing chain, model definition, workload profile, constraints, scoring, ranking, report, three formatters, CLI.
- `neatlogs/config/pricing.json` (modified, schema v1 → v2): 33 models across OpenAI, Anthropic, Google GenAI, DeepSeek, Groq with `usage_types` dict, `capabilities` list, and `tiers` where applicable.
- `pyproject.toml` (modified): `[project.scripts]` entry for `neatlogs-eval`.
- `tests/unit/test_intel.py` (new, ~1800 lines, 107 tests): parser, brace-balanced JSON, all `ModelDefinition` methods, all three `PricingProvider` types, `ChainProvider` priority / fallthrough, `TokenStats` percentiles, `WorkloadProfile`, `_span_cost` (basic / cache_read / cache_write / reasoning / tier / embedding), `_is_span_compatible`, `ScoredModel` ranking, `EvaluationReport`, `evaluate_workload` (basic / unknown / auto-infer / explicit-baseline / min-compatibility), formatters (text / json / csv / dispatch), CLI (basic / json / csv / need / no-candidates / comma-separated / pricing-file / min-context).

## Backward compatibility

None. Pure addition. No existing public API changes. The `[project.scripts]` entry is opt-in. The `pricing.json` schema bump (v1 → v2) is internal to this PR — the v1 file was on PR #56 (not yet merged), so there is no shipped artifact to keep compatible.

## Test plan

- 107 unit tests, 96% line coverage on `neatlogs/intel.py`.
- `black` and `isort` clean.
- Manual smoke test:

  ```bash
  neatlogs-eval logs/spans_raw_optimized.log \
      --candidates openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3-5-haiku-latest,openai/gpt-4.1-mini
  ```

  Produces a ranked table with the baseline first, compatible models by cost, incompatible last, and a capability gap section for any model missing a required capability.
