### PR TITLE
fix(crewai): preserve task prompts beyond 10,000 characters

### DIFF
--- a/examples/sdk_examples/crewai_prompt_fidelity.py
+++ b/examples/sdk_examples/crewai_prompt_fidelity.py
@@ -1,0 +1,210 @@
+"""Generic CrewAI long-prompt fidelity example for NeatLogs.
+
+The example creates a deterministic synthetic document whose task description exceeds
+12,000 characters. Stable markers on both sides of the historical 10,000-character
+boundary make it easy to verify that the complete runtime user message reaches a trace.
+
+Run from the SDK repository root:
+
+    NEATLOGS_ENV_FILE=/absolute/path/to/.env \
+    NEATLOGS_ENDPOINT=http://127.0.0.1:4100 \
+    CREWAI_MODEL=openai/gpt-4o-mini \
+    .venv/bin/python examples/sdk_examples/crewai_prompt_fidelity.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+from dotenv import load_dotenv
+
+import neatlogs
+
+AGENT_ROLE = "Long Document Analyst"
+AGENT_GOAL = "Summarize long synthetic documents without losing details near the end"
+AGENT_BACKSTORY = (
+    "You inspect technical documents carefully and return concise, structured findings."
+)
+
+PROMPT_START_MARKER = "PROMPT_FIDELITY_TASK_START"
+NEAR_10000_MARKER = "PROMPT_FIDELITY_NEAR_10000"
+TAIL_AFTER_12000_MARKER = "PROMPT_FIDELITY_TAIL_AFTER_12000"
+
+EXPECTED_OUTPUT = dedent("""
+    {
+        "summary": "string",
+        "key_points": ["string"],
+        "open_questions": ["string"],
+        "tail_marker_seen": "boolean"
+    }
+    """).strip()
+
+
+def _synthetic_document(long_body: str) -> dict[str, Any]:
+    return {
+        "document_id": "synthetic-document-001",
+        "title": "Synthetic reliability review",
+        "sections": [
+            {
+                "heading": "Background",
+                "content": "This document is generated solely for prompt-fidelity testing.",
+            },
+            {
+                "heading": "Long analysis",
+                "content": long_body,
+            },
+        ],
+    }
+
+
+def _render_task_description(document_json: str) -> str:
+    return dedent(f"""
+        **Objective:** Analyze the synthetic document and return a structured summary.
+
+        **Instructions:**
+        1. Read the complete input, including content near the end.
+        2. Summarize the main topic in one sentence.
+        3. List the most important technical points.
+        4. List any open questions.
+        5. Set `tail_marker_seen` to true only if the final fidelity marker is present.
+        6. Return JSON only.
+
+        **Input document:**
+        {document_json}
+
+        **Required output schema:**
+        {EXPECTED_OUTPUT}
+        """).strip()
+
+
+def build_long_task_description() -> str:
+    """Build a deterministic task with markers around the capture boundary."""
+    probe_body = f"{PROMPT_START_MARKER}\n{NEAR_10000_MARKER}"
+    probe_json = json.dumps(_synthetic_document(probe_body), sort_keys=True)
+    probe_prompt = _render_task_description(probe_json)
+    padding_length = 9_800 - probe_prompt.index(NEAR_10000_MARKER)
+    if padding_length <= 0:
+        raise AssertionError("The fixed task text already reaches the near marker")
+
+    long_body = (
+        f"{PROMPT_START_MARKER}\n"
+        f"{'x' * padding_length}{NEAR_10000_MARKER}\n"
+        f"{'y' * 2_500}{TAIL_AFTER_12000_MARKER}"
+    )
+    document_json = json.dumps(_synthetic_document(long_body), sort_keys=True)
+    description = _render_task_description(document_json)
+
+    near_offset = description.index(NEAR_10000_MARKER)
+    tail_offset = description.index(TAIL_AFTER_12000_MARKER)
+    assert 9_500 < near_offset < 10_000
+    assert tail_offset > 12_000
+    return description
+
+
+def _load_runtime_environment() -> None:
+    env_file = os.getenv("NEATLOGS_ENV_FILE")
+    if env_file:
+        load_dotenv(Path(env_file), override=False)
+    else:
+        load_dotenv(override=False)
+
+
+def _first_env(*names: str) -> str:
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    raise SystemExit(f"Missing required environment variable; expected one of: {', '.join(names)}")
+
+
+def setup_neatlogs() -> None:
+    """Initialize automatic CrewAI instrumentation before importing CrewAI."""
+    neatlogs.init(
+        api_key=_first_env("NEATLOGS_API_KEY"),
+        endpoint=_first_env("NEATLOGS_ENDPOINT"),
+        workflow_name="crewai-long-prompt-fidelity",
+        instrumentations=["crewai"],
+        debug=os.getenv("NEATLOGS_DEBUG", "").lower() in {"1", "true", "yes"},
+    )
+
+
+def _build_llm():
+    # CrewAI must be imported only after setup_neatlogs() installs its hooks.
+    from crewai import LLM
+
+    return LLM(
+        model=_first_env("CREWAI_MODEL"),
+        api_key=_first_env("OPENAI_API_KEY"),
+        max_completion_tokens=600,
+        drop_params=True,
+    )
+
+
+async def run_example() -> str:
+    # These imports deliberately occur after setup_neatlogs().
+    from crewai import Agent, Crew, Task
+
+    run_id = os.getenv("CREWAI_PROMPT_RUN_ID", str(int(time.time())))
+    description = build_long_task_description()
+    near_offset = description.index(NEAR_10000_MARKER)
+    tail_offset = description.index(TAIL_AFTER_12000_MARKER)
+
+    agent = Agent(
+        role=AGENT_ROLE,
+        goal=AGENT_GOAL,
+        backstory=AGENT_BACKSTORY,
+        allow_delegation=False,
+        max_iter=1,
+        llm=_build_llm(),
+        verbose=False,
+    )
+    task = Task(
+        description=description,
+        expected_output=EXPECTED_OUTPUT,
+        agent=agent,
+    )
+    crew = Crew(agents=[agent], tasks=[task], verbose=False)
+
+    trace_id = ""
+    try:
+        with neatlogs.trace(
+            name="long_prompt_fidelity",
+            kind="WORKFLOW",
+            metadata={
+                "example": "crewai-long-prompt-fidelity",
+                "run_id": run_id,
+                "task_chars": len(description),
+            },
+        ) as trace_span:
+            span_context = trace_span.get_span_context()
+            trace_id = f"{span_context.trace_id:032x}"
+            result = await crew.kickoff_async()
+    finally:
+        neatlogs.flush()
+        await asyncio.sleep(3)
+
+    result_text = str(getattr(result, "raw", result))
+    print(f"run_id={run_id}")
+    print(f"trace_id={trace_id}")
+    print(f"task_chars={len(description)} near_offset={near_offset} " f"tail_offset={tail_offset}")
+    print(f"result_preview={result_text[:120]!r}")
+    return trace_id
+
+
+def main() -> None:
+    _load_runtime_environment()
+    setup_neatlogs()
+    try:
+        asyncio.run(run_example())
+    finally:
+        neatlogs.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/neatlogs/crewai.py
+++ b/neatlogs/crewai.py
@@ -42,6 +42,7 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import attach_as_current, detach, get_tracer, serialize
 
 _CLASS_HOOKS_INSTALLED = False
+_LLM_INPUT_CAPTURE_LIMIT = 1 * 1024 * 1024
 
 
 def _shared_trace_kwargs() -> dict:
@@ -1073,17 +1074,35 @@ def _patch_llm_call(LLM) -> None:
         if model:
             attrs["neatlogs.llm.model_name"] = str(model)
 
+        input_messages: list[dict[str, str]] = []
         if isinstance(messages, str):
-            attrs["neatlogs.llm.input_messages.0.role"] = "user"
-            attrs["neatlogs.llm.input_messages.0.content"] = messages[:10000]
+            input_messages.append(
+                {
+                    "role": "user",
+                    "content": messages[:_LLM_INPUT_CAPTURE_LIMIT],
+                }
+            )
         elif isinstance(messages, list):
-            for i, msg in enumerate(messages):
+            for msg in messages:
                 role = msg.get("role", "") if isinstance(msg, dict) else getattr(msg, "role", "")
-                content = msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")
-                if role:
-                    attrs[f"neatlogs.llm.input_messages.{i}.role"] = role
-                if content:
-                    attrs[f"neatlogs.llm.input_messages.{i}.content"] = (content if isinstance(content, str) else serialize(content))[:10000]
+                content = (
+                    msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")
+                )
+                content_text = content if isinstance(content, str) else serialize(content)
+                input_messages.append(
+                    {
+                        "role": str(role) if role else "",
+                        "content": content_text[:_LLM_INPUT_CAPTURE_LIMIT],
+                    }
+                )
+
+        for i, message in enumerate(input_messages):
+            if message["role"]:
+                attrs[f"neatlogs.llm.input_messages.{i}.role"] = message["role"]
+            if message["content"]:
+                attrs[f"neatlogs.llm.input_messages.{i}.content"] = message["content"]
+        if input_messages:
+            attrs["input.value"] = serialize({"messages": input_messages})
 
         # Invocation params from the LLM object (max_completion_tokens is crewai's
         # alias for max_tokens). The litellm capture below overrides these with the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.poetry]
 name = "neatlogs"
-version = "1.4.16"
+version = "1.4.17"
 description = "A Python package for extracting and managing LLM logs to build a collaborative workspace"
 readme = "README.MD"
 license = "MIT"
@@ -139,7 +139,7 @@ milvus = ["pymilvus", "milvus-lite"]
 
 [project]
 name = "neatlogs"
-version = "1.4.16"
+version = "1.4.17"
 description = "A Python package for extracting and managing LLM logs to build a collaborative workspace"
 readme = "README.MD"
 license = {text = "MIT"}

--- a/tests/unit/test_crewai_prompt_fidelity.py
+++ b/tests/unit/test_crewai_prompt_fidelity.py
@@ -1,0 +1,162 @@
+import importlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+import neatlogs
+
+EXAMPLE_PATH = Path(__file__).parents[2] / "examples" / "sdk_examples" / "crewai_prompt_fidelity.py"
+
+
+def _load_example(monkeypatch):
+    for name in (
+        "NEATLOGS_API_KEY",
+        "NEATLOGS_ENDPOINT",
+        "CREWAI_MODEL",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.setenv(name, f"test-{name.lower()}")
+    monkeypatch.setattr(neatlogs, "init", lambda **_kwargs: None)
+
+    module_name = "crewai_prompt_fidelity_example_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, EXAMPLE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+def test_example_uses_generic_document_analysis_contract(monkeypatch) -> None:
+    example = _load_example(monkeypatch)
+
+    assert example.AGENT_ROLE == "Long Document Analyst"
+    assert example.AGENT_GOAL == (
+        "Summarize long synthetic documents without losing details near the end"
+    )
+    assert example.AGENT_BACKSTORY == (
+        "You inspect technical documents carefully and return concise, structured findings."
+    )
+
+    description = example.build_long_task_description()
+    assert (
+        "**Objective:** Analyze the synthetic document and return a structured summary."
+        in description
+    )
+    assert "**Input document:**" in description
+    assert "**Required output schema:**" in description
+    assert '"document_id": "synthetic-document-001"' in description
+    assert '"tail_marker_seen": "boolean"' in description
+
+
+def test_example_builds_deterministic_task_beyond_12000_characters(monkeypatch) -> None:
+    example = _load_example(monkeypatch)
+
+    description = example.build_long_task_description()
+    near_offset = description.index(example.NEAR_10000_MARKER)
+    tail_offset = description.index(example.TAIL_AFTER_12000_MARKER)
+
+    assert len(description) > 12_000
+    assert 9_500 < near_offset < 10_000
+    assert tail_offset > 12_000
+
+
+def test_example_uses_automatic_crewai_instrumentation() -> None:
+    source = EXAMPLE_PATH.read_text()
+
+    assert 'workflow_name="crewai-long-prompt-fidelity"' in source
+    assert 'instrumentations=["crewai"]' in source
+    assert 'name="long_prompt_fidelity"' in source
+    assert 'kind="WORKFLOW"' in source
+    assert "await crew.kickoff_async()" in source
+    assert "bind_templates(" not in source
+    assert "register_crewai_task(" not in source
+
+
+def _install_test_tracer(in_memory_span_exporter) -> None:
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+    trace.set_tracer_provider(provider)
+    neatlogs.init(api_key="test-key", disable_export=True, instrumentations=[])
+
+
+def test_crewai_string_input_preserves_content_after_10000_characters(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = importlib.import_module("neatlogs.crewai")
+
+    class FakeStringLlm:
+        model = "test-model"
+
+        def call(self, messages, *args, **kwargs):
+            return "ok"
+
+    crewai_instrumentation._patch_llm_call(FakeStringLlm)
+
+    tail_sentinel = "TAIL_SENTINEL_AFTER_10000"
+    user_prompt = f"USER_PROMPT_START\n{'u' * 12_000}\n{tail_sentinel}"
+    FakeStringLlm().call(user_prompt)
+
+    llm_span = next(
+        span
+        for span in in_memory_span_exporter.get_finished_spans()
+        if span.name == "crewai.llm.call"
+    )
+    captured = llm_span.attributes["neatlogs.llm.input_messages.0.content"]
+
+    assert captured == user_prompt
+    assert tail_sentinel in captured
+    structured_input = json.loads(llm_span.attributes["input.value"])
+    assert structured_input == {"messages": [{"role": "user", "content": user_prompt}]}
+
+
+def test_crewai_message_list_preserves_roles_history_and_long_prompts(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = importlib.import_module("neatlogs.crewai")
+
+    class FakeMessageLlm:
+        model = "test-model"
+
+        def call(self, messages, *args, **kwargs):
+            return "ok"
+
+    crewai_instrumentation._patch_llm_call(FakeMessageLlm)
+
+    system_tail = "SYSTEM_TAIL_AFTER_10000"
+    user_tail = "TASK_TAIL_AFTER_10000"
+    messages = [
+        {
+            "role": "system",
+            "content": f"SYSTEM_START\n{'s' * 12_000}\n{system_tail}",
+        },
+        {"role": "assistant", "content": "prior answer"},
+        {
+            "role": "user",
+            "content": f"Current Task:\n{'t' * 12_000}\n{user_tail}",
+        },
+    ]
+    FakeMessageLlm().call(messages)
+
+    llm_span = next(
+        span
+        for span in in_memory_span_exporter.get_finished_spans()
+        if span.name == "crewai.llm.call"
+    )
+    assert llm_span.attributes["neatlogs.llm.input_messages.0.role"] == "system"
+    assert llm_span.attributes["neatlogs.llm.input_messages.1.role"] == "assistant"
+    assert llm_span.attributes["neatlogs.llm.input_messages.2.role"] == "user"
+    assert system_tail in llm_span.attributes["neatlogs.llm.input_messages.0.content"]
+    assert user_tail in llm_span.attributes["neatlogs.llm.input_messages.2.content"]
+    structured_input = json.loads(llm_span.attributes["input.value"])
+    assert structured_input == {"messages": messages}


### PR DESCRIPTION
## Summary

Preserve CrewAI LLM task prompts beyond the previous 10,000-character cutoff and emit a structured LLM input alongside indexed role/content attributes.

This also adds a public-safe, synthetic long-document example and regression coverage for string and multi-message CrewAI inputs.

## Problem / context

CrewAI task descriptions can produce runtime user messages longer than 10,000 characters. The SDK previously sliced every captured LLM input message to 10,000 characters before export, so anything after that boundary was permanently unavailable to downstream trace processing.

This is the SDK half of the two-part prompt-fidelity fix tracked in [NL-1530](https://linear.app/neatlogs/issue/NL-1530). The companion backend PR restores the runtime user/task turn in the simplified Trace view when optional user-template metadata is absent.

## What changed

- Replace the fixed 10,000-character CrewAI LLM-message slice with a named 1 MiB per-message capture bound.
- Normalize string and list message inputs into ordered role/content records.
- Continue emitting indexed `neatlogs.llm.input_messages.*` attributes.
- Add structured `input.value` JSON so downstream readers do not have to reconstruct the conversation from flattened attributes.
- Add `examples/sdk_examples/crewai_prompt_fidelity.py`, which uses a deterministic synthetic document with markers before 10,000 and after 12,000 characters.
- Add regression tests for long string inputs, ordered multi-message history, automatic instrumentation shape, and reproduction markers.

## Example privacy boundary

- The example is generic and uses only synthetic document-analysis data.
- It contains no external organization identifiers or domain-specific prompt, schema, or workflow content.
- Runtime credentials are read from environment variables and are not printed or committed.

## Impact

- **User:** CrewAI task-prompt content after character 10,000 is preserved in newly emitted LLM spans.
- **SDK/data:** Larger input payloads are allowed, bounded to 1 MiB per captured message.
- **Backend:** Structured input becomes available to the finalizer; the companion backend change consumes it.
- **Frontend / API / AI:** No frontend, public API, Zod contract, or AI-service change.

## Security, migration, and rollout

- The reproduction uses synthetic data only.
- No database migration, backfill, or environment-variable change is required.
- Full resolution requires publishing a fixed SDK version.
- The backend compatibility PR may deploy independently, but only the SDK fix preserves prompt content that an older SDK discarded after character 10,000.

## Verification

```bash
.venv/bin/python -m pytest -q \
  tests/unit/test_crewai_prompt_fidelity.py \
  tests/integration/test_crewai_instrumentation.py
# 25 passed

.venv/bin/black --check \
  examples/sdk_examples/crewai_prompt_fidelity.py \
  tests/unit/test_crewai_prompt_fidelity.py

.venv/bin/isort --check-only \
  examples/sdk_examples/crewai_prompt_fidelity.py \
  tests/unit/test_crewai_prompt_fidelity.py

git diff origin/main...HEAD --check
```

The synthetic end-to-end comparison verified:

- Before the fix, the runtime user message ended at exactly 10,000 characters and the post-12,000 marker was absent.
- After the fix, the runtime user message contained 16,596 characters, and both structured `input.value` and the post-12,000 marker were present.

## Companion PR

- Backend finalizer: https://github.com/neatlogs/neatlogs-app/pull/1012

## Linear

[NL-1530](https://linear.app/neatlogs/issue/NL-1530)
