### PR TITLE
feat(cost): add neatlogs-cost LLM cost intelligence engine

### DIFF
--- a/neatlogs/config/pricing.json
+++ b/neatlogs/config/pricing.json
@@ -1,0 +1,212 @@
+{
+  "_meta": {
+    "currency": "USD",
+    "units": "per_1m_tokens",
+    "schema_version": "2.0",
+    "notes": "v2 schema: usage_types is a dict mapping usage type → USD per 1M tokens. Capabilities is a list of strings. Tiers are a per-usage-type list of {above_tokens, rate} entries (Langfuse convention). Override via --pricing-file or NEATLOGS_PRICING_FILE.",
+    "last_updated": "2026-07"
+  },
+  "models": {
+    "openai/gpt-5": {
+      "provider": "openai",
+      "context_window": 400000,
+      "capabilities": ["tools", "json_mode", "vision", "reasoning"],
+      "usage_types": {"input": 1.25, "output": 10.00}
+    },
+    "openai/gpt-5-mini": {
+      "provider": "openai",
+      "context_window": 400000,
+      "capabilities": ["tools", "json_mode", "vision", "reasoning"],
+      "usage_types": {"input": 0.25, "output": 2.00}
+    },
+    "openai/gpt-5-nano": {
+      "provider": "openai",
+      "context_window": 400000,
+      "capabilities": ["tools", "json_mode", "vision", "reasoning"],
+      "usage_types": {"input": 0.05, "output": 0.40}
+    },
+    "openai/gpt-4.1": {
+      "provider": "openai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 2.00, "output": 8.00, "cache_read": 0.50}
+    },
+    "openai/gpt-4.1-mini": {
+      "provider": "openai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.40, "output": 1.60, "cache_read": 0.10}
+    },
+    "openai/gpt-4.1-nano": {
+      "provider": "openai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.10, "output": 0.40, "cache_read": 0.025}
+    },
+    "openai/gpt-4o": {
+      "provider": "openai",
+      "context_window": 128000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 2.50, "output": 10.00, "cache_read": 1.25}
+    },
+    "openai/gpt-4o-mini": {
+      "provider": "openai",
+      "context_window": 128000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.15, "output": 0.60, "cache_read": 0.075}
+    },
+    "openai/gpt-4o-mini-2024-07-18": {
+      "provider": "openai",
+      "context_window": 128000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.15, "output": 0.60, "cache_read": 0.075}
+    },
+    "openai/o1": {
+      "provider": "openai",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+      "usage_types": {"input": 15.00, "output": 60.00, "reasoning": 60.00, "cache_read": 7.50}
+    },
+    "openai/o1-mini": {
+      "provider": "openai",
+      "context_window": 128000,
+      "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+      "usage_types": {"input": 3.00, "output": 12.00, "reasoning": 12.00, "cache_read": 1.50}
+    },
+    "openai/o3": {
+      "provider": "openai",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+      "usage_types": {"input": 10.00, "output": 40.00, "reasoning": 40.00, "cache_read": 5.00}
+    },
+    "openai/o3-mini": {
+      "provider": "openai",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+      "usage_types": {"input": 1.10, "output": 4.40, "reasoning": 4.40, "cache_read": 0.55}
+    },
+    "openai/o4-mini": {
+      "provider": "openai",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+      "usage_types": {"input": 1.10, "output": 4.40, "reasoning": 4.40, "cache_read": 0.55}
+    },
+    "openai/text-embedding-3-small": {
+      "provider": "openai",
+      "context_window": 8191,
+      "capabilities": ["embedding"],
+      "usage_types": {"input": 0.02, "output": 0.0}
+    },
+    "openai/text-embedding-3-large": {
+      "provider": "openai",
+      "context_window": 8191,
+      "capabilities": ["embedding"],
+      "usage_types": {"input": 0.13, "output": 0.0}
+    },
+    "anthropic/claude-opus-4-1": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 15.00, "output": 75.00, "cache_write": 18.75, "cache_read": 1.50}
+    },
+    "anthropic/claude-opus-4": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 15.00, "output": 75.00, "cache_write": 18.75, "cache_read": 1.50}
+    },
+    "anthropic/claude-sonnet-4": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 3.00, "output": 15.00, "cache_write": 3.75, "cache_read": 0.30},
+      "tiers": {"input": [{"above_tokens": 200000, "rate": 6.00}], "output": [{"above_tokens": 200000, "rate": 22.50}]}
+    },
+    "anthropic/claude-3-7-sonnet-latest": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 3.00, "output": 15.00, "cache_write": 3.75, "cache_read": 0.30},
+      "tiers": {"input": [{"above_tokens": 200000, "rate": 6.00}], "output": [{"above_tokens": 200000, "rate": 22.50}]}
+    },
+    "anthropic/claude-3-5-sonnet-latest": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 3.00, "output": 15.00, "cache_write": 3.75, "cache_read": 0.30}
+    },
+    "anthropic/claude-3-5-haiku-latest": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.80, "output": 4.00, "cache_write": 1.00, "cache_read": 0.08}
+    },
+    "anthropic/claude-3-haiku-20240307": {
+      "provider": "anthropic",
+      "context_window": 200000,
+      "capabilities": ["tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.25, "output": 1.25, "cache_write": 0.30, "cache_read": 0.03}
+    },
+    "google_genai/gemini-2.5-pro": {
+      "provider": "google_genai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode"],
+      "usage_types": {"input": 1.25, "output": 10.00},
+      "tiers": {"input": [{"above_tokens": 200000, "rate": 2.50}], "output": [{"above_tokens": 200000, "rate": 15.00}]}
+    },
+    "google_genai/gemini-2.5-flash": {
+      "provider": "google_genai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode"],
+      "usage_types": {"input": 0.30, "output": 2.50}
+    },
+    "google_genai/gemini-2.0-flash": {
+      "provider": "google_genai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode"],
+      "usage_types": {"input": 0.10, "output": 0.40}
+    },
+    "google_genai/gemini-1.5-pro": {
+      "provider": "google_genai",
+      "context_window": 2000000,
+      "capabilities": ["vision", "tools", "json_mode"],
+      "usage_types": {"input": 1.25, "output": 5.00}
+    },
+    "google_genai/gemini-1.5-flash": {
+      "provider": "google_genai",
+      "context_window": 1000000,
+      "capabilities": ["vision", "tools", "json_mode"],
+      "usage_types": {"input": 0.075, "output": 0.30}
+    },
+    "deepseek/deepseek-chat": {
+      "provider": "deepseek",
+      "context_window": 128000,
+      "capabilities": ["tools", "json_mode", "prompt_cache"],
+      "usage_types": {"input": 0.27, "output": 1.10, "cache_read": 0.07}
+    },
+    "deepseek/deepseek-reasoner": {
+      "provider": "deepseek",
+      "context_window": 128000,
+      "capabilities": ["reasoning"],
+      "usage_types": {"input": 0.55, "output": 2.19, "reasoning": 2.19}
+    },
+    "groq/llama-3.1-70b-versatile": {
+      "provider": "groq",
+      "context_window": 128000,
+      "capabilities": ["tools", "json_mode"],
+      "usage_types": {"input": 0.59, "output": 0.79}
+    },
+    "groq/llama-3.1-8b-instant": {
+      "provider": "groq",
+      "context_window": 128000,
+      "capabilities": ["tools", "json_mode"],
+      "usage_types": {"input": 0.05, "output": 0.08}
+    },
+    "groq/llama-3.3-70b-versatile": {
+      "provider": "groq",
+      "context_window": 128000,
+      "capabilities": ["tools", "json_mode"],
+      "usage_types": {"input": 0.59, "output": 0.79}
+    }
+  }
+}

--- a/neatlogs/cost/__init__.py
+++ b/neatlogs/cost/__init__.py
@@ -1,0 +1,127 @@
+"""
+LLM cost intelligence engine for neatlogs span JSONL logs.
+
+Given a past span log and a list of candidate ``provider/model`` keys,
+answer the questions a finance or engineering team actually asks:
+
+* "What did this workload cost on each model, broken down by input /
+  output / cache / reasoning?" (``breakdown_workload``)
+* "Which candidate is the cheapest one that can still serve the same
+  workload?" (``evaluate_workload``)
+* "What will my monthly bill be at a given call volume?" (``forecast``)
+
+All three share one schema and one CLI (``neatlogs-cost``). Pricing is
+decoupled from the engine via a ``PricingProvider`` chain so users can
+override rates per-environment, fetch a remote catalog, or plug in
+LiteLLM's mirror without touching core code.
+
+CLI::
+
+    neatlogs-cost spans.log \\
+        --candidates openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3-5-haiku-latest
+
+    neatlogs-cost spans.log --candidates openai/gpt-4o-mini,openai/gpt-4o --breakdown
+
+    neatlogs-cost --forecast --model openai/gpt-4o-mini \\
+        --monthly-calls 50000 --avg-prompt 2000 --avg-completion 500 --cache-hit-rate 0.5
+
+Programmatic::
+
+    from neatlogs.cost import (
+        evaluate_workload, breakdown_workload, forecast,
+        BuiltinProvider, CustomProvider, ChainProvider, WorkloadConstraints,
+        format_evaluation, format_breakdown, format_forecast,
+    )
+"""
+
+from .breakdown import (
+    BreakdownReport,
+    ModelCostBreakdown,
+    SpanCost,
+    breakdown_workload,
+    cost_span,
+)
+from .forecast import ForecastReport, forecast
+from .formatters import (
+    format_breakdown,
+    format_breakdown_csv,
+    format_breakdown_json,
+    format_breakdown_text,
+    format_evaluation,
+    format_evaluation_csv,
+    format_evaluation_json,
+    format_evaluation_text,
+    format_forecast,
+    format_forecast_json,
+    format_forecast_text,
+)
+from .pricing import (
+    BuiltinProvider,
+    Capability,
+    ChainProvider,
+    CustomProvider,
+    ModelDefinition,
+    PricingProvider,
+    Tier,
+    UsageType,
+    default_chain,
+)
+from .ranking import (
+    EvaluationReport,
+    ScoredModel,
+    SpanVerdict,
+    evaluate_workload,
+)
+from .spans import SpanUsage
+from .workload import (
+    TokenStats,
+    WorkloadConstraints,
+    WorkloadProfile,
+    build_workload_profile,
+)
+
+__all__ = [
+    # Spans
+    "SpanUsage",
+    # Pricing
+    "Capability",
+    "UsageType",
+    "Tier",
+    "ModelDefinition",
+    "PricingProvider",
+    "BuiltinProvider",
+    "CustomProvider",
+    "ChainProvider",
+    "default_chain",
+    # Workload
+    "TokenStats",
+    "WorkloadProfile",
+    "WorkloadConstraints",
+    "build_workload_profile",
+    # Breakdown
+    "SpanCost",
+    "ModelCostBreakdown",
+    "BreakdownReport",
+    "cost_span",
+    "breakdown_workload",
+    # Ranking
+    "SpanVerdict",
+    "ScoredModel",
+    "EvaluationReport",
+    "evaluate_workload",
+    # Forecast
+    "ForecastReport",
+    "forecast",
+    # Formatters
+    "format_evaluation",
+    "format_evaluation_text",
+    "format_evaluation_json",
+    "format_evaluation_csv",
+    "format_breakdown",
+    "format_breakdown_text",
+    "format_breakdown_json",
+    "format_breakdown_csv",
+    "format_forecast",
+    "format_forecast_text",
+    "format_forecast_json",
+]

--- a/neatlogs/cost/breakdown.py
+++ b/neatlogs/cost/breakdown.py
@@ -1,0 +1,205 @@
+"""Per-model cost breakdown.
+
+Given a span log and a list of candidate models, compute the cost of
+running the same workload on each model and report a per-usage-type
+split (input / output / cache_read / cache_write / reasoning /
+image / audio).
+
+Unlike the ranking evaluator, every model gets a real cost row — there
+is no compatibility filter, no capability gap, no "incompatible"
+state. If a model doesn't bill a usage type, that field is $0.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import sys
+from typing import List, Optional, Sequence, TextIO, Union
+
+from .pricing import ModelDefinition, PricingProvider
+from .spans import PathLike, SpanUsage
+from .workload import WorkloadProfile, _read_paths, build_workload_profile
+
+
+@dataclasses.dataclass
+class SpanCost:
+    """Cost of one span on one model, broken down by usage type.
+
+    Any field not billed by the model is left at 0. A model that does
+    not declare an ``input`` rate but does declare an ``output`` rate
+    will have ``input_cost == 0`` and ``output_cost > 0``.
+    """
+
+    span_id: str
+    model_key: str
+    input_cost: float = 0.0
+    output_cost: float = 0.0
+    cache_read_cost: float = 0.0
+    cache_write_cost: float = 0.0
+    reasoning_cost: float = 0.0
+    image_cost: float = 0.0
+    audio_cost: float = 0.0
+
+    @property
+    def total(self) -> float:
+        return (
+            self.input_cost
+            + self.output_cost
+            + self.cache_read_cost
+            + self.cache_write_cost
+            + self.reasoning_cost
+            + self.image_cost
+            + self.audio_cost
+        )
+
+
+def cost_span(usage: SpanUsage, model: ModelDefinition) -> SpanCost:
+    """Cost of one span on one model, broken down by usage type.
+
+    Tiered pricing is applied per usage type. Returns all zeros if the
+    model does not bill any of the usage types the span actually used.
+    """
+    from .pricing import UsageType
+
+    sc = SpanCost(span_id=usage.span_id, model_key=model.model_key)
+    in_rate = model.effective_rate(UsageType.INPUT, usage.prompt_tokens)
+    out_rate = model.effective_rate(UsageType.OUTPUT, usage.completion_tokens)
+    if in_rate is None and out_rate is None:
+        return sc
+    if in_rate is not None and usage.prompt_tokens > 0:
+        sc.input_cost = (usage.prompt_tokens / 1_000_000) * in_rate
+    if out_rate is not None and usage.completion_tokens > 0:
+        sc.output_cost = (usage.completion_tokens / 1_000_000) * out_rate
+    if usage.cache_creation_tokens > 0:
+        rate = model.effective_rate(UsageType.CACHE_WRITE, usage.cache_creation_tokens)
+        if rate is not None:
+            sc.cache_write_cost = (usage.cache_creation_tokens / 1_000_000) * rate
+    if usage.cache_read_tokens > 0:
+        rate = model.effective_rate(UsageType.CACHE_READ, usage.cache_read_tokens)
+        if rate is not None:
+            sc.cache_read_cost = (usage.cache_read_tokens / 1_000_000) * rate
+    if usage.reasoning_tokens > 0:
+        rate = model.effective_rate(UsageType.REASONING, usage.reasoning_tokens)
+        if rate is not None:
+            sc.reasoning_cost = (usage.reasoning_tokens / 1_000_000) * rate
+    return sc
+
+
+@dataclasses.dataclass
+class ModelCostBreakdown:
+    """Aggregated cost breakdown for one model across a workload."""
+
+    model_key: str
+    provider: str
+    total_cost: float
+    input_cost: float
+    output_cost: float
+    cache_read_cost: float
+    cache_write_cost: float
+    reasoning_cost: float
+    image_cost: float
+    audio_cost: float
+    spans_with_tokens: int
+    spans_total: int
+    spans_skipped: int
+
+
+def _aggregate_costs(usages: List[SpanUsage], model: ModelDefinition) -> ModelCostBreakdown:
+    sums = {
+        "input_cost": 0.0,
+        "output_cost": 0.0,
+        "cache_read_cost": 0.0,
+        "cache_write_cost": 0.0,
+        "reasoning_cost": 0.0,
+        "image_cost": 0.0,
+        "audio_cost": 0.0,
+    }
+    with_tokens = 0
+    for u in usages:
+        if not u.has_tokens:
+            continue
+        with_tokens += 1
+        sc = cost_span(u, model)
+        for k in sums:
+            sums[k] += getattr(sc, k)
+    total = sum(sums.values())
+    return ModelCostBreakdown(
+        model_key=model.model_key,
+        provider=model.provider,
+        total_cost=total,
+        **sums,
+        spans_with_tokens=with_tokens,
+        spans_total=len(usages),
+        spans_skipped=len(usages) - with_tokens,
+    )
+
+
+@dataclasses.dataclass
+class BreakdownReport:
+    """A side-by-side cost breakdown of N candidate models against one
+    workload."""
+
+    profile: WorkloadProfile
+    models: List[ModelCostBreakdown]
+    unknown_models: List[str]
+    files_read: int
+
+    def ranked(self) -> List[ModelCostBreakdown]:
+        return sorted(self.models, key=lambda m: m.total_cost)
+
+    def find(self, model_key: str) -> Optional[ModelCostBreakdown]:
+        for m in self.models:
+            if m.model_key == model_key:
+                return m
+        return None
+
+
+def breakdown_workload(
+    paths: Union[PathLike, Sequence[PathLike]],
+    *,
+    candidates: Sequence[str],
+    pricing: Optional[PricingProvider] = None,
+    warn_stream: Optional[TextIO] = None,
+) -> BreakdownReport:
+    """Read span logs and compute a per-model cost breakdown for each
+    candidate. Unlike ``evaluate_workload``, every model is reported
+    with a real cost — there is no compatibility filter.
+    """
+    if isinstance(paths, (str, os.PathLike)):
+        seq: List[PathLike] = [paths]
+    else:
+        seq = list(paths)
+    if pricing is None:
+        from .pricing import default_chain
+
+        pricing = default_chain()
+    sink = warn_stream if warn_stream is not None else sys.stderr
+
+    profile, _ = build_workload_profile(seq, pricing, auto_infer_capabilities=False)
+    all_usages = _read_paths(seq)
+
+    unknown: List[str] = []
+    resolved: dict = {}
+    for key in candidates:
+        d = pricing.lookup(key)
+        if d is None:
+            unknown.append(key)
+        else:
+            resolved[key] = d
+
+    for k in sorted(unknown):
+        sink.write(
+            f"[neatlogs-cost] warning: candidate model {k!r} not in pricing catalog; "
+            f"it will be omitted from the report. "
+            f"Override via --pricing-file or update "
+            f"neatlogs/config/pricing.json.\n"
+        )
+
+    breakdowns = [_aggregate_costs(all_usages, d) for d in resolved.values()]
+    return BreakdownReport(
+        profile=profile,
+        models=breakdowns,
+        unknown_models=sorted(unknown),
+        files_read=profile.files_read,
+    )

--- a/neatlogs/cost/cli.py
+++ b/neatlogs/cost/cli.py
@@ -1,0 +1,277 @@
+"""``neatlogs-cost`` CLI.
+
+Three modes share one CLI:
+
+* default: what-if ranking with compatibility scoring
+* ``--breakdown``: per-model cost breakdown
+* ``--forecast``: monthly / annual cost projection
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional, Sequence
+
+from .breakdown import breakdown_workload
+from .forecast import forecast
+from .formatters import (
+    _USE_COLOR,
+    format_breakdown,
+    format_evaluation,
+    format_forecast,
+)
+from .pricing import default_chain
+from .ranking import evaluate_workload
+from .workload import WorkloadConstraints
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="neatlogs-cost",
+        description=(
+            "LLM cost intelligence engine: per-model breakdown, what-if "
+            "model ranking, and monthly cost forecasting. Given a span log "
+            "and a list of `provider/model` keys, find the cheapest model "
+            "that can still serve the same workload."
+        ),
+    )
+    p.add_argument(
+        "paths",
+        nargs="*",
+        help="One or more span log file paths. Ignored in --forecast mode.",
+    )
+    p.add_argument(
+        "--candidates",
+        default=None,
+        help=(
+            "Comma-separated list of `provider/model` keys to evaluate. "
+            "In ranking / breakdown mode, the first one is the baseline; "
+            "use --baseline to override. In --forecast mode, defaults to "
+            "--model if --candidates is not given."
+        ),
+    )
+    p.add_argument(
+        "--baseline",
+        default=None,
+        help="Explicit baseline model key. Default: first --candidates entry.",
+    )
+    p.add_argument(
+        "--breakdown",
+        action="store_true",
+        help=(
+            "Show per-model cost breakdown (input / output / cache / "
+            "reasoning) instead of the what-if ranking."
+        ),
+    )
+    p.add_argument(
+        "--need",
+        action="append",
+        default=[],
+        help=(
+            "Require a capability (repeatable). Values: vision, tools, "
+            "json_mode, prompt_cache, reasoning, audio, image_input, "
+            "embedding. By default the engine infers capability needs "
+            "from the source models in the log; --need adds to the set."
+        ),
+    )
+    p.add_argument(
+        "--min-context",
+        type=int,
+        default=0,
+        help=(
+            "Minimum context window in tokens. Models with a smaller "
+            "context_window (or no context_window declared) are marked "
+            "incompatible for any span that exceeds the constraint. "
+            "Default: 0 (no constraint)."
+        ),
+    )
+    p.add_argument(
+        "--min-compatibility",
+        type=float,
+        default=0.95,
+        help=(
+            "Minimum fraction of spans a candidate must be able to serve "
+            "(0.0–1.0). Default: 0.95."
+        ),
+    )
+    p.add_argument(
+        "--format",
+        choices=("text", "json", "csv"),
+        default="text",
+        help="Output format. Default: text.",
+    )
+    p.add_argument(
+        "--pricing-file",
+        default=None,
+        help="Path to a JSON pricing catalog. Default: the bundled catalog.",
+    )
+    p.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI color output even when stdout is a TTY.",
+    )
+    p.add_argument(
+        "--color",
+        action="store_true",
+        help="Force ANSI color output even when stdout is not a TTY.",
+    )
+    p.add_argument(
+        "--no-auto-infer",
+        action="store_true",
+        help=(
+            "Do NOT infer capability needs from the source models. "
+            "Use only --need. Use this when the source model declares "
+            "capabilities the workload does not actually exercise."
+        ),
+    )
+
+    fc = p.add_argument_group("forecast options (use with --forecast)")
+    fc.add_argument(
+        "--forecast",
+        action="store_true",
+        help=(
+            "Switch to forecast mode: project monthly / annual cost for a "
+            "given traffic pattern. Required: --monthly-calls. Useful: "
+            "--avg-prompt, --avg-completion, --cache-hit-rate, "
+            "--reasoning-per-call."
+        ),
+    )
+    fc.add_argument(
+        "--model",
+        default=None,
+        help=(
+            "Model key for --forecast mode. Defaults to the first "
+            "--candidates entry if --candidates is given."
+        ),
+    )
+    fc.add_argument(
+        "--monthly-calls",
+        type=int,
+        default=0,
+        help="Expected number of calls per month.",
+    )
+    fc.add_argument(
+        "--avg-prompt",
+        type=int,
+        default=0,
+        help="Average prompt tokens per call.",
+    )
+    fc.add_argument(
+        "--avg-completion",
+        type=int,
+        default=0,
+        help="Average completion tokens per call.",
+    )
+    fc.add_argument(
+        "--cache-hit-rate",
+        type=float,
+        default=0.0,
+        help="Fraction of prompt tokens served from cache (0.0–1.0).",
+    )
+    fc.add_argument(
+        "--reasoning-per-call",
+        type=int,
+        default=0,
+        help="Average reasoning tokens per call (o-series, R1, etc.).",
+    )
+    return p
+
+
+def _cli(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    global _USE_COLOR
+    if args.no_color:
+        _USE_COLOR = False
+    elif args.color:
+        _USE_COLOR = True
+    pricing = default_chain(args.pricing_file)
+
+    if args.forecast:
+        model_key = args.model
+        if model_key is None and args.candidates:
+            model_key = args.candidates.split(",")[0].strip()
+        if model_key is None:
+            print(
+                "[neatlogs-cost] --forecast requires --model or --candidates",
+                file=sys.stderr,
+            )
+            return 2
+        if args.monthly_calls <= 0:
+            print(
+                "[neatlogs-cost] --forecast requires --monthly-calls > 0",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            fc_report = forecast(
+                model_key=model_key,
+                monthly_calls=args.monthly_calls,
+                avg_prompt_tokens=args.avg_prompt,
+                avg_completion_tokens=args.avg_completion,
+                cache_hit_rate=args.cache_hit_rate,
+                reasoning_per_call=args.reasoning_per_call,
+                pricing=pricing,
+            )
+        except ValueError as e:
+            print(f"[neatlogs-cost] {e}", file=sys.stderr)
+            return 2
+        sys.stdout.write(format_forecast(fc_report, style=args.format))
+        return 0
+
+    if not args.candidates:
+        print(
+            "[neatlogs-cost] --candidates is required in ranking / breakdown mode",
+            file=sys.stderr,
+        )
+        return 2
+    if not args.paths:
+        print(
+            "[neatlogs-cost] at least one path is required in ranking / breakdown mode",
+            file=sys.stderr,
+        )
+        return 2
+
+    candidates = [c.strip() for c in args.candidates.split(",") if c.strip()]
+    constraints = WorkloadConstraints(
+        need_capabilities=set(args.need or []),
+        min_context_window=args.min_context,
+        min_compatibility_pct=args.min_compatibility,
+    )
+
+    if args.breakdown:
+        bd_report = breakdown_workload(
+            args.paths,
+            candidates=candidates,
+            pricing=pricing,
+        )
+        if not bd_report.models:
+            print(
+                "[neatlogs-cost] no candidate models found in the pricing catalog",
+                file=sys.stderr,
+            )
+            return 2
+        sys.stdout.write(format_breakdown(bd_report, style=args.format))
+        return 0
+
+    report = evaluate_workload(
+        args.paths,
+        candidates=candidates,
+        baseline=args.baseline,
+        pricing=pricing,
+        constraints=constraints,
+        auto_infer_capabilities=not args.no_auto_infer,
+    )
+    if not report.alternatives and report.baseline is None:
+        print(
+            "[neatlogs-cost] no candidate models found in the pricing catalog",
+            file=sys.stderr,
+        )
+        return 2
+    sys.stdout.write(format_evaluation(report, style=args.format))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/neatlogs/cost/forecast.py
+++ b/neatlogs/cost/forecast.py
@@ -1,0 +1,123 @@
+"""Monthly / annual cost projection for a given traffic pattern.
+
+The forecast treats the model as a single point estimate: every call
+is assumed to use the same average prompt and completion token counts.
+For more realistic estimates, vary the inputs across a range and
+aggregate.
+
+Notes are added when a requested feature (cache or reasoning) is not
+supported by the model, so the user can see why a portion of the
+forecast is $0.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import List, Optional
+
+from .pricing import PricingProvider, UsageType
+
+
+@dataclasses.dataclass
+class ForecastReport:
+    """Monthly / annual cost projection for a given traffic pattern."""
+
+    model_key: str
+    monthly_calls: int
+    avg_prompt_tokens: int
+    avg_completion_tokens: int
+    cache_hit_rate: float
+    reasoning_per_call: int
+    per_call_cost: float
+    monthly_cost: float
+    annual_cost: float
+    input_cost: float
+    output_cost: float
+    cache_cost: float
+    reasoning_cost: float
+    notes: List[str] = dataclasses.field(default_factory=list)
+
+
+def forecast(
+    *,
+    model_key: str,
+    monthly_calls: int,
+    avg_prompt_tokens: int = 0,
+    avg_completion_tokens: int = 0,
+    cache_hit_rate: float = 0.0,
+    reasoning_per_call: int = 0,
+    pricing: Optional[PricingProvider] = None,
+) -> ForecastReport:
+    """Project monthly and annual cost for a given traffic pattern.
+
+    ``cache_hit_rate`` is the fraction of prompt tokens served from
+    cache (0.0–1.0). When the model does not support prompt caching
+    and ``cache_hit_rate > 0``, the cache portion contributes $0 and a
+    note is added.
+
+    ``reasoning_per_call`` is the average reasoning tokens per call.
+    When the model does not support reasoning and ``reasoning_per_call > 0``,
+    the reasoning portion contributes $0 and a note is added.
+    """
+    if pricing is None:
+        from .pricing import default_chain
+
+        pricing = default_chain()
+    d = pricing.lookup(model_key)
+    if d is None:
+        raise ValueError(f"unknown model: {model_key!r}")
+    notes: List[str] = []
+    cache_hit_rate = max(0.0, min(1.0, float(cache_hit_rate)))
+    hit_prompt = int(avg_prompt_tokens * cache_hit_rate)
+    miss_prompt = avg_prompt_tokens - hit_prompt
+
+    if cache_hit_rate > 0 and (
+        UsageType.CACHE_READ not in d.usage_types and UsageType.CACHE_WRITE not in d.usage_types
+    ):
+        notes.append(
+            f"cache_hit_rate={cache_hit_rate} requested but model does not support prompt caching; cache cost set to 0"
+        )
+    if reasoning_per_call > 0 and UsageType.REASONING not in d.usage_types:
+        notes.append(
+            f"reasoning_per_call={reasoning_per_call} requested but model is not a reasoning model; reasoning cost set to 0"
+        )
+
+    in_rate = d.effective_rate(UsageType.INPUT, miss_prompt)
+    out_rate = d.effective_rate(UsageType.OUTPUT, avg_completion_tokens)
+    input_cost = (miss_prompt / 1_000_000) * in_rate if in_rate is not None else 0.0
+    output_cost = (avg_completion_tokens / 1_000_000) * out_rate if out_rate is not None else 0.0
+
+    cache_cost = 0.0
+    if hit_prompt > 0:
+        cr = d.effective_rate(UsageType.CACHE_READ, hit_prompt)
+        if cr is not None:
+            cache_cost = (hit_prompt / 1_000_000) * cr
+        else:
+            cw = d.effective_rate(UsageType.CACHE_WRITE, hit_prompt)
+            if cw is not None:
+                cache_cost = (hit_prompt / 1_000_000) * cw
+
+    reasoning_cost = 0.0
+    if reasoning_per_call > 0:
+        rr = d.effective_rate(UsageType.REASONING, reasoning_per_call)
+        if rr is not None:
+            reasoning_cost = (reasoning_per_call / 1_000_000) * rr
+
+    per_call = input_cost + output_cost + cache_cost + reasoning_cost
+    monthly = per_call * monthly_calls
+    return ForecastReport(
+        model_key=model_key,
+        monthly_calls=monthly_calls,
+        avg_prompt_tokens=avg_prompt_tokens,
+        avg_completion_tokens=avg_completion_tokens,
+        cache_hit_rate=cache_hit_rate,
+        reasoning_per_call=reasoning_per_call,
+        per_call_cost=per_call,
+        monthly_cost=monthly,
+        annual_cost=monthly * 12,
+        input_cost=input_cost,
+        output_cost=output_cost,
+        cache_cost=cache_cost,
+        reasoning_cost=reasoning_cost,
+        notes=notes,
+    )

--- a/neatlogs/cost/formatters.py
+++ b/neatlogs/cost/formatters.py
@@ -1,0 +1,444 @@
+"""Output formatters for evaluation, breakdown, and forecast reports.
+
+Each report type has three formatters (text / json / csv) and a
+top-level dispatcher that auto-detects TTY for color and validates the
+style argument. Text formatters take an explicit ``use_color`` flag;
+the dispatcher defaults it to ``True`` when stdout is a TTY.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import sys
+from typing import Any, Dict, Optional, TextIO
+
+from .breakdown import BreakdownReport, ModelCostBreakdown
+from .forecast import ForecastReport
+from .ranking import EvaluationReport, ScoredModel
+
+# ---------------------------------------------------------------------------
+# Color
+# ---------------------------------------------------------------------------
+
+
+_USE_COLOR = True
+
+
+def _supports_color(stream: TextIO) -> bool:
+    if not _USE_COLOR:
+        return False
+    if not hasattr(stream, "isatty"):
+        return False
+    return bool(stream.isatty())
+
+
+def _ansi(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m"
+
+
+# ---------------------------------------------------------------------------
+# Evaluation (ranking)
+# ---------------------------------------------------------------------------
+
+
+def format_evaluation_text(report: EvaluationReport, *, use_color: bool = True) -> str:
+    buf = io.StringIO()
+    if not report.alternatives and report.baseline is None:
+        buf.write("(no candidate models in the pricing catalog)\n")
+        return buf.getvalue()
+    p = report.profile
+    buf.write(
+        f"Workload: {p.spans_with_tokens} spans across {len(p.models_used)} model(s); "
+        f"prompt p50={p.prompt_stats.p50:,} p99={p.prompt_stats.p99:,} max={p.prompt_stats.max:,} "
+        f"completion p50={p.completion_stats.p50:,} max={p.completion_stats.max:,}\n"
+    )
+    buf.write(f"  models: {sorted(p.models_used)}\n")
+    if p.capabilities_inferred:
+        buf.write(f"  capabilities inferred: {sorted(p.capabilities_inferred)}\n")
+    constraints = report.constraints.explains()
+    if constraints:
+        buf.write(f"  constraints: {'; '.join(constraints)}\n")
+    buf.write("\n")
+
+    header = f"{'Model':<34} {'Prov':<12} {'Compat':>7} " f"{'Cost':>10} {'vs base':>10}"
+    buf.write(header + "\n")
+    buf.write("-" * len(header) + "\n")
+    for sm in report.ranked():
+        cost_disp = f"${sm.total_cost:.4f}" if sm.meets_min_compatibility else "incompatible"
+        if sm.is_baseline:
+            delta_disp = "(baseline)"
+        else:
+            pct = report.delta_pct_for(sm)
+            delta_disp = f"{pct:+.0f}%" if pct is not None else "n/a"
+        compat_disp = f"{sm.compatibility_pct * 100:.0f}%"
+        line = (
+            f"{sm.model_key[:34]:<34} {sm.provider[:12]:<12} "
+            f"{compat_disp:>7} {cost_disp:>10} {delta_disp:>10}"
+        )
+        if use_color:
+            if sm.is_baseline:
+                line = _ansi("1;33", line)
+            elif not sm.meets_min_compatibility:
+                line = _ansi("31", line)
+            elif report.delta_pct_for(sm) is not None and report.delta_pct_for(sm) < 0:
+                line = _ansi("32", line)
+        buf.write(line + "\n")
+    buf.write("-" * len(header) + "\n")
+
+    if report.baseline is not None:
+        any_gap = any(sm.missing_capabilities for sm in report.alternatives)
+        if any_gap:
+            buf.write("\nCapability gap vs inferred workload needs:\n")
+            for sm in report.alternatives:
+                if sm.missing_capabilities:
+                    buf.write(f"  {sm.model_key}: missing {sorted(sm.missing_capabilities)}\n")
+
+    if p.spans_skipped:
+        buf.write(f"\n({p.spans_skipped} span(s) skipped: no model or no token counts.)\n")
+    return buf.getvalue()
+
+
+def format_evaluation_json(report: EvaluationReport) -> str:
+    def row(sm: ScoredModel) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "model": sm.model_key,
+            "provider": sm.provider,
+            "total_cost": round(sm.total_cost, 6),
+            "compatibility_pct": round(sm.compatibility_pct * 100, 2),
+            "meets_min_compatibility": sm.meets_min_compatibility,
+            "missing_capabilities": sorted(sm.missing_capabilities),
+            "context_window": sm.context_window,
+            "is_baseline": sm.is_baseline,
+        }
+        if not sm.is_baseline and report.baseline is not None:
+            pct = report.delta_pct_for(sm)
+            if pct is not None:
+                d["delta_pct_vs_baseline"] = round(pct, 2)
+        return d
+
+    p = report.profile
+    return (
+        json.dumps(
+            {
+                "currency": "USD",
+                "workload": {
+                    "total_spans": p.total_spans,
+                    "spans_with_tokens": p.spans_with_tokens,
+                    "spans_skipped": p.spans_skipped,
+                    "models_used": sorted(p.models_used),
+                    "capabilities_inferred": sorted(p.capabilities_inferred),
+                    "prompt_stats": {
+                        "p50": p.prompt_stats.p50,
+                        "p90": p.prompt_stats.p90,
+                        "p99": p.prompt_stats.p99,
+                        "max": p.prompt_stats.max,
+                        "total": p.prompt_stats.total,
+                    },
+                    "completion_stats": {
+                        "p50": p.completion_stats.p50,
+                        "p90": p.completion_stats.p90,
+                        "p99": p.completion_stats.p99,
+                        "max": p.completion_stats.max,
+                        "total": p.completion_stats.total,
+                    },
+                },
+                "constraints": {
+                    "need_capabilities": sorted(report.constraints.need_capabilities),
+                    "min_context_window": report.constraints.min_context_window,
+                    "min_compatibility_pct": report.constraints.min_compatibility_pct,
+                },
+                "explicit_constraints": {
+                    "need_capabilities": sorted(report.explicit_constraints.need_capabilities),
+                    "min_context_window": report.explicit_constraints.min_context_window,
+                    "min_compatibility_pct": report.explicit_constraints.min_compatibility_pct,
+                },
+                "baseline": row(report.baseline) if report.baseline else None,
+                "alternatives": [row(sm) for sm in report.alternatives],
+                "ranked": [row(sm) for sm in report.ranked()],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def format_evaluation_csv(report: EvaluationReport) -> str:
+    buf = io.StringIO()
+    w = csv.writer(buf, lineterminator="\n")
+    w.writerow(
+        [
+            "model",
+            "provider",
+            "is_baseline",
+            "total_cost",
+            "compatibility_pct",
+            "meets_min_compatibility",
+            "context_window",
+            "missing_capabilities",
+            "delta_pct_vs_baseline",
+        ]
+    )
+    for sm in report.ranked():
+        pct = report.delta_pct_for(sm)
+        w.writerow(
+            [
+                sm.model_key,
+                sm.provider,
+                "true" if sm.is_baseline else "false",
+                f"{sm.total_cost:.6f}",
+                f"{sm.compatibility_pct * 100:.2f}",
+                "true" if sm.meets_min_compatibility else "false",
+                sm.context_window if sm.context_window is not None else "",
+                ";".join(sorted(sm.missing_capabilities)),
+                "" if pct is None else f"{pct:.2f}",
+            ]
+        )
+    return buf.getvalue()
+
+
+def format_evaluation(
+    report: EvaluationReport,
+    *,
+    style: str = "text",
+    stream: Optional[TextIO] = None,
+) -> str:
+    if style not in ("text", "json", "csv"):
+        raise ValueError(f"unknown style: {style!r}")
+    if style == "json":
+        return format_evaluation_json(report)
+    if style == "csv":
+        return format_evaluation_csv(report)
+    use_color = _supports_color(stream or sys.stdout)
+    return format_evaluation_text(report, use_color=use_color)
+
+
+# ---------------------------------------------------------------------------
+# Breakdown
+# ---------------------------------------------------------------------------
+
+
+def format_breakdown_text(report: BreakdownReport, *, use_color: bool = True) -> str:
+    buf = io.StringIO()
+    if not report.models:
+        buf.write("(no candidate models in the pricing catalog)\n")
+        return buf.getvalue()
+    p = report.profile
+    buf.write(
+        f"Workload: {p.spans_with_tokens} spans across {len(p.models_used)} model(s); "
+        f"prompt p50={p.prompt_stats.p50:,} p99={p.prompt_stats.p99:,} max={p.prompt_stats.max:,} "
+        f"completion p50={p.completion_stats.p50:,} max={p.completion_stats.max:,}\n\n"
+    )
+
+    header = (
+        f"{'Model':<34} {'Input':>10} {'Output':>10} "
+        f"{'CacheR':>10} {'CacheW':>10} {'Reason':>10} {'Total':>10}"
+    )
+    buf.write(header + "\n")
+    buf.write("-" * len(header) + "\n")
+    ranked = report.ranked()
+    for m in ranked:
+        line = (
+            f"{m.model_key[:34]:<34} "
+            f"${m.input_cost:>9.4f} ${m.output_cost:>9.4f} "
+            f"${m.cache_read_cost:>9.4f} ${m.cache_write_cost:>9.4f} "
+            f"${m.reasoning_cost:>9.4f} ${m.total_cost:>9.4f}"
+        )
+        if use_color and m == ranked[0] and ranked[0].total_cost > 0:
+            line = _ansi("32", line)
+        buf.write(line + "\n")
+    buf.write("-" * len(header) + "\n")
+
+    if p.spans_skipped:
+        buf.write(f"\n({p.spans_skipped} span(s) skipped: no model or no token counts.)\n")
+    return buf.getvalue()
+
+
+def format_breakdown_json(report: BreakdownReport) -> str:
+    def row(m: ModelCostBreakdown) -> Dict[str, Any]:
+        return {
+            "model": m.model_key,
+            "provider": m.provider,
+            "total_cost": round(m.total_cost, 6),
+            "input_cost": round(m.input_cost, 6),
+            "output_cost": round(m.output_cost, 6),
+            "cache_read_cost": round(m.cache_read_cost, 6),
+            "cache_write_cost": round(m.cache_write_cost, 6),
+            "reasoning_cost": round(m.reasoning_cost, 6),
+            "image_cost": round(m.image_cost, 6),
+            "audio_cost": round(m.audio_cost, 6),
+            "spans_with_tokens": m.spans_with_tokens,
+            "spans_total": m.spans_total,
+            "spans_skipped": m.spans_skipped,
+        }
+
+    p = report.profile
+    return (
+        json.dumps(
+            {
+                "currency": "USD",
+                "workload": {
+                    "total_spans": p.total_spans,
+                    "spans_with_tokens": p.spans_with_tokens,
+                    "spans_skipped": p.spans_skipped,
+                    "models_used": sorted(p.models_used),
+                    "prompt_stats": {
+                        "p50": p.prompt_stats.p50,
+                        "p90": p.prompt_stats.p90,
+                        "p99": p.prompt_stats.p99,
+                        "max": p.prompt_stats.max,
+                        "total": p.prompt_stats.total,
+                    },
+                    "completion_stats": {
+                        "p50": p.completion_stats.p50,
+                        "p90": p.completion_stats.p90,
+                        "p99": p.completion_stats.p99,
+                        "max": p.completion_stats.max,
+                        "total": p.completion_stats.total,
+                    },
+                },
+                "models": [row(m) for m in report.ranked()],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def format_breakdown_csv(report: BreakdownReport) -> str:
+    buf = io.StringIO()
+    w = csv.writer(buf, lineterminator="\n")
+    w.writerow(
+        [
+            "model",
+            "provider",
+            "input_cost",
+            "output_cost",
+            "cache_read_cost",
+            "cache_write_cost",
+            "reasoning_cost",
+            "image_cost",
+            "audio_cost",
+            "total_cost",
+            "spans_with_tokens",
+            "spans_total",
+            "spans_skipped",
+        ]
+    )
+    for m in report.ranked():
+        w.writerow(
+            [
+                m.model_key,
+                m.provider,
+                f"{m.input_cost:.6f}",
+                f"{m.output_cost:.6f}",
+                f"{m.cache_read_cost:.6f}",
+                f"{m.cache_write_cost:.6f}",
+                f"{m.reasoning_cost:.6f}",
+                f"{m.image_cost:.6f}",
+                f"{m.audio_cost:.6f}",
+                f"{m.total_cost:.6f}",
+                m.spans_with_tokens,
+                m.spans_total,
+                m.spans_skipped,
+            ]
+        )
+    return buf.getvalue()
+
+
+def format_breakdown(
+    report: BreakdownReport,
+    *,
+    style: str = "text",
+    stream: Optional[TextIO] = None,
+) -> str:
+    if style not in ("text", "json", "csv"):
+        raise ValueError(f"unknown style: {style!r}")
+    if style == "json":
+        return format_breakdown_json(report)
+    if style == "csv":
+        return format_breakdown_csv(report)
+    use_color = _supports_color(stream or sys.stdout)
+    return format_breakdown_text(report, use_color=use_color)
+
+
+# ---------------------------------------------------------------------------
+# Forecast
+# ---------------------------------------------------------------------------
+
+
+def format_forecast_text(report: ForecastReport, *, use_color: bool = True) -> str:
+    buf = io.StringIO()
+    buf.write(f"Forecast for {report.model_key} at " f"{report.monthly_calls:,} call(s)/month\n")
+    buf.write(
+        f"  avg prompt: {report.avg_prompt_tokens:,} tokens, "
+        f"avg completion: {report.avg_completion_tokens:,} tokens\n"
+    )
+    if report.cache_hit_rate:
+        buf.write(f"  cache hit rate: {report.cache_hit_rate * 100:.0f}%\n")
+    if report.reasoning_per_call:
+        buf.write(f"  reasoning per call: {report.reasoning_per_call:,} tokens\n")
+    buf.write("\n")
+    header = f"{'':24} {'per call':>12} {'monthly':>14} {'annual':>14}"
+    buf.write(header + "\n")
+    buf.write("-" * len(header) + "\n")
+    rows = [
+        ("Input", report.input_cost),
+        ("Output", report.output_cost),
+        ("Cache", report.cache_cost),
+        ("Reasoning", report.reasoning_cost),
+        ("Total", report.per_call_cost),
+    ]
+    for label, per_call in rows:
+        monthly = per_call * report.monthly_calls
+        annual = monthly * 12
+        line = f"{label:<24} ${per_call:>11.6f} ${monthly:>13.2f} ${annual:>13.2f}"
+        if use_color and label == "Total":
+            line = _ansi("1;33", line)
+        buf.write(line + "\n")
+    if report.notes:
+        buf.write("\nNotes:\n")
+        for n in report.notes:
+            buf.write(f"  {n}\n")
+    return buf.getvalue()
+
+
+def format_forecast_json(report: ForecastReport) -> str:
+    return (
+        json.dumps(
+            {
+                "currency": "USD",
+                "model": report.model_key,
+                "monthly_calls": report.monthly_calls,
+                "avg_prompt_tokens": report.avg_prompt_tokens,
+                "avg_completion_tokens": report.avg_completion_tokens,
+                "cache_hit_rate": report.cache_hit_rate,
+                "reasoning_per_call": report.reasoning_per_call,
+                "per_call_cost": round(report.per_call_cost, 6),
+                "input_cost": round(report.input_cost, 6),
+                "output_cost": round(report.output_cost, 6),
+                "cache_cost": round(report.cache_cost, 6),
+                "reasoning_cost": round(report.reasoning_cost, 6),
+                "monthly_cost": round(report.monthly_cost, 2),
+                "annual_cost": round(report.annual_cost, 2),
+                "notes": list(report.notes),
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def format_forecast(
+    report: ForecastReport,
+    *,
+    style: str = "text",
+    stream: Optional[TextIO] = None,
+) -> str:
+    if style not in ("text", "json"):
+        raise ValueError(f"unknown style: {style!r}")
+    if style == "json":
+        return format_forecast_json(report)
+    use_color = _supports_color(stream or sys.stdout)
+    return format_forecast_text(report, use_color=use_color)

--- a/neatlogs/cost/pricing.py
+++ b/neatlogs/cost/pricing.py
@@ -1,0 +1,284 @@
+"""Pricing schema, model definitions, and the PricingProvider chain.
+
+Schema (v2):
+
+* ``usage_types`` is an open dict — ``input`` / ``output`` /
+  ``cache_read`` / ``cache_write`` / ``reasoning`` / ``image`` /
+  ``audio`` / ``embedding`` / ... — USD per 1M tokens. Adding a new
+  cost dimension is a JSON edit, not a code change.
+* ``capabilities`` is a list of strings — ``vision`` / ``tools`` /
+  ``json_mode`` / ``prompt_cache`` / ``reasoning`` / ``audio`` /
+  ``image_input`` / ``embedding``. Third-party providers can extend
+  without code changes.
+* ``tiers`` is per-usage-type (``{input: [...], output: [...]}``). The
+  largest crossed ``above_tokens`` threshold wins.
+* ``context_window`` is the model's max input tokens.
+
+The chain pattern matches Langfuse's model-definition resolution:
+override first, then bundled, then fallback to provider alias / regex /
+heuristic. New providers (litellm mirror, HTTP catalog) plug in without
+touching the engine.
+"""
+
+from __future__ import annotations
+
+import abc
+import dataclasses
+import json
+import os
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+
+class Capability:
+    """Standard capability names. The catalog is a free-form set, so
+    third-party providers can extend this without code changes —
+    compatibility checks only fail closed on explicit declarations."""
+
+    VISION = "vision"
+    TOOLS = "tools"
+    JSON_MODE = "json_mode"
+    PROMPT_CACHE = "prompt_cache"
+    REASONING = "reasoning"
+    AUDIO = "audio"
+    IMAGE_INPUT = "image_input"
+    EMBEDDING = "embedding"
+
+
+class UsageType:
+    """Standard usage type names. The ``usage_types`` dict on a
+    ``ModelDefinition`` can contain any string key, so this list is
+    documentation rather than a closed enum."""
+
+    INPUT = "input"
+    OUTPUT = "output"
+    CACHE_READ = "cache_read"
+    CACHE_WRITE = "cache_write"
+    REASONING = "reasoning"
+    IMAGE = "image"
+    AUDIO = "audio"
+
+
+@dataclasses.dataclass
+class Tier:
+    """A single tiered rate: if the usage count is strictly above
+    ``above_tokens``, use ``rate`` instead of the base rate. A model
+    with multiple tiers picks the largest ``above_tokens`` that is
+    crossed."""
+
+    above_tokens: int
+    rate: float
+
+
+@dataclasses.dataclass
+class ModelDefinition:
+    """Pricing and capability data for one model.
+
+    ``usage_types`` maps a usage type to USD per 1M tokens. Missing
+    keys mean that usage type is not billed (or not supported).
+
+    ``tiers`` is a per-usage-type list of ``Tier`` entries. When a
+    span's token count crosses a tier threshold, that tier's rate
+    is used. The largest crossed tier wins.
+    """
+
+    model_key: str
+    provider: str
+    context_window: int | None = None
+    capabilities: Set[str] = dataclasses.field(default_factory=set)
+    usage_types: Dict[str, float] = dataclasses.field(default_factory=dict)
+    tiers: Dict[str, List[Tier]] = dataclasses.field(default_factory=dict)
+
+    def rate_for(self, usage_type: str) -> Optional[float]:
+        return self.usage_types.get(usage_type)
+
+    def effective_rate(self, usage_type: str, count: int) -> Optional[float]:
+        base = self.rate_for(usage_type)
+        if base is None:
+            return None
+        if count <= 0 or usage_type not in self.tiers:
+            return base
+        crossed = [t for t in self.tiers[usage_type] if t.above_tokens < count]
+        if not crossed:
+            return base
+        return max(crossed, key=lambda t: t.above_tokens).rate
+
+    def has_capability(self, cap: str) -> bool:
+        return cap in self.capabilities
+
+    def has_all_capabilities(self, caps: Iterable[str]) -> bool:
+        return all(c in self.capabilities for c in caps)
+
+    def missing_capabilities(self, caps: Iterable[str]) -> Set[str]:
+        return {c for c in caps if c not in self.capabilities}
+
+
+class PricingProvider(abc.ABC):
+    """Source of ``ModelDefinition`` for a given model key.
+
+    Implementations include ``BuiltinProvider`` (bundled JSON),
+    ``CustomProvider`` (user-supplied override file), and any future
+    HTTP-backed or litellm-mirror provider. ``ChainProvider`` composes
+    multiple providers in priority order.
+    """
+
+    @abc.abstractmethod
+    def lookup(self, model_key: str) -> Optional[ModelDefinition]: ...
+
+    def lookup_by_provider_and_name(
+        self, provider: Optional[str], model_name: str
+    ) -> Optional[ModelDefinition]:
+        return None
+
+
+def _build_def(key: str, raw: Dict) -> Optional[ModelDefinition]:
+    if not isinstance(raw, dict):
+        return None
+    provider = str(raw.get("provider", "")).lower()
+    if "/" not in key or not provider:
+        return None
+    caps_raw = raw.get("capabilities") or []
+    if not isinstance(caps_raw, list):
+        caps_raw = []
+    capabilities = {str(c) for c in caps_raw if isinstance(c, str)}
+    usage_types_raw = raw.get("usage_types") or {}
+    if not isinstance(usage_types_raw, dict):
+        usage_types_raw = {}
+    usage_types = {
+        str(k): float(v) for k, v in usage_types_raw.items() if isinstance(v, (int, float))
+    }
+    tiers_raw = raw.get("tiers") or {}
+    if not isinstance(tiers_raw, dict):
+        tiers_raw = {}
+    tiers: Dict[str, List[Tier]] = {}
+    for usage_type, entries in tiers_raw.items():
+        if not isinstance(entries, list):
+            continue
+        out_entries: List[Tier] = []
+        for e in entries:
+            if (
+                isinstance(e, dict)
+                and isinstance(e.get("above_tokens"), int)
+                and isinstance(e.get("rate"), (int, float))
+            ):
+                out_entries.append(Tier(above_tokens=e["above_tokens"], rate=float(e["rate"])))
+        if out_entries:
+            tiers[str(usage_type)] = out_entries
+    cw_raw = raw.get("context_window")
+    context_window = cw_raw if isinstance(cw_raw, int) and not isinstance(cw_raw, bool) else None
+    return ModelDefinition(
+        model_key=key,
+        provider=provider,
+        context_window=context_window,
+        capabilities=capabilities,
+        usage_types=usage_types,
+        tiers=tiers,
+    )
+
+
+class BuiltinProvider(PricingProvider):
+    """Reads ``neatlogs/config/pricing.json``."""
+
+    def __init__(self, path: Optional[str | os.PathLike] = None):
+        src = (
+            Path(path)
+            if path is not None
+            else Path(__file__).parent.parent / "config" / "pricing.json"
+        )
+        with open(src, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self._models: Dict[str, ModelDefinition] = {}
+        self._by_pn: Dict[Tuple[str, str], str] = {}
+        for key, raw in (data.get("models") or {}).items():
+            d = _build_def(key, raw)
+            if d is not None:
+                self._models[key] = d
+                self._by_pn[(d.provider, key.split("/", 1)[1])] = key
+
+    def lookup(self, model_key: str) -> Optional[ModelDefinition]:
+        return self._models.get(model_key)
+
+    def lookup_by_provider_and_name(
+        self, provider: Optional[str], model_name: str
+    ) -> Optional[ModelDefinition]:
+        if provider:
+            key = self._by_pn.get((provider.lower(), model_name))
+            if key:
+                return self._models.get(key)
+            return None
+        for prov, name in self._by_pn.keys():
+            if name == model_name:
+                return self._models.get(self._by_pn[(prov, name)])
+        return None
+
+
+class CustomProvider(PricingProvider):
+    """A user-supplied override file. Sits on top of the builtin catalog
+    in a ``ChainProvider`` so the override wins for any model it declares
+    and falls through for everything else.
+    """
+
+    def __init__(self, path: str | os.PathLike):
+        self._path = Path(path)
+        with open(self._path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self._models: Dict[str, ModelDefinition] = {}
+        self._by_pn: Dict[Tuple[str, str], str] = {}
+        for key, raw in (data.get("models") or {}).items():
+            d = _build_def(key, raw)
+            if d is not None:
+                self._models[key] = d
+                self._by_pn[(d.provider, key.split("/", 1)[1])] = key
+
+    def lookup(self, model_key: str) -> Optional[ModelDefinition]:
+        return self._models.get(model_key)
+
+    def lookup_by_provider_and_name(
+        self, provider: Optional[str], model_name: str
+    ) -> Optional[ModelDefinition]:
+        if provider:
+            key = self._by_pn.get((provider.lower(), model_name))
+            if key:
+                return self._models.get(key)
+            return None
+        for prov, name in self._by_pn.keys():
+            if name == model_name:
+                return self._models.get(self._by_pn[(prov, name)])
+        return None
+
+
+class ChainProvider(PricingProvider):
+    """Composes a list of providers in priority order. The first one
+    to return a non-None result wins. Matches the Langfuse model-
+    definition resolution pattern: custom override first, then bundled
+    catalog, then fallback to provider alias / regex / heuristic."""
+
+    def __init__(self, providers: Sequence[PricingProvider]):
+        self._providers = list(providers)
+
+    def lookup(self, model_key: str) -> Optional[ModelDefinition]:
+        for p in self._providers:
+            r = p.lookup(model_key)
+            if r is not None:
+                return r
+        return None
+
+    def lookup_by_provider_and_name(
+        self, provider: Optional[str], model_name: str
+    ) -> Optional[ModelDefinition]:
+        for p in self._providers:
+            r = p.lookup_by_provider_and_name(provider, model_name)
+            if r is not None:
+                return r
+        return None
+
+
+def default_chain(pricing_file: Optional[str | os.PathLike] = None) -> ChainProvider:
+    """Build the default chain: optional user override, then bundled."""
+    providers: List[PricingProvider] = []
+    if pricing_file is not None:
+        providers.append(CustomProvider(pricing_file))
+    elif os.environ.get("NEATLOGS_PRICING_FILE"):
+        providers.append(CustomProvider(os.environ["NEATLOGS_PRICING_FILE"]))
+    providers.append(BuiltinProvider())
+    return ChainProvider(providers)

--- a/neatlogs/cost/ranking.py
+++ b/neatlogs/cost/ranking.py
@@ -1,0 +1,251 @@
+"""What-if model ranking with capability scoring.
+
+Given a span log and a list of candidate models, score every candidate
+against the workload and return a report ranked by cost under
+capability / context / compatibility constraints.
+
+A span is "compatible" with a candidate when:
+
+* the model's ``context_window`` is large enough (when constrained), AND
+* the model declares every capability the workload needs, AND
+* the span didn't use a feature the model doesn't bill (cache on a
+  no-cache model, reasoning on a non-reasoning model).
+
+The candidate's score is the sum of compatible-span costs and the
+``compatibility_pct`` is the fraction of spans it can serve. Ranking
+is: baseline first, then compatible by cost (cheap first), then
+incompatible last.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import sys
+from typing import Dict, List, Optional, Sequence, Set, TextIO, Tuple, Union
+
+from .breakdown import cost_span
+from .pricing import ModelDefinition, PricingProvider, UsageType
+from .spans import PathLike, SpanUsage
+from .workload import WorkloadConstraints, WorkloadProfile, build_workload_profile
+
+
+@dataclasses.dataclass
+class SpanVerdict:
+    """One span's compatibility with one candidate model."""
+
+    span_id: str
+    compatible: bool
+    reasons: List[str] = dataclasses.field(default_factory=list)
+    cost: float = 0.0
+
+
+def _is_span_compatible(
+    usage: SpanUsage, model: ModelDefinition, constraints: WorkloadConstraints
+) -> Tuple[bool, List[str]]:
+    reasons: List[str] = []
+    compatible = True
+    if constraints.min_context_window > 0:
+        if model.context_window is None:
+            compatible = False
+            reasons.append(
+                f"min context {constraints.min_context_window:,} required; "
+                f"model has no declared context"
+            )
+        elif model.context_window < usage.input_total:
+            compatible = False
+            reasons.append(f"prompt {usage.input_total:,} > context {model.context_window:,}")
+    missing = model.missing_capabilities(constraints.need_capabilities)
+    if missing:
+        compatible = False
+        reasons.append(f"missing {sorted(missing)}")
+    if (
+        usage.uses_prompt_cache
+        and UsageType.CACHE_READ not in model.usage_types
+        and UsageType.CACHE_WRITE not in model.usage_types
+    ):
+        compatible = False
+        reasons.append("used cache; model has no cache rate")
+    if usage.uses_reasoning and UsageType.REASONING not in model.usage_types:
+        compatible = False
+        reasons.append("used reasoning; model has no reasoning rate")
+    return compatible, reasons
+
+
+def _score_model(
+    model: ModelDefinition,
+    usages: List[SpanUsage],
+    constraints: WorkloadConstraints,
+    is_baseline: bool,
+) -> "ScoredModel":
+    per_span: List[SpanVerdict] = []
+    for u in usages:
+        ok, reasons = _is_span_compatible(u, model, constraints)
+        cost = cost_span(u, model).total if ok else 0.0
+        per_span.append(SpanVerdict(span_id=u.span_id, compatible=ok, reasons=reasons, cost=cost))
+    compatible_spans = sum(1 for v in per_span if v.compatible)
+    total = sum(v.cost for v in per_span)
+    compat_pct = compatible_spans / len(per_span) if per_span else 0.0
+    meets_pct = compat_pct >= constraints.min_compatibility_pct
+    return ScoredModel(
+        model_key=model.model_key,
+        provider=model.provider,
+        total_cost=total,
+        compatible_spans=compatible_spans,
+        total_spans=len(per_span),
+        compatibility_pct=compat_pct,
+        meets_min_compatibility=meets_pct,
+        missing_capabilities=model.missing_capabilities(constraints.need_capabilities),
+        context_window=model.context_window,
+        per_span=per_span,
+        is_baseline=is_baseline,
+    )
+
+
+@dataclasses.dataclass
+class ScoredModel:
+    """One candidate model's score against the workload."""
+
+    model_key: str
+    provider: str
+    total_cost: float
+    compatible_spans: int
+    total_spans: int
+    compatibility_pct: float
+    meets_min_compatibility: bool
+    missing_capabilities: Set[str]
+    context_window: Optional[int]
+    per_span: List[SpanVerdict]
+    is_baseline: bool = False
+
+    @property
+    def rank_key(self) -> Tuple[int, int, float]:
+        """Lower is better. Sort: baseline first, then compatible by
+        cost (cheap first), then incompatible last."""
+        return (
+            0 if self.is_baseline else 1,
+            0 if self.meets_min_compatibility else 1,
+            self.total_cost,
+        )
+
+    @property
+    def delta_pct_vs_baseline(self) -> Optional[float]:
+        return None  # filled in by EvaluationReport
+
+
+@dataclasses.dataclass
+class EvaluationReport:
+    baseline: Optional[ScoredModel]
+    alternatives: List[ScoredModel]
+    profile: WorkloadProfile
+    constraints: WorkloadConstraints
+    explicit_constraints: WorkloadConstraints
+    unknown_models: List[str]
+    files_read: int
+
+    def all(self) -> List[ScoredModel]:
+        if self.baseline is None:
+            return list(self.alternatives)
+        return [self.baseline] + self.alternatives
+
+    def delta_pct_for(self, sm: ScoredModel) -> Optional[float]:
+        if self.baseline is None or sm.is_baseline:
+            return None
+        if self.baseline.total_cost == 0:
+            return None
+        return (sm.total_cost - self.baseline.total_cost) / self.baseline.total_cost * 100.0
+
+    def ranked(self) -> List[ScoredModel]:
+        return sorted(self.all(), key=lambda s: s.rank_key)
+
+    def find(self, model_key: str) -> Optional[ScoredModel]:
+        for sm in self.all():
+            if sm.model_key == model_key:
+                return sm
+        return None
+
+
+def evaluate_workload(
+    paths: Union[PathLike, Sequence[PathLike]],
+    *,
+    candidates: Sequence[str],
+    baseline: Optional[str] = None,
+    pricing: Optional[PricingProvider] = None,
+    constraints: Optional[WorkloadConstraints] = None,
+    auto_infer_capabilities: bool = True,
+    warn_stream: Optional[TextIO] = None,
+) -> EvaluationReport:
+    """Read span logs, score every candidate model, return a report.
+
+    ``candidates``: ``provider/model`` keys to evaluate.
+    ``baseline``: explicit baseline. Defaults to the first candidate.
+    ``pricing``: override the default chain. ``None`` builds the default.
+    ``constraints``: capability / context-window filters. ``None`` = no filter.
+    ``auto_infer_capabilities``: when True (default), capability
+        requirements are inferred from the source models in the
+        workload. When False, only ``constraints.need_capabilities``
+        applies.
+    """
+    if isinstance(paths, (str, os.PathLike)):
+        seq: List[PathLike] = [paths]
+    else:
+        seq = list(paths)
+    if pricing is None:
+        from .pricing import default_chain
+
+        pricing = default_chain()
+    if constraints is None:
+        constraints = WorkloadConstraints()
+    sink = warn_stream if warn_stream is not None else sys.stderr
+
+    profile, usages = build_workload_profile(
+        seq, pricing, auto_infer_capabilities=auto_infer_capabilities
+    )
+    effective_caps = set(constraints.need_capabilities)
+    if auto_infer_capabilities:
+        effective_caps |= profile.capabilities_inferred
+    effective_constraints = WorkloadConstraints(
+        need_capabilities=effective_caps,
+        min_context_window=constraints.min_context_window,
+        min_compatibility_pct=constraints.min_compatibility_pct,
+    )
+
+    baseline_key = baseline or (candidates[0] if candidates else None)
+    unknown: List[str] = []
+    resolved: Dict[str, ModelDefinition] = {}
+    for key in candidates:
+        d = pricing.lookup(key)
+        if d is None:
+            unknown.append(key)
+        else:
+            resolved[key] = d
+
+    scored: Dict[str, ScoredModel] = {}
+    for key, d in resolved.items():
+        sm = _score_model(
+            d,
+            usages,
+            effective_constraints,
+            is_baseline=(key == baseline_key),
+        )
+        scored[key] = sm
+    baseline_sm = scored.pop(baseline_key, None) if baseline_key else None
+    alternatives = [scored[k] for k in candidates if k in scored and k != baseline_key]
+
+    for k in sorted(unknown):
+        sink.write(
+            f"[neatlogs-cost] warning: candidate model {k!r} not in pricing catalog; "
+            f"it will be omitted from the report. "
+            f"Override via --pricing-file or update "
+            f"neatlogs/config/pricing.json.\n"
+        )
+
+    return EvaluationReport(
+        baseline=baseline_sm,
+        alternatives=alternatives,
+        profile=profile,
+        constraints=effective_constraints,
+        explicit_constraints=constraints,
+        unknown_models=sorted(unknown),
+        files_read=profile.files_read,
+    )

--- a/neatlogs/cost/spans.py
+++ b/neatlogs/cost/spans.py
@@ -1,0 +1,179 @@
+"""Span reading for the cost engine.
+
+Extracts token usage from raw or processed span JSONL records written
+by ``NEATLOGS_LOG_SPANS=true`` / ``NEATLOGS_LOG_RAW_SPANS=true``.
+
+The reader is intentionally permissive: missing fields default to 0,
+malformed lines are skipped, and the same parser handles both the
+processed ``span_data`` shape and the raw ``ReadableSpan.to_json()``
+shape by reading whatever attributes the record declares.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Sequence, Union
+
+PathLike = Union[str, os.PathLike]
+
+
+@dataclasses.dataclass
+class SpanUsage:
+    """One LLM span's token usage, extracted from span attributes."""
+
+    span_id: str
+    trace_id: str
+    model: str
+    provider: str | None
+    prompt_tokens: int
+    completion_tokens: int
+    cache_creation_tokens: int
+    cache_read_tokens: int
+    reasoning_tokens: int
+
+    @property
+    def input_total(self) -> int:
+        return self.prompt_tokens + self.cache_creation_tokens + self.cache_read_tokens
+
+    @property
+    def output_total(self) -> int:
+        return self.completion_tokens + self.reasoning_tokens
+
+    @property
+    def has_tokens(self) -> bool:
+        return any(
+            t > 0
+            for t in (
+                self.prompt_tokens,
+                self.completion_tokens,
+                self.cache_creation_tokens,
+                self.cache_read_tokens,
+                self.reasoning_tokens,
+            )
+        )
+
+    @property
+    def uses_prompt_cache(self) -> bool:
+        return self.cache_creation_tokens > 0 or self.cache_read_tokens > 0
+
+    @property
+    def uses_reasoning(self) -> bool:
+        return self.reasoning_tokens > 0
+
+
+def _int_attr(attrs: Dict[str, Any], *keys: str) -> int:
+    for k in keys:
+        v = attrs.get(k)
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, int) and v >= 0:
+            return v
+        if isinstance(v, float) and v.is_integer() and v >= 0:
+            return int(v)
+    return 0
+
+
+def _extract_usage(obj: Dict[str, Any]) -> SpanUsage:
+    attrs = obj.get("attributes") or {}
+    if not isinstance(attrs, dict):
+        attrs = {}
+    model = (
+        attrs.get("neatlogs.llm.model_name")
+        or attrs.get("gen_ai.response.model")
+        or attrs.get("gen_ai.request.model")
+        or ""
+    )
+    provider = (
+        attrs.get("neatlogs.llm.provider")
+        or attrs.get("neatlogs.llm.system")
+        or attrs.get("gen_ai.system")
+    )
+    if isinstance(provider, str):
+        provider = provider.lower() or None
+    return SpanUsage(
+        span_id=str(obj.get("span_id") or obj.get("context", {}).get("span_id") or ""),
+        trace_id=str(obj.get("trace_id") or obj.get("context", {}).get("trace_id") or ""),
+        model=str(model),
+        provider=provider,
+        prompt_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.prompt",
+            "gen_ai.usage.input_tokens",
+            "gen_ai.usage.prompt_tokens",
+        ),
+        completion_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.completion",
+            "gen_ai.usage.output_tokens",
+            "gen_ai.usage.completion_tokens",
+        ),
+        cache_creation_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.cache_creation",
+            "gen_ai.usage.cache_creation_input_tokens",
+        ),
+        cache_read_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.cache_read",
+            "gen_ai.usage.cache_read_input_tokens",
+        ),
+        reasoning_tokens=_int_attr(
+            attrs,
+            "neatlogs.llm.token_count.reasoning",
+            "gen_ai.usage.reasoning_tokens",
+        ),
+    )
+
+
+def _iter_json_objects(text: str) -> Iterator[Dict[str, Any]]:
+    """Brace-balanced parser; tolerates newlines inside string values."""
+    depth = 0
+    start = -1
+    in_string = False
+    escape = False
+    for i, ch in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                try:
+                    yield json.loads(text[start : i + 1])
+                except json.JSONDecodeError:
+                    pass
+                start = -1
+            elif depth < 0:
+                depth = 0
+
+
+def _read_usages(path: PathLike) -> List[SpanUsage]:
+    p = Path(path)
+    if not p.exists():
+        return []
+    text = p.read_text(encoding="utf-8", errors="replace")
+    if not text.strip():
+        return []
+    return [_extract_usage(obj) for obj in _iter_json_objects(text) if isinstance(obj, dict)]
+
+
+def _read_paths(paths: Sequence[PathLike]) -> List[SpanUsage]:
+    out: List[SpanUsage] = []
+    for raw in paths:
+        out.extend(_read_usages(raw))
+    return out

--- a/neatlogs/cost/workload.py
+++ b/neatlogs/cost/workload.py
@@ -1,0 +1,166 @@
+"""Workload profile and constraints.
+
+A ``WorkloadProfile`` is derived once from a span log and reused by
+both the breakdown and the ranking evaluators. The same percentile
+stats power the per-model breakdown and the what-if ranking tables.
+
+``WorkloadConstraints`` declares what a candidate model must satisfy
+to be considered. The constraint object is the same in both
+``breakdown_workload`` and ``evaluate_workload``; the breakdown mode
+ignores the capability / context-window filters (every model gets a
+real cost row, no compatibility filter).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import List, Sequence, Set, Tuple
+
+from .pricing import PricingProvider
+from .spans import PathLike, SpanUsage, _read_paths
+
+
+@dataclasses.dataclass
+class TokenStats:
+    """Lightweight summary of a token distribution."""
+
+    p50: int
+    p90: int
+    p99: int
+    max: int
+    total: int
+
+    @classmethod
+    def from_values(cls, values: Sequence[int]) -> "TokenStats":
+        if not values:
+            return cls(0, 0, 0, 0, 0)
+        sorted_vals = sorted(values)
+        n = len(sorted_vals)
+
+        def pct(p: float) -> int:
+            idx = min(int(p * (n - 1)), n - 1)
+            return sorted_vals[idx]
+
+        return cls(
+            p50=pct(0.50),
+            p90=pct(0.90),
+            p99=pct(0.99),
+            max=sorted_vals[-1],
+            total=sum(sorted_vals),
+        )
+
+
+@dataclasses.dataclass
+class WorkloadProfile:
+    """Summary of a span log, derived once and reused by both the
+    breakdown and the evaluator."""
+
+    total_spans: int
+    spans_with_tokens: int
+    spans_skipped: int
+    models_used: Set[str]
+    capabilities_inferred: Set[str]
+    prompt_stats: TokenStats
+    completion_stats: TokenStats
+    cache_read_total: int
+    cache_write_total: int
+    reasoning_total: int
+    files_read: int
+
+    @property
+    def needs_cache(self) -> bool:
+        return (self.cache_read_total + self.cache_write_total) > 0
+
+    @property
+    def needs_reasoning(self) -> bool:
+        return self.reasoning_total > 0
+
+
+def _resolve_definition(usage: SpanUsage, pricing: PricingProvider):
+    if not usage.model:
+        return None
+    if usage.provider:
+        candidate = f"{usage.provider}/{usage.model}"
+        d = pricing.lookup(candidate)
+        if d is not None:
+            return d
+    return pricing.lookup_by_provider_and_name(usage.provider, usage.model)
+
+
+def build_workload_profile(
+    paths: Sequence[PathLike],
+    pricing: PricingProvider,
+    *,
+    auto_infer_capabilities: bool = True,
+) -> Tuple[WorkloadProfile, List[SpanUsage]]:
+    """Read span logs, derive a profile, and return ``(profile, usages)``.
+
+    ``auto_infer_capabilities`` (default True) infers the capability set
+    the workload needs from the source models in the log. The user can
+    override via ``WorkloadConstraints.need_capabilities``.
+    """
+    usages = _read_paths(paths)
+    files_read = sum(1 for p in paths if Path(p).exists())
+    with_tokens = [u for u in usages if u.model and u.has_tokens]
+    skipped = len(usages) - len(with_tokens)
+    models_used: Set[str] = set()
+    capabilities: Set[str] = set()
+    prompt_vals: List[int] = []
+    completion_vals: List[int] = []
+    cache_read_total = 0
+    cache_write_total = 0
+    reasoning_total = 0
+    for u in with_tokens:
+        models_used.add(f"{u.provider}/{u.model}" if u.provider else u.model)
+        prompt_vals.append(u.prompt_tokens)
+        completion_vals.append(u.completion_tokens)
+        cache_read_total += u.cache_read_tokens
+        cache_write_total += u.cache_creation_tokens
+        reasoning_total += u.reasoning_tokens
+        if auto_infer_capabilities:
+            d = _resolve_definition(u, pricing)
+            if d is not None:
+                capabilities.update(d.capabilities)
+    profile = WorkloadProfile(
+        total_spans=len(usages),
+        spans_with_tokens=len(with_tokens),
+        spans_skipped=skipped,
+        models_used=models_used,
+        capabilities_inferred=capabilities,
+        prompt_stats=TokenStats.from_values(prompt_vals),
+        completion_stats=TokenStats.from_values(completion_vals),
+        cache_read_total=cache_read_total,
+        cache_write_total=cache_write_total,
+        reasoning_total=reasoning_total,
+        files_read=files_read,
+    )
+    return profile, with_tokens
+
+
+@dataclasses.dataclass
+class WorkloadConstraints:
+    """What a candidate model must satisfy to be considered.
+
+    ``need_capabilities``: set of capability strings the candidate must
+    declare. Missing one is a hard fail.
+    ``min_context_window``: candidate's ``context_window`` must be ``>=``
+    this value. ``0`` (default) means no constraint.
+    ``min_compatibility_pct``: minimum fraction of spans (by count) the
+    candidate can serve. Default 0.95 = "you can switch 95% of the
+    workload to this model".
+    """
+
+    need_capabilities: Set[str] = dataclasses.field(default_factory=set)
+    min_context_window: int = 0
+    min_compatibility_pct: float = 0.95
+
+    def explains(self) -> List[str]:
+        out: List[str] = []
+        if self.need_capabilities:
+            out.append(f"need capabilities: {sorted(self.need_capabilities)}")
+        if self.min_context_window > 0:
+            out.append(f"min context: {self.min_context_window:,} tokens")
+        if self.min_compatibility_pct > 0:
+            out.append(f"min compatibility: {self.min_compatibility_pct * 100:.0f}%")
+        return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,6 +322,9 @@ milvus = [
 [project.entry-points."hermes_agent.plugins"]
 neatlogs = "neatlogs.hermes_plugin"
 
+[project.scripts]
+neatlogs-cost = "neatlogs.cost.cli:_cli"
+
 [project.urls]
 Homepage = "https://github.com/NeatLogs/neatlogs"
 Repository = "https://github.com/NeatLogs/neatlogs.git"

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -1,0 +1,2398 @@
+"""
+Unit tests for neatlogs.cost.
+
+The cost module is the LLM cost intelligence engine: per-model cost
+breakdown, what-if model ranking with compatibility scoring, and
+monthly cost forecasting. All three share the same PricingProvider
+chain and the same v2 pricing schema (usage_types dict, capabilities
+set, per-usage-type tiers).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from neatlogs.cost import (
+    BuiltinProvider,
+    ChainProvider,
+    CustomProvider,
+    EvaluationReport,
+    ModelCostBreakdown,
+    ModelDefinition,
+    ScoredModel,
+    SpanCost,
+    SpanUsage,
+    Tier,
+    TokenStats,
+    UsageType,
+    WorkloadConstraints,
+    WorkloadProfile,
+    breakdown_workload,
+    build_workload_profile,
+    cost_span,
+    default_chain,
+    evaluate_workload,
+    forecast,
+    format_breakdown,
+    format_breakdown_csv,
+    format_breakdown_json,
+    format_breakdown_text,
+    format_evaluation,
+    format_evaluation_csv,
+    format_evaluation_json,
+    format_evaluation_text,
+    format_forecast,
+    format_forecast_json,
+    format_forecast_text,
+)
+
+# Private symbols (from submodules — not part of the public API).
+from neatlogs.cost.pricing import _build_def
+from neatlogs.cost.ranking import _is_span_compatible, _score_model
+from neatlogs.cost.spans import (
+    _extract_usage,
+    _iter_json_objects,
+    _read_paths,
+    _read_usages,
+)
+from neatlogs.cost.workload import _resolve_definition
+
+# ---------------------------------------------------------------------------
+# Test catalog (in-memory)
+# ---------------------------------------------------------------------------
+
+
+def _make_catalog() -> Dict[str, Any]:
+    """A small in-memory catalog for tests. Each model has a distinct
+    capability set and price profile so capability-matching and tier
+    logic can be exercised."""
+    return {
+        "_meta": {"schema_version": "2.0"},
+        "models": {
+            "openai/gpt-4o-mini": {
+                "provider": "openai",
+                "context_window": 128000,
+                "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+                "usage_types": {"input": 0.15, "output": 0.60, "cache_read": 0.075},
+            },
+            "openai/gpt-4o": {
+                "provider": "openai",
+                "context_window": 128000,
+                "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+                "usage_types": {"input": 2.50, "output": 10.00, "cache_read": 1.25},
+            },
+            "openai/o3-mini": {
+                "provider": "openai",
+                "context_window": 200000,
+                "capabilities": ["tools", "json_mode", "reasoning", "prompt_cache"],
+                "usage_types": {
+                    "input": 1.10,
+                    "output": 4.40,
+                    "reasoning": 4.40,
+                    "cache_read": 0.55,
+                },
+            },
+            "openai/text-embedding-3-small": {
+                "provider": "openai",
+                "context_window": 8191,
+                "capabilities": ["embedding"],
+                "usage_types": {"input": 0.02, "output": 0.0},
+            },
+            "anthropic/claude-3-5-haiku-latest": {
+                "provider": "anthropic",
+                "context_window": 200000,
+                "capabilities": ["tools", "json_mode", "prompt_cache"],
+                "usage_types": {
+                    "input": 0.80,
+                    "output": 4.00,
+                    "cache_write": 1.00,
+                    "cache_read": 0.08,
+                },
+            },
+            "anthropic/claude-3-5-sonnet-latest": {
+                "provider": "anthropic",
+                "context_window": 200000,
+                "capabilities": ["vision", "tools", "json_mode", "prompt_cache"],
+                "usage_types": {
+                    "input": 3.00,
+                    "output": 15.00,
+                    "cache_write": 3.75,
+                    "cache_read": 0.30,
+                },
+                "tiers": {
+                    "input": [{"above_tokens": 200000, "rate": 6.00}],
+                    "output": [{"above_tokens": 200000, "rate": 22.50}],
+                },
+            },
+            "anthropic/claude-3-haiku-20240307": {
+                "provider": "anthropic",
+                "context_window": 200000,
+                "capabilities": ["tools", "json_mode", "prompt_cache"],
+                "usage_types": {
+                    "input": 0.25,
+                    "output": 1.25,
+                    "cache_write": 0.30,
+                    "cache_read": 0.03,
+                },
+            },
+        },
+    }
+
+
+def _write_catalog_to_tmp(catalog: Dict[str, Any]) -> Path:
+    fd, path = tempfile.mkstemp(suffix=".json")
+    Path(path).write_text(json.dumps(catalog))
+    return Path(path)
+
+
+def _build_test_provider(catalog: Dict[str, Any] = None) -> CustomProvider:
+    catalog = catalog if catalog is not None else _make_catalog()
+    return CustomProvider(_write_catalog_to_tmp(catalog))
+
+
+def _write_span_log(path: Path, spans: List[Dict[str, Any]]) -> None:
+    path.write_text("\n".join(json.dumps(s) for s in spans))
+
+
+def _span(
+    trace_id: str = "a",
+    span_id: str = "1",
+    name: str = "openai.chat.completions.create",
+    model: str = "gpt-4o-mini",
+    provider: str = "openai",
+    prompt: int = 1000,
+    completion: int = 500,
+    cache_creation: int = 0,
+    cache_read: int = 0,
+    reasoning: int = 0,
+) -> Dict[str, Any]:
+    attrs: Dict[str, Any] = {
+        "neatlogs.llm.model_name": model,
+        "neatlogs.llm.provider": provider,
+        "neatlogs.llm.token_count.prompt": prompt,
+        "neatlogs.llm.token_count.completion": completion,
+    }
+    if cache_creation:
+        attrs["neatlogs.llm.token_count.cache_creation"] = cache_creation
+    if cache_read:
+        attrs["neatlogs.llm.token_count.cache_read"] = cache_read
+    if reasoning:
+        attrs["neatlogs.llm.token_count.reasoning"] = reasoning
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": None,
+        "name": name,
+        "kind": "llm",
+        "start_time": "2024-01-15T10:00:00Z",
+        "end_time": "2024-01-15T10:00:01Z",
+        "attributes": attrs,
+        "status": {"code": "OK", "description": ""},
+        "events": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Span reading
+# ---------------------------------------------------------------------------
+
+
+class TestIntAttr:
+    def test_zero_value_kept(self):
+        # 0 is a valid value, not "missing".
+        from neatlogs.cost.spans import _int_attr
+
+        assert _int_attr({"k": 0}, "k") == 0
+
+    def test_negative_ignored(self):
+        from neatlogs.cost.spans import _int_attr
+
+        assert _int_attr({"k": -5}, "k") == 0
+
+    def test_bool_ignored(self):
+        from neatlogs.cost.spans import _int_attr
+
+        assert _int_attr({"k": True}, "k") == 0
+
+    def test_first_key_wins(self):
+        from neatlogs.cost.spans import _int_attr
+
+        assert _int_attr({"a": 100, "b": 200}, "a", "b") == 100
+        assert _int_attr({"b": 200}, "a", "b") == 200
+
+
+class TestExtractUsage:
+    def test_basic(self):
+        d = {
+            "attributes": {
+                "neatlogs.llm.model_name": "gpt-4o-mini",
+                "neatlogs.llm.provider": "OpenAI",
+                "neatlogs.llm.token_count.prompt": 100,
+                "neatlogs.llm.token_count.completion": 50,
+            }
+        }
+        u = _extract_usage(d)
+        assert u.model == "gpt-4o-mini"
+        assert u.provider == "openai"  # lowercased
+        assert u.prompt_tokens == 100
+        assert u.completion_tokens == 50
+        assert u.cache_creation_tokens == 0
+        assert u.cache_read_tokens == 0
+        assert u.reasoning_tokens == 0
+
+    def test_otel_fallback(self):
+        d = {
+            "attributes": {
+                "gen_ai.system": "openai",
+                "gen_ai.request.model": "gpt-4o",
+                "gen_ai.usage.input_tokens": 200,
+                "gen_ai.usage.output_tokens": 100,
+            }
+        }
+        u = _extract_usage(d)
+        assert u.model == "gpt-4o"
+        assert u.prompt_tokens == 200
+
+    def test_cache_and_reasoning(self):
+        d = {
+            "attributes": {
+                "neatlogs.llm.model_name": "m",
+                "neatlogs.llm.provider": "p",
+                "neatlogs.llm.token_count.prompt": 1000,
+                "neatlogs.llm.token_count.completion": 500,
+                "neatlogs.llm.token_count.cache_creation": 200,
+                "neatlogs.llm.token_count.cache_read": 800,
+                "neatlogs.llm.token_count.reasoning": 100,
+            }
+        }
+        u = _extract_usage(d)
+        assert u.cache_creation_tokens == 200
+        assert u.cache_read_tokens == 800
+        assert u.reasoning_tokens == 100
+        assert u.uses_prompt_cache is True
+        assert u.uses_reasoning is True
+        assert u.input_total == 2000
+        assert u.output_total == 600
+
+
+class TestIterJsonObjects:
+    def test_basic(self):
+        out = list(_iter_json_objects('{"a": 1}\n{"b": 2}'))
+        assert out == [{"a": 1}, {"b": 2}]
+
+    def test_escaped_quotes(self):
+        text = '{"name": "a \\"quoted\\" word"}'
+        out = list(_iter_json_objects(text))
+        assert out == [{"name": 'a "quoted" word'}]
+
+    def test_nested_braces_in_strings(self):
+        text = '{"name": "a {b} c"}'
+        out = list(_iter_json_objects(text))
+        assert out == [{"name": "a {b} c"}]
+
+    def test_malformed_skipped(self):
+        text = '{"a": 1}\n{not valid}\n{"b": 2}'
+        out = list(_iter_json_objects(text))
+        assert out == [{"a": 1}, {"b": 2}]
+
+
+class TestReadUsages:
+    def test_missing_path(self, tmp_path: Path):
+        usages = _read_usages(tmp_path / "missing.jsonl")
+        assert usages == []
+
+    def test_empty(self, tmp_path: Path):
+        p = tmp_path / "empty.jsonl"
+        p.write_text("")
+        assert _read_usages(p) == []
+
+    def test_basic(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=100, completion=50)])
+        usages = _read_usages(p)
+        assert len(usages) == 1
+        assert usages[0].prompt_tokens == 100
+
+    def test_brace_balanced_nested_strings(self, tmp_path: Path):
+        d = _span()
+        d["attributes"]["event_payload"] = "line 1\nline 2 {x}"
+        p = tmp_path / "nested.jsonl"
+        _write_span_log(p, [d])
+        usages = _read_usages(p)
+        assert len(usages) == 1
+
+
+class TestReadPaths:
+    def test_multi_file(self, tmp_path: Path):
+        p1 = tmp_path / "a.jsonl"
+        p2 = tmp_path / "b.jsonl"
+        _write_span_log(p1, [_span(span_id="1", prompt=100)])
+        _write_span_log(p2, [_span(span_id="2", prompt=200)])
+        usages = _read_paths([p1, p2])
+        assert len(usages) == 2
+        assert {u.prompt_tokens for u in usages} == {100, 200}
+
+
+# ---------------------------------------------------------------------------
+# ModelDefinition + Pricing
+# ---------------------------------------------------------------------------
+
+
+class TestModelDefinition:
+    def test_basic(self):
+        d = ModelDefinition(
+            model_key="openai/gpt-4o-mini",
+            provider="openai",
+            context_window=128000,
+            capabilities={"vision", "tools"},
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        assert d.rate_for(UsageType.INPUT) == 0.15
+        assert d.rate_for(UsageType.OUTPUT) == 0.60
+        assert d.rate_for(UsageType.CACHE_READ) is None
+
+    def test_effective_rate_no_tier(self):
+        d = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 0.15},
+        )
+        assert d.effective_rate(UsageType.INPUT, 1000) == 0.15
+        assert d.effective_rate(UsageType.INPUT, 1_000_000) == 0.15
+
+    def test_effective_rate_tier_crossed(self):
+        d = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 3.00},
+            tiers={"input": [Tier(above_tokens=200_000, rate=6.00)]},
+        )
+        # Below threshold: base rate.
+        assert d.effective_rate(UsageType.INPUT, 100_000) == 3.00
+        # Strictly above threshold: tier rate.
+        assert d.effective_rate(UsageType.INPUT, 200_001) == 6.00
+        assert d.effective_rate(UsageType.INPUT, 1_000_000) == 6.00
+
+    def test_effective_rate_zero_tokens(self):
+        d = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 3.00},
+            tiers={"input": [Tier(above_tokens=200_000, rate=6.00)]},
+        )
+        assert d.effective_rate(UsageType.INPUT, 0) == 3.00
+
+    def test_effective_rate_picks_largest_crossed(self):
+        d = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 1.00},
+            tiers={
+                "input": [
+                    Tier(above_tokens=100_000, rate=2.00),
+                    Tier(above_tokens=500_000, rate=4.00),
+                ]
+            },
+        )
+        assert d.effective_rate(UsageType.INPUT, 50_000) == 1.00
+        assert d.effective_rate(UsageType.INPUT, 200_000) == 2.00
+        assert d.effective_rate(UsageType.INPUT, 1_000_000) == 4.00
+
+    def test_capability_helpers(self):
+        d = ModelDefinition(
+            model_key="m",
+            provider="p",
+            capabilities={"vision", "tools", "json_mode"},
+        )
+        assert d.has_capability("vision")
+        assert not d.has_capability("audio")
+        assert d.has_all_capabilities(["vision", "tools"])
+        assert not d.has_all_capabilities(["vision", "audio"])
+        assert d.missing_capabilities(["vision", "audio", "embedding"]) == {"audio", "embedding"}
+
+
+class TestBuildDef:
+    def test_basic(self):
+        d = _build_def(
+            "openai/gpt-4o-mini",
+            {
+                "provider": "openai",
+                "context_window": 128000,
+                "capabilities": ["vision", "tools"],
+                "usage_types": {"input": 0.15, "output": 0.60},
+            },
+        )
+        assert d is not None
+        assert d.model_key == "openai/gpt-4o-mini"
+        assert d.provider == "openai"
+        assert d.context_window == 128000
+        assert d.capabilities == {"vision", "tools"}
+        assert d.usage_types == {"input": 0.15, "output": 0.60}
+
+    def test_with_tiers(self):
+        d = _build_def(
+            "anthropic/claude-3-5-sonnet-latest",
+            {
+                "provider": "anthropic",
+                "context_window": 200000,
+                "capabilities": ["vision", "tools"],
+                "usage_types": {"input": 3.0, "output": 15.0},
+                "tiers": {
+                    "input": [{"above_tokens": 200000, "rate": 6.0}],
+                    "output": [{"above_tokens": 200000, "rate": 22.5}],
+                },
+            },
+        )
+        assert d is not None
+        assert len(d.tiers["input"]) == 1
+        assert d.tiers["input"][0].above_tokens == 200000
+        assert d.tiers["input"][0].rate == 6.0
+
+    def test_skips_invalid_entry(self):
+        assert _build_def("no-slash", {"provider": "openai", "input": 1.0}) is None
+        assert _build_def("openai/no-provider", {"input": 1.0}) is None
+        assert _build_def("openai/x", "not a dict") is None
+
+    def test_skips_invalid_capabilities(self):
+        d = _build_def(
+            "openai/x",
+            {
+                "provider": "openai",
+                "capabilities": "not a list",  # type skip
+                "usage_types": {"input": 1.0},
+            },
+        )
+        assert d is not None
+        assert d.capabilities == set()
+
+    def test_skips_invalid_tier_entries(self):
+        d = _build_def(
+            "openai/x",
+            {
+                "provider": "openai",
+                "usage_types": {"input": 1.0},
+                "tiers": {
+                    "input": [
+                        {"above_tokens": "not an int", "rate": 2.0},  # skip
+                        {"above_tokens": 100, "rate": 2.0},  # keep
+                        "not a dict",  # skip
+                    ],
+                },
+            },
+        )
+        assert d is not None
+        assert len(d.tiers["input"]) == 1
+        assert d.tiers["input"][0].above_tokens == 100
+
+
+# ---------------------------------------------------------------------------
+# PricingProvider
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinProvider:
+    def test_loads_bundled(self):
+        p = BuiltinProvider()
+        assert p.lookup("openai/gpt-4o-mini") is not None
+        assert p.lookup("openai/gpt-4o") is not None
+        assert p.lookup("anthropic/claude-3-5-haiku-latest") is not None
+
+    def test_miss(self):
+        p = BuiltinProvider()
+        assert p.lookup("openai/gpt-99") is None
+
+    def test_lookup_by_provider_and_name(self):
+        p = BuiltinProvider()
+        d = p.lookup_by_provider_and_name("openai", "gpt-4o-mini")
+        assert d is not None
+        assert d.model_key == "openai/gpt-4o-mini"
+
+    def test_lookup_provider_miss_no_fallback(self):
+        # If the user specifies a provider that doesn't have the model,
+        # don't silently fall back to a different provider.
+        p = BuiltinProvider()
+        assert p.lookup_by_provider_and_name("nonexistent", "gpt-4o-mini") is None
+
+    def test_loads_from_custom_path(self, tmp_path: Path):
+        p = tmp_path / "pricing.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "_meta": {"schema_version": "2.0"},
+                    "models": {
+                        "custom/m1": {
+                            "provider": "custom",
+                            "capabilities": [],
+                            "usage_types": {"input": 1.0, "output": 2.0},
+                        },
+                    },
+                }
+            )
+        )
+        provider = BuiltinProvider(p)
+        assert provider.lookup("custom/m1") is not None
+
+
+class TestCustomProvider:
+    def test_loads(self):
+        path = _write_catalog_to_tmp(_make_catalog())
+        try:
+            p = CustomProvider(path)
+            assert p.lookup("openai/gpt-4o-mini") is not None
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_lookup_by_provider_and_name(self):
+        path = _write_catalog_to_tmp(_make_catalog())
+        try:
+            p = CustomProvider(path)
+            d = p.lookup_by_provider_and_name("anthropic", "claude-3-5-haiku-latest")
+            assert d is not None
+        finally:
+            path.unlink(missing_ok=True)
+
+
+class TestChainProvider:
+    def test_first_match_wins(self):
+        # Custom provider returns one def, builtin returns a different one
+        # for the same key. Custom should win.
+        custom = CustomProvider(
+            _write_catalog_to_tmp(
+                {
+                    "_meta": {"schema_version": "2.0"},
+                    "models": {
+                        "openai/gpt-4o-mini": {
+                            "provider": "openai",
+                            "capabilities": ["vision"],
+                            "usage_types": {"input": 0.10, "output": 0.40},
+                        }
+                    },
+                }
+            )
+        )
+        builtin = _build_test_provider()
+        try:
+            chain = ChainProvider([custom, builtin])
+            d = chain.lookup("openai/gpt-4o-mini")
+            assert d is not None
+            # Custom's rate (0.10) wins over builtin's 0.15.
+            assert d.usage_types["input"] == 0.10
+        finally:
+            custom._path.unlink(missing_ok=True)
+
+    def test_falls_through(self):
+        # Custom doesn't have the model, builtin does. Chain falls through.
+        custom_path = _write_catalog_to_tmp(
+            {
+                "_meta": {"schema_version": "2.0"},
+                "models": {
+                    "openai/gpt-4o": {
+                        "provider": "openai",
+                        "capabilities": ["vision"],
+                        "usage_types": {"input": 0.99},
+                    }
+                },
+            }
+        )
+        try:
+            chain = ChainProvider([CustomProvider(custom_path), _build_test_provider()])
+            d = chain.lookup("openai/gpt-4o-mini")
+            assert d is not None
+            assert d.usage_types["input"] == 0.15  # builtin rate
+        finally:
+            custom_path.unlink(missing_ok=True)
+
+    def test_miss_returns_none(self):
+        chain = ChainProvider([_build_test_provider()])
+        assert chain.lookup("openai/gpt-99") is None
+
+    def test_lookup_by_provider_and_name_falls_through(self):
+        chain = ChainProvider([_build_test_provider()])
+        d = chain.lookup_by_provider_and_name("openai", "gpt-4o-mini")
+        assert d is not None
+
+    def test_empty_chain(self):
+        chain = ChainProvider([])
+        assert chain.lookup("openai/gpt-4o-mini") is None
+        assert chain.lookup_by_provider_and_name("openai", "gpt-4o-mini") is None
+
+
+class TestDefaultChain:
+    def test_default_chain_uses_builtin(self, monkeypatch):
+        monkeypatch.delenv("NEATLOGS_PRICING_FILE", raising=False)
+        chain = default_chain()
+        assert chain.lookup("openai/gpt-4o-mini") is not None
+
+    def test_default_chain_uses_pricing_file(self, tmp_path, monkeypatch):
+        custom = tmp_path / "my.json"
+        custom.write_text(
+            json.dumps(
+                {
+                    "_meta": {"schema_version": "2.0"},
+                    "models": {
+                        "custom/m1": {
+                            "provider": "custom",
+                            "capabilities": [],
+                            "usage_types": {"input": 0.01},
+                        }
+                    },
+                }
+            )
+        )
+        chain = default_chain(custom)
+        # Custom override is loaded.
+        assert chain.lookup("custom/m1") is not None
+        # Builtin catalog is also in the chain (custom is just on top).
+        assert chain.lookup("openai/gpt-4o-mini") is not None
+
+    def test_default_chain_uses_env_var(self, tmp_path, monkeypatch):
+        custom = tmp_path / "env.json"
+        custom.write_text(
+            json.dumps(
+                {
+                    "_meta": {"schema_version": "2.0"},
+                    "models": {
+                        "env/m1": {
+                            "provider": "env",
+                            "capabilities": [],
+                            "usage_types": {"input": 0.01},
+                        }
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("NEATLOGS_PRICING_FILE", str(custom))
+        chain = default_chain()
+        assert chain.lookup("env/m1") is not None
+
+
+# ---------------------------------------------------------------------------
+# Workload profile + TokenStats
+# ---------------------------------------------------------------------------
+
+
+class TestTokenStats:
+    def test_empty(self):
+        s = TokenStats.from_values([])
+        assert s.p50 == 0
+        assert s.max == 0
+        assert s.total == 0
+
+    def test_single(self):
+        s = TokenStats.from_values([42])
+        assert s.p50 == 42
+        assert s.p90 == 42
+        assert s.max == 42
+        assert s.total == 42
+
+    def test_percentiles(self):
+        s = TokenStats.from_values(list(range(1, 101)))  # 1..100
+        assert s.p50 == 50
+        assert s.p90 == 90
+        assert s.p99 == 99
+        assert s.max == 100
+        assert s.total == 5050
+
+
+class TestBuildWorkloadProfile:
+    def test_basic(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(
+            p,
+            [
+                _span(span_id="1", prompt=1000, completion=500),
+                _span(span_id="2", prompt=2000, completion=800),
+            ],
+        )
+        profile, usages = build_workload_profile([p], _build_test_provider())
+        assert profile.total_spans == 2
+        assert profile.spans_with_tokens == 2
+        assert profile.spans_skipped == 0
+        assert profile.files_read == 1
+        assert len(usages) == 2
+        # Models used: only gpt-4o-mini.
+        assert profile.models_used == {"openai/gpt-4o-mini"}
+        # Capabilities inferred from the source model.
+        assert "vision" in profile.capabilities_inferred
+        assert "tools" in profile.capabilities_inferred
+        # Prompt stats.
+        assert profile.prompt_stats.max == 2000
+        assert profile.prompt_stats.total == 3000
+        assert profile.completion_stats.max == 800
+
+    def test_auto_infer_off(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        profile, _ = build_workload_profile(
+            [p],
+            _build_test_provider(),
+            auto_infer_capabilities=False,
+        )
+        assert profile.capabilities_inferred == set()
+
+    def test_skips_no_model_spans(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        d = _span(span_id="1")
+        d["attributes"] = {"foo": "bar"}  # no model
+        _write_span_log(p, [d])
+        profile, usages = build_workload_profile([p], _build_test_provider())
+        assert profile.total_spans == 1
+        assert profile.spans_with_tokens == 0
+        assert profile.spans_skipped == 1
+        assert usages == []
+
+    def test_skips_zero_token_spans(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        d = _span(prompt=0, completion=0)
+        _write_span_log(p, [d])
+        profile, _ = build_workload_profile([p], _build_test_provider())
+        assert profile.spans_with_tokens == 0
+        assert profile.spans_skipped == 1
+
+    def test_needs_cache_when_cache_used(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(
+            p,
+            [
+                _span(span_id="1", prompt=100, completion=50, cache_read=50),
+            ],
+        )
+        profile, _ = build_workload_profile([p], _build_test_provider())
+        assert profile.needs_cache is True
+        assert profile.cache_read_total == 50
+
+    def test_unknown_model_no_crash(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(model="some/future-model")])
+        # The future model isn't in the catalog, so no capabilities get
+        # inferred. The profile still gets built.
+        profile, _ = build_workload_profile([p], _build_test_provider())
+        assert profile.capabilities_inferred == set()
+
+    def test_resolve_definition(self):
+        d = _resolve_definition(
+            SpanUsage("s", "t", "gpt-4o-mini", "openai", 100, 50, 0, 0, 0),
+            _build_test_provider(),
+        )
+        assert d is not None
+        assert d.model_key == "openai/gpt-4o-mini"
+
+    def test_resolve_definition_provider_agnostic(self):
+        d = _resolve_definition(
+            SpanUsage("s", "t", "gpt-4o-mini", None, 100, 50, 0, 0, 0),
+            _build_test_provider(),
+        )
+        assert d is not None
+
+    def test_resolve_definition_no_match(self):
+        d = _resolve_definition(
+            SpanUsage("s", "t", "gpt-99", None, 100, 50, 0, 0, 0),
+            _build_test_provider(),
+        )
+        assert d is None
+
+    def test_resolve_definition_empty_model(self):
+        d = _resolve_definition(
+            SpanUsage("s", "t", "", None, 100, 50, 0, 0, 0),
+            _build_test_provider(),
+        )
+        assert d is None
+
+
+# ---------------------------------------------------------------------------
+# Cost engine: cost_span + _is_span_compatible
+# ---------------------------------------------------------------------------
+
+
+class TestCostSpan:
+    def test_basic(self):
+        m = _build_test_provider().lookup("openai/gpt-4o-mini")
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 1_000_000, 1_000_000, 0, 0, 0)
+        c = cost_span(u, m)
+        # input 1M * 0.15 + output 1M * 0.60
+        assert c.total == pytest.approx(0.75, abs=1e-6)
+        assert c.input_cost == pytest.approx(0.15, abs=1e-6)
+        assert c.output_cost == pytest.approx(0.60, abs=1e-6)
+
+    def test_cache_read(self):
+        m = _build_test_provider().lookup("openai/gpt-4o-mini")
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 0, 0, 0, 1_000_000, 0)
+        c = cost_span(u, m)
+        # 1M cache_read at 0.075
+        assert c.total == pytest.approx(0.075, abs=1e-6)
+        assert c.cache_read_cost == pytest.approx(0.075, abs=1e-6)
+        assert c.input_cost == 0.0
+        assert c.output_cost == 0.0
+
+    def test_cache_write_anthropic(self):
+        m = _build_test_provider().lookup("anthropic/claude-3-5-haiku-latest")
+        # prompt=0 so only the cache_write cost is billed.
+        u = SpanUsage("s", "t", "m", "anthropic", 0, 0, 1_000_000, 0, 0)
+        c = cost_span(u, m)
+        # 1M cache_write at 1.00
+        assert c.total == pytest.approx(1.00, abs=1e-6)
+        assert c.cache_write_cost == pytest.approx(1.00, abs=1e-6)
+        assert c.cache_read_cost == 0.0
+
+    def test_reasoning_o_series(self):
+        m = _build_test_provider().lookup("openai/o3-mini")
+        # completion=0 so only input + reasoning are billed.
+        u = SpanUsage("s", "t", "o3-mini", "openai", 100_000, 0, 0, 0, 100_000)
+        c = cost_span(u, m)
+        # 100k input @ 1.10/1M = 0.11, 100k reasoning @ 4.40/1M = 0.44
+        assert c.total == pytest.approx(0.55, abs=1e-6)
+        assert c.input_cost == pytest.approx(0.11, abs=1e-6)
+        assert c.reasoning_cost == pytest.approx(0.44, abs=1e-6)
+        assert c.output_cost == 0.0
+
+    def test_tier_applied(self):
+        m = _build_test_provider().lookup("anthropic/claude-3-5-sonnet-latest")
+        # 300k input crosses the 200k threshold.
+        u = SpanUsage("s", "t", "m", "anthropic", 300_000, 1000, 0, 0, 0)
+        c = cost_span(u, m)
+        # input 300k * 6.00/1M = 1.80; output 1k * 15.00/1M = 0.015
+        assert c.total == pytest.approx(1.815, abs=1e-6)
+        assert c.input_cost == pytest.approx(1.80, abs=1e-6)
+        assert c.output_cost == pytest.approx(0.015, abs=1e-6)
+
+    def test_embedding_model(self):
+        m = _build_test_provider().lookup("openai/text-embedding-3-small")
+        u = SpanUsage("s", "t", "m", "openai", 1_000_000, 0, 0, 0, 0)
+        c = cost_span(u, m)
+        # 1M input at 0.02/1M = 0.02
+        assert c.total == pytest.approx(0.02, abs=1e-6)
+        assert c.input_cost == pytest.approx(0.02, abs=1e-6)
+
+    def test_no_input_or_output_rate(self):
+        # A model with no input/output rate (edge case): cost is 0.
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"image": 0.10},
+        )
+        u = SpanUsage("s", "t", "m", "p", 100, 50, 0, 0, 0)
+        assert cost_span(u, m).total == 0.0
+
+    def test_span_cost_dataclass_defaults(self):
+        c = SpanCost(span_id="x", model_key="y")
+        assert c.input_cost == 0.0
+        assert c.output_cost == 0.0
+        assert c.total == 0.0
+
+    def test_input_only_no_completion(self):
+        m = _build_test_provider().lookup("openai/gpt-4o-mini")
+        u = SpanUsage("s", "t", "m", "openai", 100, 0, 0, 0, 0)
+        c = cost_span(u, m)
+        # 100 input at 0.15/1M = 0.000015
+        assert c.input_cost == pytest.approx(0.000015, abs=1e-9)
+        assert c.output_cost == 0.0
+        assert c.total == c.input_cost
+
+
+class TestSpanCompatibility:
+    def test_compatible_no_constraints(self):
+        m = _build_test_provider().lookup("openai/gpt-4o-mini")
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 100, 50, 0, 0, 0)
+        ok, reasons = _is_span_compatible(u, m, WorkloadConstraints())
+        assert ok is True
+        assert reasons == []
+
+    def test_cache_used_no_cache_rate_incompatible(self):
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        u = SpanUsage("s", "t", "m", "p", 100, 50, 0, 50, 0)
+        ok, reasons = _is_span_compatible(u, m, WorkloadConstraints())
+        assert ok is False
+        assert any("cache" in r for r in reasons)
+
+    def test_reasoning_used_no_reasoning_rate_incompatible(self):
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        u = SpanUsage("s", "t", "m", "p", 100, 50, 0, 0, 50)
+        ok, reasons = _is_span_compatible(u, m, WorkloadConstraints())
+        assert ok is False
+        assert any("reasoning" in r for r in reasons)
+
+    def test_capability_constraint_missing(self):
+        m = _build_test_provider().lookup("anthropic/claude-3-5-haiku-latest")
+        u = SpanUsage("s", "t", "m", "anthropic", 100, 50, 0, 0, 0)
+        ok, reasons = _is_span_compatible(
+            u,
+            m,
+            WorkloadConstraints(need_capabilities={"vision"}),
+        )
+        assert ok is False
+        assert any("vision" in r for r in reasons)
+
+    def test_capability_constraint_satisfied(self):
+        m = _build_test_provider().lookup("openai/gpt-4o")
+        u = SpanUsage("s", "t", "m", "openai", 100, 50, 0, 0, 0)
+        ok, _ = _is_span_compatible(
+            u,
+            m,
+            WorkloadConstraints(need_capabilities={"vision", "tools"}),
+        )
+        assert ok is True
+
+    def test_context_window_too_small(self):
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            context_window=1000,
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        u = SpanUsage("s", "t", "m", "p", 2000, 50, 0, 0, 0)
+        ok, reasons = _is_span_compatible(
+            u,
+            m,
+            WorkloadConstraints(min_context_window=4000),
+        )
+        assert ok is False
+        assert any("context" in r for r in reasons)
+
+    def test_context_window_no_declaration_incompatible(self):
+        # If the model doesn't declare a context_window, the constraint
+        # is treated as a hard fail.
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            context_window=None,
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        u = SpanUsage("s", "t", "m", "p", 100, 50, 0, 0, 0)
+        ok, _ = _is_span_compatible(
+            u,
+            m,
+            WorkloadConstraints(min_context_window=1000),
+        )
+        assert ok is False
+
+    def test_context_window_zero_means_no_constraint(self):
+        m = ModelDefinition(
+            model_key="m",
+            provider="p",
+            context_window=1000,
+            usage_types={"input": 0.15, "output": 0.60},
+        )
+        u = SpanUsage("s", "t", "m", "p", 100_000, 50, 0, 0, 0)
+        ok, _ = _is_span_compatible(u, m, WorkloadConstraints(min_context_window=0))
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# ScoredModel + EvaluationReport
+# ---------------------------------------------------------------------------
+
+
+class TestScoreModel:
+    def test_basic(self):
+        m = _build_test_provider().lookup("openai/gpt-4o-mini")
+        u = SpanUsage("s", "t", "gpt-4o-mini", "openai", 1_000_000, 1_000_000, 0, 0, 0)
+        sm = _score_model(m, [u], WorkloadConstraints(), is_baseline=True)
+        assert sm.total_cost == pytest.approx(0.75, abs=1e-6)
+        assert sm.compatibility_pct == 1.0
+        assert sm.meets_min_compatibility is True
+        assert sm.is_baseline is True
+        assert sm.missing_capabilities == set()
+
+    def test_partial_compatibility(self):
+        m = _build_test_provider().lookup("anthropic/claude-3-5-haiku-latest")
+        u_compat = SpanUsage("1", "t", "m", "anthropic", 100, 50, 0, 0, 0)
+        u_incompat = SpanUsage("2", "t", "m", "anthropic", 100, 50, 0, 0, 0)
+        # Make the second one require vision.
+        m_vision = _build_test_provider().lookup("openai/gpt-4o-mini")
+        u_incompat2 = SpanUsage("3", "t", "m", "openai", 100, 50, 0, 0, 0)
+        # Use constraints to force one span to be incompatible.
+        c = WorkloadConstraints(need_capabilities={"vision"})
+        sm = _score_model(m, [u_compat, u_incompat, u_incompat2], c, is_baseline=False)
+        # 1 of 3 spans compatible (the haiku one is compatible for its own
+        # span, but the constraint forces vision which it lacks).
+        assert sm.compatible_spans == 0
+        assert sm.meets_min_compatibility is False
+
+    def test_rank_key(self):
+        sm_ok = ScoredModel(
+            model_key="a",
+            provider="p",
+            total_cost=0.10,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+        )
+        sm_bad = ScoredModel(
+            model_key="b",
+            provider="p",
+            total_cost=0.0,
+            compatible_spans=0,
+            total_spans=10,
+            compatibility_pct=0.0,
+            meets_min_compatibility=False,
+            missing_capabilities={"vision"},
+            context_window=128000,
+            per_span=[],
+        )
+        # Compatible always ranks first.
+        assert sm_ok.rank_key < sm_bad.rank_key
+
+
+class TestEvaluationReport:
+    def test_delta_pct(self):
+        b = ScoredModel(
+            model_key="b",
+            provider="p",
+            total_cost=1.0,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+            is_baseline=True,
+        )
+        a = ScoredModel(
+            model_key="a",
+            provider="p",
+            total_cost=0.5,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+        )
+        r = EvaluationReport(
+            baseline=b,
+            alternatives=[a],
+            profile=WorkloadProfile(
+                total_spans=10,
+                spans_with_tokens=10,
+                spans_skipped=0,
+                models_used=set(),
+                capabilities_inferred=set(),
+                prompt_stats=TokenStats(0, 0, 0, 0, 0),
+                completion_stats=TokenStats(0, 0, 0, 0, 0),
+                cache_read_total=0,
+                cache_write_total=0,
+                reasoning_total=0,
+                files_read=1,
+            ),
+            constraints=WorkloadConstraints(),
+            explicit_constraints=WorkloadConstraints(),
+            unknown_models=[],
+            files_read=1,
+        )
+        # (0.5 - 1.0) / 1.0 * 100 = -50%
+        assert r.delta_pct_for(a) == pytest.approx(-50, abs=0.1)
+        assert r.delta_pct_for(b) is None  # baseline
+
+    def test_delta_pct_zero_baseline(self):
+        b = ScoredModel(
+            model_key="b",
+            provider="p",
+            total_cost=0.0,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+            is_baseline=True,
+        )
+        a = ScoredModel(
+            model_key="a",
+            provider="p",
+            total_cost=0.5,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+        )
+        r = EvaluationReport(
+            baseline=b,
+            alternatives=[a],
+            profile=WorkloadProfile(
+                total_spans=10,
+                spans_with_tokens=10,
+                spans_skipped=0,
+                models_used=set(),
+                capabilities_inferred=set(),
+                prompt_stats=TokenStats(0, 0, 0, 0, 0),
+                completion_stats=TokenStats(0, 0, 0, 0, 0),
+                cache_read_total=0,
+                cache_write_total=0,
+                reasoning_total=0,
+                files_read=1,
+            ),
+            constraints=WorkloadConstraints(),
+            explicit_constraints=WorkloadConstraints(),
+            unknown_models=[],
+            files_read=1,
+        )
+        # Avoid division by zero.
+        assert r.delta_pct_for(a) is None
+
+    def test_ranked(self):
+        b = ScoredModel(
+            model_key="b",
+            provider="p",
+            total_cost=1.0,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+            is_baseline=True,
+        )
+        a = ScoredModel(
+            model_key="a",
+            provider="p",
+            total_cost=0.5,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+        )
+        c_bad = ScoredModel(
+            model_key="c",
+            provider="p",
+            total_cost=0.0,
+            compatible_spans=0,
+            total_spans=10,
+            compatibility_pct=0.0,
+            meets_min_compatibility=False,
+            missing_capabilities={"vision"},
+            context_window=128000,
+            per_span=[],
+        )
+        r = EvaluationReport(
+            baseline=b,
+            alternatives=[a, c_bad],
+            profile=WorkloadProfile(
+                total_spans=10,
+                spans_with_tokens=10,
+                spans_skipped=0,
+                models_used=set(),
+                capabilities_inferred=set(),
+                prompt_stats=TokenStats(0, 0, 0, 0, 0),
+                completion_stats=TokenStats(0, 0, 0, 0, 0),
+                cache_read_total=0,
+                cache_write_total=0,
+                reasoning_total=0,
+                files_read=1,
+            ),
+            constraints=WorkloadConstraints(),
+            explicit_constraints=WorkloadConstraints(),
+            unknown_models=[],
+            files_read=1,
+        )
+        ranked = r.ranked()
+        assert ranked[0].model_key == "b"  # baseline first
+        assert ranked[1].model_key == "a"  # cheaper alternative
+        assert ranked[2].model_key == "c"  # incompatible last
+
+    def test_find(self):
+        b = ScoredModel(
+            model_key="b",
+            provider="p",
+            total_cost=1.0,
+            compatible_spans=10,
+            total_spans=10,
+            compatibility_pct=1.0,
+            meets_min_compatibility=True,
+            missing_capabilities=set(),
+            context_window=128000,
+            per_span=[],
+            is_baseline=True,
+        )
+        r = EvaluationReport(
+            baseline=b,
+            alternatives=[],
+            profile=WorkloadProfile(
+                total_spans=10,
+                spans_with_tokens=10,
+                spans_skipped=0,
+                models_used=set(),
+                capabilities_inferred=set(),
+                prompt_stats=TokenStats(0, 0, 0, 0, 0),
+                completion_stats=TokenStats(0, 0, 0, 0, 0),
+                cache_read_total=0,
+                cache_write_total=0,
+                reasoning_total=0,
+                files_read=1,
+            ),
+            constraints=WorkloadConstraints(),
+            explicit_constraints=WorkloadConstraints(),
+            unknown_models=[],
+            files_read=1,
+        )
+        assert r.find("b") is b
+        assert r.find("missing") is None
+
+
+# ---------------------------------------------------------------------------
+# evaluate_workload (top-level)
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateWorkload:
+    def test_basic(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "openai/gpt-4o",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            baseline="openai/gpt-4o-mini",
+            pricing=chain,
+            auto_infer_capabilities=False,
+        )
+        assert report.baseline is not None
+        assert report.baseline.model_key == "openai/gpt-4o-mini"
+        assert len(report.alternatives) == 2
+        # All three models should be compatible with the workload when
+        # we don't infer capabilities from the source model.
+        for sm in report.all():
+            assert sm.meets_min_compatibility is True
+
+    def test_unknown_candidate_warns(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        buf = io.StringIO()
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "nonexistent/model"],
+            pricing=chain,
+            warn_stream=buf,
+        )
+        assert "nonexistent/model" in buf.getvalue()
+        # The unknown model is omitted; only the known one is in the report.
+        assert report.find("nonexistent/model") is None
+
+    def test_no_candidates_no_baseline(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[],
+            pricing=chain,
+        )
+        assert report.baseline is None
+        assert report.alternatives == []
+
+    def test_capability_constraint_filters_alternatives(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        # The source model is gpt-4o-mini (has vision). We REQUIRE vision.
+        # haiku (no vision) should be incompatible.
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            constraints=WorkloadConstraints(need_capabilities={"vision"}),
+            auto_infer_capabilities=False,  # explicit only
+        )
+        haiku = report.find("anthropic/claude-3-5-haiku-latest")
+        assert haiku is not None
+        assert haiku.meets_min_compatibility is False
+
+    def test_auto_infer_capabilities(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        # Source model is gpt-4o-mini which has vision. The user does
+        # NOT pass --need; we should still require vision (inferred).
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            # No explicit need; auto_infer is on by default.
+        )
+        haiku = report.find("anthropic/claude-3-5-haiku-latest")
+        assert haiku is not None
+        # haiku is incompatible because the workload needs vision.
+        assert haiku.meets_min_compatibility is False
+
+    def test_auto_infer_can_be_disabled(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            auto_infer_capabilities=False,
+        )
+        haiku = report.find("anthropic/claude-3-5-haiku-latest")
+        # Without auto-infer, haiku is compatible (no constraint applied).
+        assert haiku is not None
+        assert haiku.meets_min_compatibility is True
+
+    def test_explicit_baseline(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            baseline="openai/gpt-4o",
+            pricing=chain,
+        )
+        assert report.baseline.model_key == "openai/gpt-4o"
+        assert report.find("openai/gpt-4o-mini") is not None
+
+    def test_single_path_string(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            str(p),  # str, not Path
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        assert report.baseline is not None
+
+    def test_min_compatibility_pct(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        # 5 spans, 1 needs vision (the source model has vision but only
+        # one span will be marked as needing it via explicit constraint).
+        _write_span_log(
+            p,
+            [
+                _span(span_id="1", prompt=100, completion=50),
+                _span(span_id="2", prompt=100, completion=50),
+                _span(span_id="3", prompt=100, completion=50),
+                _span(span_id="4", prompt=100, completion=50),
+                _span(span_id="5", prompt=100, completion=50),
+            ],
+        )
+        chain = ChainProvider([_build_test_provider()])
+        # haiku (no vision) is incompatible on all 5 spans with vision
+        # required → 0% compatibility → fails the 95% threshold.
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            constraints=WorkloadConstraints(
+                need_capabilities={"vision"},
+                min_compatibility_pct=0.95,
+            ),
+            auto_infer_capabilities=False,
+        )
+        haiku = report.find("anthropic/claude-3-5-haiku-latest")
+        assert haiku is not None
+        assert haiku.meets_min_compatibility is False
+
+    def test_min_compatibility_low_threshold(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span() for _ in range(10)])
+        chain = ChainProvider([_build_test_provider()])
+        # 50% threshold: haiku is OK because it's still in the top
+        # for the 10 spans that are the same.
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            constraints=WorkloadConstraints(
+                need_capabilities={"vision"},
+                min_compatibility_pct=0.0,
+            ),
+            auto_infer_capabilities=False,
+        )
+        haiku = report.find("anthropic/claude-3-5-haiku-latest")
+        assert haiku is not None
+        # 0.0 threshold = always passes.
+        assert haiku.meets_min_compatibility is True
+
+    def test_no_spans_with_tokens(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        d = _span()
+        d["attributes"] = {"foo": "bar"}
+        _write_span_log(p, [d])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        assert report.profile.spans_with_tokens == 0
+        assert report.profile.spans_skipped == 1
+        # Baseline is still set even with no input data; cost is $0.
+        assert report.baseline is not None
+        assert report.baseline.total_cost == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatEvaluationText:
+    def test_basic(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "openai/gpt-4o",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+        )
+        out = format_evaluation_text(report, use_color=False)
+        assert "Workload:" in out
+        assert "openai/gpt-4o-mini" in out
+        assert "openai/gpt-4o" in out
+        assert "anthropic/claude-3-5-haiku-latest" in out
+        assert "(baseline)" in out
+        assert "vs base" in out
+
+    def test_incompatible_shown(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            constraints=WorkloadConstraints(need_capabilities={"vision"}),
+            auto_infer_capabilities=False,
+        )
+        out = format_evaluation_text(report, use_color=False)
+        assert "incompatible" in out
+
+    def test_no_results(self):
+        report = EvaluationReport(
+            baseline=None,
+            alternatives=[],
+            profile=WorkloadProfile(
+                total_spans=0,
+                spans_with_tokens=0,
+                spans_skipped=0,
+                models_used=set(),
+                capabilities_inferred=set(),
+                prompt_stats=TokenStats(0, 0, 0, 0, 0),
+                completion_stats=TokenStats(0, 0, 0, 0, 0),
+                cache_read_total=0,
+                cache_write_total=0,
+                reasoning_total=0,
+                files_read=0,
+            ),
+            constraints=WorkloadConstraints(),
+            explicit_constraints=WorkloadConstraints(),
+            unknown_models=[],
+            files_read=0,
+        )
+        out = format_evaluation_text(report, use_color=False)
+        assert "no candidate" in out
+
+    def test_capability_gap_section(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=[
+                "openai/gpt-4o-mini",
+                "anthropic/claude-3-5-haiku-latest",
+            ],
+            pricing=chain,
+            constraints=WorkloadConstraints(need_capabilities={"vision"}),
+            auto_infer_capabilities=False,
+        )
+        out = format_evaluation_text(report, use_color=False)
+        assert "Capability gap" in out
+        assert "vision" in out
+
+    def test_color_in_output(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            pricing=chain,
+        )
+        out = format_evaluation_text(report, use_color=True)
+        assert "\033[" in out
+
+    def test_color_disabled(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=100, completion=50)])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        out = format_evaluation_text(report, use_color=False)
+        assert "\033[" not in out
+
+
+class TestFormatEvaluationJson:
+    def test_shape(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            pricing=chain,
+        )
+        out = format_evaluation_json(report)
+        obj = json.loads(out)
+        assert obj["currency"] == "USD"
+        assert "workload" in obj
+        assert obj["workload"]["spans_with_tokens"] == 1
+        assert obj["baseline"]["model"] == "openai/gpt-4o-mini"
+        assert obj["baseline"]["is_baseline"] is True
+        assert len(obj["alternatives"]) == 1
+        assert "delta_pct_vs_baseline" in obj["alternatives"][0]
+        # Ranked list is also present.
+        assert "ranked" in obj
+        assert len(obj["ranked"]) == 2
+
+    def test_constraints_in_payload(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(model="text-embedding-3-small")])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+            constraints=WorkloadConstraints(need_capabilities={"vision", "tools"}),
+        )
+        out = format_evaluation_json(report)
+        obj = json.loads(out)
+        assert "constraints" in obj
+        assert "explicit_constraints" in obj
+        assert sorted(obj["explicit_constraints"]["need_capabilities"]) == ["tools", "vision"]
+        assert "embedding" in obj["constraints"]["need_capabilities"]
+        assert "tools" in obj["constraints"]["need_capabilities"]
+        assert "vision" in obj["constraints"]["need_capabilities"]
+
+
+class TestFormatEvaluationCsv:
+    def test_lf_line_endings(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            pricing=chain,
+        )
+        out = format_evaluation_csv(report)
+        assert "\r\n" not in out
+        assert out.endswith("\n")
+        lines = out.strip().split("\n")
+        assert lines[0].startswith("model,provider,is_baseline")
+        # 1 header + 2 data rows.
+        assert len(lines) == 3
+
+
+class TestFormatEvaluationDispatch:
+    def test_dispatch(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        assert "Workload:" in format_evaluation(report, style="text")
+        assert "currency" in format_evaluation(report, style="json")
+        assert "model,provider" in format_evaluation(report, style="csv")
+
+    def test_unknown_style(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = evaluate_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        with pytest.raises(ValueError):
+            format_evaluation(report, style="bogus")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_basic(self, tmp_path: Path, capsys):
+        from neatlogs.cost.cli import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3-5-haiku-latest",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "openai/gpt-4o-mini" in out
+        assert "openai/gpt-4o" in out
+        assert "anthropic/claude-3-5-haiku-latest" in out
+        assert "(baseline)" in out
+
+    def test_json(self, tmp_path: Path, capsys):
+        from neatlogs.cost.cli import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        obj = json.loads(out)
+        assert obj["currency"] == "USD"
+
+    def test_csv(self, tmp_path: Path, capsys):
+        from neatlogs.cost.cli import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini",
+                "--format",
+                "csv",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "model,provider" in out
+
+    def test_need_capability(self, tmp_path: Path, capsys):
+        from neatlogs.cost.cli import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini,anthropic/claude-3-5-haiku-latest",
+                "--need",
+                "vision",
+                "--no-color",
+                "--no-auto-infer",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        # haiku is incompatible because no vision.
+        assert "incompatible" in out
+
+    def test_no_candidates_returns_2(self, tmp_path: Path, capsys):
+        from neatlogs.cost.cli import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "totally/nonexistent",
+            ]
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "no candidate" in err
+
+    def test_comma_separated_models(self, tmp_path: Path, capsys):
+        from neatlogs.cost.cli import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini, openai/gpt-4o, anthropic/claude-3-5-haiku-latest",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert all(
+            m in out
+            for m in [
+                "openai/gpt-4o-mini",
+                "openai/gpt-4o",
+                "anthropic/claude-3-5-haiku-latest",
+            ]
+        )
+
+    def test_pricing_file_override(self, tmp_path: Path, capsys):
+        from neatlogs.cost.cli import _cli
+
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        custom = tmp_path / "my.json"
+        custom.write_text(
+            json.dumps(
+                {
+                    "_meta": {"schema_version": "2.0"},
+                    "models": {
+                        "openai/gpt-4o-mini": {
+                            "provider": "openai",
+                            "context_window": 128000,
+                            "capabilities": ["vision", "tools"],
+                            "usage_types": {"input": 0.10, "output": 0.40},
+                        }
+                    },
+                }
+            )
+        )
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini",
+                "--pricing-file",
+                str(custom),
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        # The custom rate is reflected in the output.
+        assert "openai/gpt-4o-mini" in out
+
+    def test_min_context(self, tmp_path: Path, capsys):
+        from neatlogs.cost.cli import _cli
+
+        p = tmp_path / "spans.jsonl"
+        # A 1M-token prompt won't fit in any model in our test catalog.
+        _write_span_log(p, [_span(prompt=1_000_000, completion=50)])
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini",
+                "--min-context",
+                "2000000",
+                "--no-color",
+                "--no-auto-infer",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Incompatible because the prompt exceeds the context.
+        assert "incompatible" in out
+
+
+# ---------------------------------------------------------------------------
+# Per-model cost breakdown
+# ---------------------------------------------------------------------------
+
+
+class TestBreakdownWorkload:
+    def test_basic(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = breakdown_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "openai/gpt-4o"],
+            pricing=chain,
+        )
+        assert len(report.models) == 2
+        # Both models compatible — totals are real, not $0.
+        gpt4o_mini = report.find("openai/gpt-4o-mini")
+        gpt4o = report.find("openai/gpt-4o")
+        # gpt-4o-mini: 1M input * 0.15 + 1M output * 0.60 = 0.75
+        # gpt-4o: 1M input * 2.50 + 1M output * 10.00 = 12.50
+        assert gpt4o_mini.total_cost == pytest.approx(0.75, abs=1e-6)
+        assert gpt4o.total_cost == pytest.approx(12.50, abs=1e-6)
+        assert gpt4o_mini.input_cost == pytest.approx(0.15, abs=1e-6)
+        assert gpt4o_mini.output_cost == pytest.approx(0.60, abs=1e-6)
+
+    def test_unknown_candidate_omitted(self, tmp_path: Path, capsys):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = breakdown_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini", "openai/unknown"],
+            pricing=chain,
+        )
+        assert len(report.models) == 1
+        assert "openai/unknown" in report.unknown_models
+        captured = capsys.readouterr()
+        assert "openai/unknown" in captured.err
+
+    def test_no_candidates(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = breakdown_workload(
+            paths=p,
+            candidates=[],
+            pricing=chain,
+        )
+        assert report.models == []
+        assert report.unknown_models == []
+
+    def test_ranked(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=1_000_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = breakdown_workload(
+            paths=p,
+            candidates=["openai/gpt-4o", "openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        ranked = report.ranked()
+        assert ranked[0].model_key == "openai/gpt-4o-mini"
+        assert ranked[1].model_key == "openai/gpt-4o"
+
+    def test_spans_skipped_counted(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        # One with tokens, one without.
+        _write_span_log(
+            p,
+            [
+                _span(span_id="1", prompt=1_000_000, completion=500_000),
+                _span(span_id="2", prompt=0, completion=0),
+            ],
+        )
+        chain = ChainProvider([_build_test_provider()])
+        report = breakdown_workload(
+            paths=p,
+            candidates=["openai/gpt-4o-mini"],
+            pricing=chain,
+        )
+        m = report.find("openai/gpt-4o-mini")
+        assert m.spans_with_tokens == 1
+        assert m.spans_total == 2
+        assert m.spans_skipped == 1
+
+
+class TestFormatBreakdown:
+    def test_text_shape(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=500_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = breakdown_workload(paths=p, candidates=["openai/gpt-4o-mini"], pricing=chain)
+        out = format_breakdown_text(report, use_color=False)
+        assert "Workload:" in out
+        assert "openai/gpt-4o-mini" in out
+        assert "Total" in out
+        assert "$" in out
+
+    def test_json_shape(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=500_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = breakdown_workload(paths=p, candidates=["openai/gpt-4o-mini"], pricing=chain)
+        out = format_breakdown_json(report)
+        obj = json.loads(out)
+        assert obj["currency"] == "USD"
+        assert "workload" in obj
+        assert "models" in obj
+        m = obj["models"][0]
+        assert m["model"] == "openai/gpt-4o-mini"
+        assert m["input_cost"] == pytest.approx(0.15, abs=1e-6)
+        assert m["output_cost"] == pytest.approx(0.30, abs=1e-6)
+        assert m["total_cost"] == pytest.approx(0.45, abs=1e-6)
+
+    def test_csv_lf(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=500_000)])
+        chain = ChainProvider([_build_test_provider()])
+        report = breakdown_workload(paths=p, candidates=["openai/gpt-4o-mini"], pricing=chain)
+        out = format_breakdown_csv(report)
+        assert "\r\n" not in out
+        rows = list(csv.DictReader(io.StringIO(out)))
+        assert len(rows) == 1
+        assert rows[0]["model"] == "openai/gpt-4o-mini"
+        assert float(rows[0]["input_cost"]) == pytest.approx(0.15, abs=1e-6)
+
+    def test_no_results(self):
+        from neatlogs.cost import BreakdownReport
+
+        report = BreakdownReport(
+            profile=WorkloadProfile(
+                total_spans=0,
+                spans_with_tokens=0,
+                spans_skipped=0,
+                models_used=set(),
+                capabilities_inferred=set(),
+                prompt_stats=TokenStats(0, 0, 0, 0, 0),
+                completion_stats=TokenStats(0, 0, 0, 0, 0),
+                cache_read_total=0,
+                cache_write_total=0,
+                reasoning_total=0,
+                files_read=0,
+            ),
+            models=[],
+            unknown_models=[],
+            files_read=0,
+        )
+        out = format_breakdown_text(report, use_color=False)
+        assert "no candidate" in out
+
+    def test_dispatch_unknown_style_raises(self, tmp_path: Path):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        chain = ChainProvider([_build_test_provider()])
+        report = breakdown_workload(paths=p, candidates=["openai/gpt-4o-mini"], pricing=chain)
+        with pytest.raises(ValueError, match="unknown style"):
+            format_breakdown(report, style="xml")
+
+
+# ---------------------------------------------------------------------------
+# Forecast
+# ---------------------------------------------------------------------------
+
+
+class TestForecast:
+    def test_basic_no_cache_no_reasoning(self):
+        chain = ChainProvider([_build_test_provider()])
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=10_000,
+            avg_prompt_tokens=1_000,
+            avg_completion_tokens=500,
+            pricing=chain,
+        )
+        # per call: 1k * 0.15/1M + 500 * 0.60/1M = 0.00015 + 0.0003 = 0.00045
+        assert report.per_call_cost == pytest.approx(0.00045, abs=1e-7)
+        assert report.monthly_cost == pytest.approx(4.50, abs=1e-3)
+        assert report.annual_cost == pytest.approx(54.00, abs=1e-2)
+        assert report.input_cost == pytest.approx(0.00015, abs=1e-7)
+        assert report.output_cost == pytest.approx(0.0003, abs=1e-7)
+        assert report.cache_cost == 0.0
+        assert report.reasoning_cost == 0.0
+        assert report.notes == []
+
+    def test_with_cache(self):
+        chain = ChainProvider([_build_test_provider()])
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=10_000,
+            avg_prompt_tokens=1_000,
+            avg_completion_tokens=500,
+            cache_hit_rate=0.5,
+            pricing=chain,
+        )
+        # 50% cached: 500 cache_read at 0.075/1M, 500 miss at 0.15/1M
+        # 500 * 0.075/1M = 0.0000375
+        # 500 * 0.15/1M = 0.000075
+        # plus 500 completion at 0.60/1M = 0.0003
+        # total per call = 0.0004125
+        assert report.cache_cost == pytest.approx(0.0000375, abs=1e-9)
+        assert report.input_cost == pytest.approx(0.000075, abs=1e-9)
+        assert report.output_cost == pytest.approx(0.0003, abs=1e-7)
+        assert report.per_call_cost == pytest.approx(0.0004125, abs=1e-7)
+        assert report.notes == []
+
+    def test_with_reasoning(self):
+        chain = ChainProvider([_build_test_provider()])
+        report = forecast(
+            model_key="openai/o3-mini",
+            monthly_calls=1_000,
+            avg_prompt_tokens=1_000,
+            avg_completion_tokens=0,
+            reasoning_per_call=2_000,
+            pricing=chain,
+        )
+        # 1k * 1.10/1M = 0.0011 input, 2k * 4.40/1M = 0.0088 reasoning
+        assert report.input_cost == pytest.approx(0.0011, abs=1e-7)
+        assert report.reasoning_cost == pytest.approx(0.0088, abs=1e-7)
+        assert report.per_call_cost == pytest.approx(0.0099, abs=1e-7)
+        assert report.monthly_cost == pytest.approx(9.90, abs=1e-2)
+
+    def test_cache_requested_but_no_cache_rate(self):
+        chain = ChainProvider([_build_test_provider()])
+        # text-embedding-3-small has no cache rate in the test catalog.
+        report = forecast(
+            model_key="openai/text-embedding-3-small",
+            monthly_calls=1_000,
+            avg_prompt_tokens=1_000,
+            avg_completion_tokens=0,
+            cache_hit_rate=0.5,
+            pricing=chain,
+        )
+        # cache_hit_rate > 0 but no cache rate → cache cost is 0, note added
+        assert report.cache_cost == 0.0
+        assert any("prompt caching" in n for n in report.notes)
+
+    def test_reasoning_requested_but_no_reasoning_rate(self):
+        chain = ChainProvider([_build_test_provider()])
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=1_000,
+            avg_prompt_tokens=1_000,
+            avg_completion_tokens=500,
+            reasoning_per_call=2_000,
+            pricing=chain,
+        )
+        assert report.reasoning_cost == 0.0
+        assert any("reasoning model" in n for n in report.notes)
+
+    def test_unknown_model_raises(self):
+        chain = ChainProvider([_build_test_provider()])
+        with pytest.raises(ValueError, match="unknown model"):
+            forecast(
+                model_key="openai/does-not-exist",
+                monthly_calls=1_000,
+                avg_prompt_tokens=1_000,
+                pricing=chain,
+            )
+
+    def test_cache_hit_rate_clamped(self):
+        chain = ChainProvider([_build_test_provider()])
+        # > 1.0 gets clamped to 1.0
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=1_000,
+            avg_prompt_tokens=1_000,
+            cache_hit_rate=1.5,
+            pricing=chain,
+        )
+        assert report.cache_hit_rate == 1.0
+        # 100% of 1k prompt tokens at cache rate 0.075/1M = 7.5e-5
+        assert report.cache_cost == pytest.approx(0.000075, abs=1e-9)
+
+
+class TestFormatForecast:
+    def test_text_shape(self):
+        chain = ChainProvider([_build_test_provider()])
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=10_000,
+            avg_prompt_tokens=1_000,
+            avg_completion_tokens=500,
+            pricing=chain,
+        )
+        out = format_forecast_text(report, use_color=False)
+        assert "Forecast for" in out
+        assert "openai/gpt-4o-mini" in out
+        assert "per call" in out
+        assert "monthly" in out
+        assert "annual" in out
+        assert "Input" in out
+        assert "Output" in out
+        assert "Total" in out
+
+    def test_json_shape(self):
+        chain = ChainProvider([_build_test_provider()])
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=10_000,
+            avg_prompt_tokens=1_000,
+            avg_completion_tokens=500,
+            pricing=chain,
+        )
+        out = format_forecast_json(report)
+        obj = json.loads(out)
+        assert obj["model"] == "openai/gpt-4o-mini"
+        assert obj["monthly_calls"] == 10_000
+        assert obj["per_call_cost"] == pytest.approx(0.00045, abs=1e-6)
+        assert obj["monthly_cost"] == pytest.approx(4.50, abs=1e-3)
+        assert obj["annual_cost"] == pytest.approx(54.00, abs=1e-2)
+
+    def test_text_with_notes(self):
+        chain = ChainProvider([_build_test_provider()])
+        report = forecast(
+            model_key="openai/text-embedding-3-small",
+            monthly_calls=1_000,
+            avg_prompt_tokens=1_000,
+            cache_hit_rate=0.5,
+            pricing=chain,
+        )
+        out = format_forecast_text(report, use_color=False)
+        assert "Notes:" in out
+        assert "prompt caching" in out
+
+    def test_dispatch_unknown_style_raises(self):
+        chain = ChainProvider([_build_test_provider()])
+        report = forecast(
+            model_key="openai/gpt-4o-mini",
+            monthly_calls=1_000,
+            avg_prompt_tokens=1_000,
+            pricing=chain,
+        )
+        with pytest.raises(ValueError, match="unknown style"):
+            format_forecast(report, style="csv")
+
+
+# ---------------------------------------------------------------------------
+# CLI: --breakdown and --forecast
+# ---------------------------------------------------------------------------
+
+
+class TestCLIBreakdown:
+    def test_breakdown(self, tmp_path, capsys):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span(prompt=1_000_000, completion=500_000)])
+        from neatlogs.cost.cli import _cli
+
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini,openai/gpt-4o",
+                "--breakdown",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Workload:" in out
+        assert "openai/gpt-4o-mini" in out
+        assert "Total" in out
+        assert "Input" in out
+        assert "Output" in out
+
+    def test_breakdown_json(self, tmp_path, capsys):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        from neatlogs.cost.cli import _cli
+
+        rc = _cli(
+            [
+                str(p),
+                "--candidates",
+                "openai/gpt-4o-mini",
+                "--breakdown",
+                "--format",
+                "json",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        obj = json.loads(out)
+        assert "models" in obj
+        assert obj["currency"] == "USD"
+
+    def test_breakdown_no_candidates(self, tmp_path, capsys):
+        p = tmp_path / "spans.jsonl"
+        _write_span_log(p, [_span()])
+        from neatlogs.cost.cli import _cli
+
+        rc = _cli([str(p), "--no-color"])
+        assert rc == 2
+        assert "--candidates" in capsys.readouterr().err
+
+    def test_breakdown_no_paths(self, capsys):
+        from neatlogs.cost.cli import _cli
+
+        rc = _cli(["--candidates", "openai/gpt-4o-mini", "--breakdown"])
+        assert rc == 2
+        assert "path" in capsys.readouterr().err
+
+
+class TestCLIForecast:
+    def test_basic(self, capsys):
+        from neatlogs.cost.cli import _cli
+
+        rc = _cli(
+            [
+                "--forecast",
+                "--model",
+                "openai/gpt-4o-mini",
+                "--monthly-calls",
+                "10000",
+                "--avg-prompt",
+                "1000",
+                "--avg-completion",
+                "500",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Forecast" in out
+        assert "openai/gpt-4o-mini" in out
+
+    def test_with_cache_and_reasoning(self, capsys):
+        from neatlogs.cost.cli import _cli
+
+        # text-embedding-3-small has no cache + no reasoning support.
+        # Request both → two notes appear.
+        rc = _cli(
+            [
+                "--forecast",
+                "--model",
+                "openai/text-embedding-3-small",
+                "--monthly-calls",
+                "1000",
+                "--avg-prompt",
+                "1000",
+                "--avg-completion",
+                "0",
+                "--reasoning-per-call",
+                "2000",
+                "--cache-hit-rate",
+                "0.5",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Notes:" in out
+        assert "prompt caching" in out
+        assert "reasoning model" in out
+
+    def test_json(self, capsys):
+        from neatlogs.cost.cli import _cli
+
+        rc = _cli(
+            [
+                "--forecast",
+                "--model",
+                "openai/gpt-4o-mini",
+                "--monthly-calls",
+                "10000",
+                "--avg-prompt",
+                "1000",
+                "--format",
+                "json",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        obj = json.loads(out)
+        assert obj["model"] == "openai/gpt-4o-mini"
+
+    def test_no_model_returns_2(self, capsys):
+        from neatlogs.cost.cli import _cli
+
+        rc = _cli(
+            [
+                "--forecast",
+                "--monthly-calls",
+                "10000",
+                "--no-color",
+            ]
+        )
+        assert rc == 2
+        assert "model" in capsys.readouterr().err
+
+    def test_no_monthly_calls_returns_2(self, capsys):
+        from neatlogs.cost.cli import _cli
+
+        rc = _cli(
+            [
+                "--forecast",
+                "--model",
+                "openai/gpt-4o-mini",
+                "--no-color",
+            ]
+        )
+        assert rc == 2
+        assert "monthly-calls" in capsys.readouterr().err
+
+    def test_unknown_model_returns_2(self, capsys):
+        from neatlogs.cost.cli import _cli
+
+        rc = _cli(
+            [
+                "--forecast",
+                "--model",
+                "openai/does-not-exist",
+                "--monthly-calls",
+                "10000",
+                "--no-color",
+            ]
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "unknown model" in err
+
+    def test_uses_candidates_when_model_omitted(self, capsys):
+        from neatlogs.cost.cli import _cli
+
+        rc = _cli(
+            [
+                "--forecast",
+                "--candidates",
+                "openai/gpt-4o-mini",
+                "--monthly-calls",
+                "10000",
+                "--avg-prompt",
+                "1000",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "openai/gpt-4o-mini" in out


### PR DESCRIPTION
Closes #55.

## What

`neatlogs-cost` is a single CLI / module that answers the three cost questions a finance or engineering team actually asks:

1. **Per-model cost breakdown** — "what did this workload cost on each model, split by input / output / cache / reasoning?"
2. **What-if ranking** — "given the same workload, which candidate is the cheapest one that can still serve it?"
3. **Monthly forecast** — "what will my monthly bill be at a given call volume?"

All three share one schema and one CLI. Pricing is decoupled via a `PricingProvider` chain so users can override rates per-environment, fetch a remote catalog, or plug in LiteLLM's mirror without touching core code.

## Why

The original `neatlogs-compare` proposal in #55 had a flat `input_per_1m` / `output_per_1m` schema with boolean capability flags. That breaks down the moment a real user shows up:

- Pricing isn't flat anymore (`cache_read`, `cache_write`, `reasoning`, `image`, `audio`, long-context tiers).
- Capability flags don't compose (adding `supports_audio_input` is a schema + code change).
- Bundled pricing doesn't scale to 800+ models across 40 providers.
- Capability needs are per-workload, not per-user (the user is the one who knows whether they used vision, not the model they happened to call).
- Forecasting needs the same pricing data and the same tier handling; building it as a separate module would mean two schemas and two engines for one user question.

This PR ships one engine, one schema, and one CLI that handles all three.

## How

- **`PricingProvider` chain** — `CustomProvider` (user override) → `BuiltinProvider` (bundled `pricing.json`) → future providers. The chain pattern matches Langfuse's model-definition resolution: override wins, fall through to bundled for everything else, pluggable without touching the engine.
- **`usage_types` dict** — `input` / `output` / `cache_read` / `cache_write` / `reasoning` / `image` / `audio` / `embedding` / `...`. Open-ended; adding `per_image` or `gpu_seconds` is a JSON edit, not a code change.
- **`capabilities` as a set of strings** — `vision`, `tools`, `json_mode`, `prompt_cache`, `reasoning`, `audio`, `image_input`, `embedding`. Third-party providers can extend without code changes; the compatibility check fails closed on explicit declarations.
- **Capability auto-infer from source models** — a log that ran on `gpt-4o-mini` is assumed to need whatever `gpt-4o-mini` supports. `--need vision --need tools` overrides. `--no-auto-infer` turns it off entirely.
- **`compatibility_pct` as a first-class metric** — every candidate gets a fraction-of-spans-served score, and a `meets_min_compatibility` flag (default 0.95 = "you can switch 95% of the workload to this model").
- **Per-usage-type tiered pricing** — `claude-3-5-sonnet-latest`'s >200K input/output tier is declared once in JSON and applied per-side. Largest crossed tier wins.
- **Per-span cost breakdown dataclass** (`SpanCost`) — input_cost / output_cost / cache_read_cost / cache_write_cost / reasoning_cost / image_cost / audio_cost, aggregated into `ModelCostBreakdown` per model.
- **Forecast mode** — synthetic per-call usage built from `--monthly-calls` / `--avg-prompt` / `--avg-completion` / `--cache-hit-rate` / `--reasoning-per-call`; per-call / monthly / annual cost reported. Notes added when a requested feature (cache or reasoning) is not supported by the model.
- **Three formatters** — text (colored when stdout is a TTY), JSON, CSV. All three are tested end-to-end on all three modes.

## Out of scope (deferred per the focused v1 in the issue)

- Auto-suggesting candidate models from the trace.
- Token counting without API calls.
- Currency conversion / batch / committed-use discounts.
- Historical pricing with `effective_from` / `effective_until`.
- Pricing drift detection.

## Files

The engine ships as a `neatlogs.cost` subpackage so each concern lives in its own focused module:

- `neatlogs/cost/__init__.py` (127 lines): public API surface — re-exports 36 symbols with one explicit `__all__` list.
- `neatlogs/cost/spans.py` (179 lines): `SpanUsage` dataclass + brace-balanced JSON parser.
- `neatlogs/cost/pricing.py` (284 lines): `ModelDefinition`, `Tier`, `PricingProvider` ABC, `BuiltinProvider`, `CustomProvider`, `ChainProvider`, `default_chain`. The v2 schema (open `usage_types` dict, capabilities set, per-usage-type `tiers`).
- `neatlogs/cost/workload.py` (166 lines): `TokenStats`, `WorkloadProfile`, `WorkloadConstraints`, `build_workload_profile`.
- `neatlogs/cost/breakdown.py` (205 lines): `SpanCost`, `ModelCostBreakdown`, `BreakdownReport`, `cost_span`, `breakdown_workload`. Per-model input/output/cache/reasoning split.
- `neatlogs/cost/ranking.py` (251 lines): `SpanVerdict`, `ScoredModel`, `EvaluationReport`, `_is_span_compatible`, `_score_model`, `evaluate_workload`. What-if ranking with capability scoring.
- `neatlogs/cost/forecast.py` (123 lines): `ForecastReport`, `forecast`. Monthly / annual cost projection.
- `neatlogs/cost/formatters.py` (444 lines): text / json / csv formatters for all three report types, plus the `_supports_color` / `_ansi` helpers.
- `neatlogs/cost/cli.py` (277 lines): `_build_parser`, `_cli`. The `neatlogs-cost` entry point.
- `neatlogs/config/pricing.json` (212 lines, schema v2): 33 models across OpenAI, Anthropic, Google GenAI, DeepSeek, Groq with `usage_types` dict, `capabilities` list, and `tiers` where applicable.
- `pyproject.toml` (modified): `[project.scripts]` entry for `neatlogs-cost` → `neatlogs.cost.cli:_cli`.
- `tests/unit/test_cost.py` (2400 lines, 141 tests): parser, brace-balanced JSON, all `ModelDefinition` methods, all three `PricingProvider` types, `ChainProvider` priority / fallthrough, `TokenStats` percentiles, `WorkloadProfile`, `cost_span` (basic / cache_read / cache_write / reasoning / tier / embedding), `_is_span_compatible`, `ScoredModel` ranking, `EvaluationReport`, `evaluate_workload` (basic / unknown / auto-infer / explicit-baseline / min-compatibility), `breakdown_workload` (basic / unknown / no-candidates / ranked / spans-skipped), `forecast` (basic / cache / reasoning / no-cache / no-reasoning / unknown / clamped), formatters (text / json / csv / dispatch for all three), CLI (ranking / breakdown / forecast / no-candidates / unknown-model / no-monthly-calls / candidates-as-model).

## Backward compatibility

None. Pure addition. No existing public API changes. The `[project.scripts]` entry is opt-in. Public imports are unchanged — `from neatlogs.cost import evaluate_workload, breakdown_workload, forecast, ...` works the same as it did when the engine was a single file.

## Test plan

- 141 unit tests, 96% line coverage on `neatlogs.cost` (every submodule 95%+).
- `black` and `isort` clean across all 10 new files.
- Manual smoke test:

  ```bash
  # What-if ranking
  neatlogs-cost logs/spans_raw_optimized.log \
      --candidates openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3-5-haiku-latest,openai/gpt-4.1-mini

  # Per-model breakdown
  neatlogs-cost logs/spans_raw_optimized.log \
      --candidates openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3-5-haiku-latest --breakdown

  # Monthly forecast
  neatlogs-cost --forecast \
      --model openai/gpt-4o-mini \
      --monthly-calls 50000 \
      --avg-prompt 2000 --avg-completion 500 --cache-hit-rate 0.5
  ```
