### PR TITLE
ci: make SDK checks deterministic

### DIFF
--- a/.github/requirements-lint.txt
+++ b/.github/requirements-lint.txt
@@ -1,0 +1,3 @@
+# Keep CI formatting deterministic across runs and Python matrix updates.
+black==26.1.0
+isort==7.0.0

--- a/.github/requirements-test.txt
+++ b/.github/requirements-test.txt
@@ -1,0 +1,9 @@
+# Direct unit-test dependencies, pinned to the versions resolved in poetry.lock.
+google-genai==1.57.0
+langchain-core==1.2.7
+openai==2.15.0
+pytest==9.0.2
+pytest-asyncio==1.3.0
+pytest-mock==3.15.1
+python-dotenv==1.2.1
+respx==0.22.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,25 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install lint tools
+        run: python -m pip install -r .github/requirements-lint.txt
+
+      - name: Format (black)
+        run: black --check neatlogs tests
+
+      - name: Imports (isort)
+        run: isort --check-only neatlogs tests
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -22,15 +41,8 @@ jobs:
 
       - name: Install
         run: |
-          python -m pip install --upgrade pip
           python -m pip install -e .
-          python -m pip install black isort pytest pytest-asyncio pytest-mock respx langchain-core
-
-      - name: Format (black)
-        run: black --check neatlogs tests
-
-      - name: Imports (isort)
-        run: isort --check-only neatlogs tests
+          python -m pip install -r .github/requirements-test.txt
 
       - name: Unit tests
         run: pytest -q tests/unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 
@@ -32,10 +32,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,230 @@
+# Contributing to the NeatLogs Python SDK
+
+This guide describes the local checks and CI maintenance rules for the
+`neatlogs` Python SDK.
+
+## CI overview
+
+The SDK CI workflow is defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+It runs on every branch push and every pull request, so a pull request may show
+two equivalent CI runs for the same commit.
+
+CI has two responsibilities:
+
+1. A single Python 3.13 lint job checks Black formatting and isort import order.
+2. Unit-test jobs run on every supported Python version: 3.10, 3.11, 3.12,
+   and 3.13.
+
+The lint job is deliberately separate from the Python matrix. A formatting
+failure should be reported once; it should not prevent four otherwise
+independent test jobs from reporting their results.
+
+## Local development setup
+
+Install the project and development dependencies with Poetry:
+
+```bash
+poetry install --with dev
+```
+
+The supported Python range is declared in `pyproject.toml`. Use a Python
+version inside that range for local development.
+
+## Required checks before pushing
+
+Run these commands from the repository root:
+
+```bash
+poetry run black neatlogs tests
+poetry run isort neatlogs tests
+poetry run pytest -q tests/unit
+git diff --check
+```
+
+Run Black before isort. The repository's Black and isort settings are defined
+in `pyproject.toml`, and both tools operate on the complete `neatlogs/` and
+`tests/` trees.
+
+Do not format only the files changed in the current branch. CI checks both
+complete directories, so an unformatted file elsewhere in the tree will still
+fail the pull request.
+
+To check formatting without modifying files:
+
+```bash
+poetry run black --check neatlogs tests
+poetry run isort --check-only neatlogs tests
+```
+
+## Formatting and logical changes
+
+Black changes layout, quoting, wrapping, and other syntax presentation without
+intending to change Python behavior. isort can also reorder or regroup import
+statements.
+
+When a formatter upgrade produces a large repository-wide diff:
+
+1. Put the formatter baseline in a dedicated commit.
+2. Keep functional changes in separate commits or a separate pull request.
+3. Run the complete unit-test suite after formatting.
+4. Review import-order changes, especially imports inside functions and modules
+   that perform registration or instrumentation during import.
+5. Avoid mixing manual refactors into the formatter-baseline commit.
+
+A formatter-only commit should be reproducible by checking out its parent and
+running the pinned formatter versions. If it cannot be reproduced that way,
+review the additional changes as normal code changes.
+
+## Keeping CI dependencies deterministic
+
+CI uses two small, pinned requirements files:
+
+- [`.github/requirements-lint.txt`](.github/requirements-lint.txt) contains
+  Black and isort.
+- [`.github/requirements-test.txt`](.github/requirements-test.txt) contains
+  direct dependencies needed by the unit-test suite.
+
+These files prevent direct formatter and test dependency upgrades from
+changing CI results without a repository change. They reduce dependency drift,
+but they are not a complete lock of every transitive dependency installed by
+pip.
+
+`poetry.lock` remains the source of truth for the resolved versions. Whenever
+the lock file changes, check whether any package listed in either CI
+requirements file also changed. If it did, update the matching pin in the same
+pull request.
+
+After installing dependencies, the resolved version of a package can be
+checked with:
+
+```bash
+poetry show <package-name>
+```
+
+### Updating Black or isort
+
+When intentionally upgrading a formatter:
+
+1. Update its constraint in `pyproject.toml` if required.
+2. Regenerate `poetry.lock`.
+3. Copy the resolved version into `.github/requirements-lint.txt`.
+4. Run Black and isort over both `neatlogs/` and `tests/`.
+5. Commit the generated formatter baseline separately from CI configuration
+   and functional changes.
+6. Run the required local checks in this guide.
+
+Do not change the formatter pin in CI without applying and reviewing the
+corresponding formatter output.
+
+### Adding or updating unit-test dependencies
+
+When a unit test directly needs a new package:
+
+1. Add it to the development dependency group in `pyproject.toml`.
+2. Regenerate `poetry.lock`.
+3. Add the exact resolved version to `.github/requirements-test.txt`.
+4. Verify installation and run `pytest -q tests/unit` in a clean environment.
+
+Only direct unit-test requirements belong in
+`.github/requirements-test.txt`. Transitive dependencies continue to be
+resolved by pip from the pinned direct dependency set and the installed SDK.
+If a transitive dependency causes a reproducible CI regression, constrain it
+through the appropriate direct dependency or introduce an explicit pin with a
+comment explaining why it is required.
+
+## Clean-environment verification
+
+When changing CI dependencies or diagnosing an installation failure, verify
+the same installation sequence used by GitHub Actions in a new virtual
+environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+
+python -m pip install -e .
+python -m pip install -r .github/requirements-test.txt
+python -m pip install -r .github/requirements-lint.txt
+
+black --check neatlogs tests
+isort --check-only neatlogs tests
+pytest -q tests/unit
+```
+
+Remove or recreate the virtual environment before repeating this test after a
+dependency change. Do not rely on packages left over from unrelated local
+development.
+
+## Changing supported Python versions
+
+Python support is defined in two places:
+
+- The Python constraint in `pyproject.toml`.
+- The test matrix in `.github/workflows/ci.yml`.
+
+When adding or removing a supported Python version:
+
+1. Update both locations in the same pull request.
+2. Confirm the project and CI-only dependencies install on every matrix
+   version.
+3. Run the unit tests on the new or affected version.
+4. Check optional instrumentation dependencies for incompatible Python
+   constraints.
+5. Keep the lint job on one supported Python version; do not duplicate linting
+   across the entire matrix.
+
+## Tests beyond the CI gate
+
+The required CI gate is:
+
+```bash
+poetry run pytest -q tests/unit
+```
+
+Integration tests may require optional framework packages, service-specific
+fixtures, credentials, or network access. Run the relevant integration tests
+when changing an instrumentation adapter, but do not treat a missing optional
+dependency as a regression without reproducing the same test against the base
+branch.
+
+Tests must not make real provider API calls unless they are explicitly marked
+and documented as live tests.
+
+## Diagnosing CI failures
+
+Use the failing step to decide where to investigate:
+
+- **Black failure:** run `black neatlogs tests`, review the generated diff, and
+  rerun Black in check mode.
+- **isort failure:** run `isort neatlogs tests`, inspect import-order changes,
+  and rerun isort in check mode.
+- **One Python version fails:** compare dependency installation and traceback
+  output for that matrix version.
+- **Every Python version fails identically:** investigate shared source,
+  dependency, or test-fixture issues rather than Python-version compatibility.
+- **CI began failing without a repository change:** check for an unpinned
+  dependency or action. Do not fix it by repeatedly rerunning the workflow.
+
+When investigating an unexpected failure, capture the exact command,
+dependency versions, Python version, and first meaningful traceback. A green
+formatter check does not prove tests pass, and a green unit suite does not
+replace reviewing a large generated diff.
+
+## Pull-request checklist
+
+Before requesting review:
+
+- [ ] Black passes for `neatlogs/` and `tests/`.
+- [ ] isort passes for `neatlogs/` and `tests/`.
+- [ ] All unit tests pass locally.
+- [ ] `git diff --check` passes.
+- [ ] CI dependency pins match `poetry.lock`.
+- [ ] Formatter-only and logical changes are clearly separated.
+- [ ] Relevant integration tests were run for instrumentation changes.
+- [ ] The pull-request description lists the exact commands and results.
+- [ ] Migration, data, security, compatibility, and release impact are stated
+      when relevant.
+
+CI-only and formatter-only maintenance does not require an SDK version bump or
+release unless packaged runtime behavior or published package metadata also
+changes.

--- a/neatlogs/__init__.py
+++ b/neatlogs/__init__.py
@@ -27,11 +27,11 @@ Available span kinds:
 """
 
 from .core.context import trace
-from .core.identity import identify
-from .core.propagation import extract_trace_context, inject_trace_context
 from .core.crewai_task_registry import register_crewai_task
+from .core.identity import identify
 from .core.llm_binder import bind_templates
 from .core.log import log
+from .core.propagation import extract_trace_context, inject_trace_context
 from .decorators import span
 from .init import flush, init, shutdown
 from .prompt.client import (
@@ -160,9 +160,7 @@ def wrap(client, **workflow_attributes):
     # detected — e.g. `class QAPipeline(dspy.Module)` has __module__ "src.pipeline"
     # but `dspy.module` appears in a base class. Used as a fallback when the leaf
     # class's own module doesn't reveal the framework.
-    mro_modules = " ".join(
-        (getattr(base, "__module__", "") or "") for base in type(client).__mro__
-    )
+    mro_modules = " ".join((getattr(base, "__module__", "") or "") for base in type(client).__mro__)
 
     # Azure OpenAI must be checked before plain OpenAI: AzureOpenAI subclasses
     # OpenAI and its module ("openai.lib.azure") contains "openai".
@@ -256,8 +254,11 @@ def wrap(client, **workflow_attributes):
     # async iterator of typed messages (query() / ClaudeSDKClient). There's no in-process LLM client
     # to wrap — we patch the streaming entry points and build spans from the message stream. Accept
     # either the module itself (`neatlogs.wrap(claude_agent_sdk)`) or a ClaudeSDKClient instance.
-    if (cls_name == "module" and getattr(client, "__name__", "") == "claude_agent_sdk") \
-            or cls_name == "ClaudeSDKClient" or "claude_agent_sdk" in module:
+    if (
+        (cls_name == "module" and getattr(client, "__name__", "") == "claude_agent_sdk")
+        or cls_name == "ClaudeSDKClient"
+        or "claude_agent_sdk" in module
+    ):
         from .claude_agent_sdk import wrap_claude_agent_sdk
 
         return _finish(wrap_claude_agent_sdk(client))

--- a/neatlogs/_wrap_utils.py
+++ b/neatlogs/_wrap_utils.py
@@ -65,6 +65,7 @@ def _isolation_active() -> bool:
     """Auto-detect gate: True in isolated mode (private provider != OTel global)."""
     return _isolated
 
+
 _wrapper_config: Dict[str, Any] = {}
 _wrap_context: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
     "neatlogs.wrap_context", default=None
@@ -392,9 +393,8 @@ def _bootstrap_from_env(api_key: str) -> None:
     from opentelemetry.sdk.trace import SpanLimits
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-    endpoint = (
-        _wrapper_config.get("endpoint")
-        or os.environ.get("NEATLOGS_ENDPOINT", "https://ingest.neatlogs.com")
+    endpoint = _wrapper_config.get("endpoint") or os.environ.get(
+        "NEATLOGS_ENDPOINT", "https://ingest.neatlogs.com"
     )
     endpoint = _normalize_traces_endpoint(endpoint)
 
@@ -751,7 +751,7 @@ class _AutoRootTracer:
         needs_root = (
             _auto_root_enabled()
             and kind not in _ROOT_KINDS
-            and "context" not in kwargs          # explicit-context callers opt out
+            and "context" not in kwargs  # explicit-context callers opt out
             and not _has_active_recording_parent()
         )
         if not needs_root:
@@ -882,6 +882,7 @@ class SyncStreamWrapper:
             return
         self._finalized = True
         from opentelemetry.trace import StatusCode
+
         self._span.set_status(StatusCode.ERROR, str(error))
         self._span.record_exception(error)
         self._span.end()
@@ -947,6 +948,7 @@ class AsyncStreamWrapper:
             return
         self._finalized = True
         from opentelemetry.trace import StatusCode
+
         self._span.set_status(StatusCode.ERROR, str(error))
         self._span.record_exception(error)
         self._span.end()

--- a/neatlogs/agno.py
+++ b/neatlogs/agno.py
@@ -166,10 +166,17 @@ def _finalize_agent_span(span: Any, response: Any, duration_ms: float) -> None:
             args = (
                 getattr(tool, "tool_args", None)
                 or getattr(tool, "arguments", None)
-                or (tool.get("tool_args") or tool.get("arguments") if isinstance(tool, dict) else None)
+                or (
+                    tool.get("tool_args") or tool.get("arguments")
+                    if isinstance(tool, dict)
+                    else None
+                )
             )
             if args:
-                span.set_attribute(f"neatlogs.llm.tool_calls.{i}.arguments", args if isinstance(args, str) else serialize(args))
+                span.set_attribute(
+                    f"neatlogs.llm.tool_calls.{i}.arguments",
+                    args if isinstance(args, str) else serialize(args),
+                )
 
     model = getattr(response, "model", None)
     if model:
@@ -320,12 +327,15 @@ def _patch_workflow(workflow: Any) -> None:
                 try:
                     iterator = orig_run(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); detach(token); raise
+                    _err(span, e)
+                    detach(token)
+                    raise
                 return _AgnoStreamIter(iterator, span, token, start, sync=True, workflow=True)
             try:
                 result = orig_run(*args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 detach(token)
             _finalize_workflow_span(span, result, (time.perf_counter() - start) * 1000)
@@ -350,12 +360,15 @@ def _patch_workflow(workflow: Any) -> None:
                 try:
                     aiter = orig_arun(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); detach(token); raise
+                    _err(span, e)
+                    detach(token)
+                    raise
                 return _AgnoAsyncStreamIter(aiter, span, token, start, workflow=True)
             try:
                 result = await orig_arun(*args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 detach(token)
             _finalize_workflow_span(span, result, (time.perf_counter() - start) * 1000)
@@ -523,7 +536,8 @@ def _patch_function_call_class() -> None:
             try:
                 result = orig_execute(self, *a, **k)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 detach(token)
             _finalize_tool(span, self, result)
@@ -542,7 +556,8 @@ def _patch_function_call_class() -> None:
             try:
                 result = await orig_aexecute(self, *a, **k)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 detach(token)
             _finalize_tool(span, self, result)
@@ -600,7 +615,11 @@ def _patch_model_class(target=None) -> None:
         if isinstance(msgs, list) and msgs:
             collected = []
             for i, m in enumerate(msgs):
-                role = getattr(m, "role", None) or (m.get("role") if isinstance(m, dict) else None) or ""
+                role = (
+                    getattr(m, "role", None)
+                    or (m.get("role") if isinstance(m, dict) else None)
+                    or ""
+                )
                 content = getattr(m, "content", None)
                 if content is None and isinstance(m, dict):
                     content = m.get("content")
@@ -639,10 +658,13 @@ def _patch_model_class(target=None) -> None:
         is_stream = "stream" in method
 
         if is_async and is_stream:
+
             def make(orig=orig):
                 async def wrapper(self, *a, **k):
                     tracer = get_tracer()
-                    span = tracer.start_span(name="agno.model.invoke", attributes=_model_attrs(self, k))
+                    span = tracer.start_span(
+                        name="agno.model.invoke", attributes=_model_attrs(self, k)
+                    )
                     token = attach_as_current(span)
                     chunks = []
                     try:
@@ -651,34 +673,46 @@ def _patch_model_class(target=None) -> None:
                             chunks.append(chunk)
                             yield chunk
                     except Exception as e:
-                        _err(span, e); raise
+                        _err(span, e)
+                        raise
                     finally:
                         detach(token)
                         if span.is_recording():
                             _finalize_model_stream(span, chunks)
+
                 return wrapper
+
             setattr(cls, method, make())
         elif is_async:
+
             def make(orig=orig):
                 async def wrapper(self, *a, **k):
                     tracer = get_tracer()
-                    span = tracer.start_span(name="agno.model.invoke", attributes=_model_attrs(self, k))
+                    span = tracer.start_span(
+                        name="agno.model.invoke", attributes=_model_attrs(self, k)
+                    )
                     token = attach_as_current(span)
                     try:
                         result = await orig(self, *a, **k)
                     except Exception as e:
-                        _err(span, e); raise
+                        _err(span, e)
+                        raise
                     finally:
                         detach(token)
                     _finalize_model(span, result)
                     return result
+
                 return wrapper
+
             setattr(cls, method, make())
         elif is_stream:
+
             def make(orig=orig):
                 def wrapper(self, *a, **k):
                     tracer = get_tracer()
-                    span = tracer.start_span(name="agno.model.invoke", attributes=_model_attrs(self, k))
+                    span = tracer.start_span(
+                        name="agno.model.invoke", attributes=_model_attrs(self, k)
+                    )
                     token = attach_as_current(span)
                     chunks = []
                     try:
@@ -687,28 +721,37 @@ def _patch_model_class(target=None) -> None:
                             chunks.append(chunk)
                             yield chunk
                     except Exception as e:
-                        _err(span, e); raise
+                        _err(span, e)
+                        raise
                     finally:
                         detach(token)
                         if span.is_recording():
                             _finalize_model_stream(span, chunks)
+
                 return wrapper
+
             setattr(cls, method, make())
         else:
+
             def make(orig=orig):
                 def wrapper(self, *a, **k):
                     tracer = get_tracer()
-                    span = tracer.start_span(name="agno.model.invoke", attributes=_model_attrs(self, k))
+                    span = tracer.start_span(
+                        name="agno.model.invoke", attributes=_model_attrs(self, k)
+                    )
                     token = attach_as_current(span)
                     try:
                         result = orig(self, *a, **k)
                     except Exception as e:
-                        _err(span, e); raise
+                        _err(span, e)
+                        raise
                     finally:
                         detach(token)
                     _finalize_model(span, result)
                     return result
+
                 return wrapper
+
             setattr(cls, method, make())
 
     cls._neatlogs_patched = True
@@ -787,7 +830,10 @@ def _finalize_model(span: Any, result: Any) -> None:
                 if name:
                     span.set_attribute(f"neatlogs.llm.tool_calls.{j}.name", name)
                 if args:
-                    span.set_attribute(f"neatlogs.llm.tool_calls.{j}.arguments", args if isinstance(args, str) else serialize(args))
+                    span.set_attribute(
+                        f"neatlogs.llm.tool_calls.{j}.arguments",
+                        args if isinstance(args, str) else serialize(args),
+                    )
                 if tc_id:
                     span.set_attribute(f"neatlogs.llm.tool_calls.{j}.id", str(tc_id))
                 collected_calls.append({"name": name, "arguments": args})

--- a/neatlogs/anthropic.py
+++ b/neatlogs/anthropic.py
@@ -119,6 +119,7 @@ def _patch_messages(messages: Any) -> None:
     messages.create = patched_create
 
     if orig_stream:
+
         def patched_stream(*args, **kwargs):
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
@@ -199,6 +200,7 @@ def _patch_async_messages(messages: Any) -> None:
     messages.create = patched_create
 
     if orig_stream:
+
         def patched_stream(*args, **kwargs):
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
@@ -250,7 +252,9 @@ def _set_input_attributes(span: Any, messages: list, system: Any, kwargs: dict) 
         else:
             span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", serialize(content))
         if msg.get("tool_call_id"):
-            span.set_attribute(f"neatlogs.llm.input_messages.{idx}.tool_call_id", msg["tool_call_id"])
+            span.set_attribute(
+                f"neatlogs.llm.input_messages.{idx}.tool_call_id", msg["tool_call_id"]
+            )
         idx += 1
 
     tools = kwargs.get("tools")
@@ -260,7 +264,9 @@ def _set_input_attributes(span: Any, messages: list, system: Any, kwargs: dict) 
             if tool.get("description"):
                 span.set_attribute(f"neatlogs.llm.tools.{i}.description", tool["description"])
             if tool.get("input_schema"):
-                span.set_attribute(f"neatlogs.llm.tools.{i}.input_schema", serialize(tool["input_schema"]))
+                span.set_attribute(
+                    f"neatlogs.llm.tools.{i}.input_schema", serialize(tool["input_schema"])
+                )
 
     for param in ("temperature", "top_p", "top_k", "max_tokens"):
         if param in kwargs and kwargs[param] is not None:
@@ -278,9 +284,16 @@ def _finalize_response(span: Any, response: Any, duration_ms: float) -> None:
         if block_type == "text":
             text_parts.append(getattr(block, "text", ""))
         elif block_type == "tool_use":
-            span.set_attribute(f"neatlogs.llm.tool_calls.{tool_call_idx}.id", getattr(block, "id", ""))
-            span.set_attribute(f"neatlogs.llm.tool_calls.{tool_call_idx}.name", getattr(block, "name", ""))
-            span.set_attribute(f"neatlogs.llm.tool_calls.{tool_call_idx}.arguments", serialize(getattr(block, "input", {})))
+            span.set_attribute(
+                f"neatlogs.llm.tool_calls.{tool_call_idx}.id", getattr(block, "id", "")
+            )
+            span.set_attribute(
+                f"neatlogs.llm.tool_calls.{tool_call_idx}.name", getattr(block, "name", "")
+            )
+            span.set_attribute(
+                f"neatlogs.llm.tool_calls.{tool_call_idx}.arguments",
+                serialize(getattr(block, "input", {})),
+            )
             tool_call_idx += 1
         elif block_type == "thinking":
             thinking_text = getattr(block, "thinking", "")
@@ -330,7 +343,9 @@ def _set_usage_attributes(span: Any, usage: Any) -> None:
         span.set_attribute("neatlogs.llm.token_count.cache_write", cache_write)
 
 
-def _finalize_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]) -> None:
+def _finalize_stream(
+    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+) -> None:
     """Finalize a streaming response span from accumulated Anthropic stream events."""
     text_parts: List[str] = []
     tool_calls_acc: dict = {}
@@ -556,6 +571,7 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
     if hasattr(messages, "parse") and not getattr(messages, "_neatlogs_parse_patched", False):
         orig_parse = messages.parse
         if is_async:
+
             async def patched_parse(*args, **kwargs):
                 if is_suppressed():
                     return await orig_parse(*args, **kwargs)
@@ -564,10 +580,13 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
                 try:
                     resp = await orig_parse(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
+                    _err(span, e)
+                    raise
                 _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
                 return resp
+
         else:
+
             def patched_parse(*args, **kwargs):
                 if is_suppressed():
                     return orig_parse(*args, **kwargs)
@@ -576,45 +595,63 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
                 try:
                     resp = orig_parse(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
+                    _err(span, e)
+                    raise
                 _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
                 return resp
+
         messages.parse = patched_parse
         messages._neatlogs_parse_patched = True
 
     # count_tokens → small utility call
-    if hasattr(messages, "count_tokens") and not getattr(messages, "_neatlogs_count_patched", False):
+    if hasattr(messages, "count_tokens") and not getattr(
+        messages, "_neatlogs_count_patched", False
+    ):
         orig_count = messages.count_tokens
         if is_async:
+
             async def patched_count(*args, **kwargs):
                 if is_suppressed():
                     return await orig_count(*args, **kwargs)
                 span = get_provider_tracer().start_span(
                     name="anthropic.messages.count_tokens",
-                    attributes={"neatlogs.span.kind": "llm", "neatlogs.llm.provider": "anthropic",
-                                "neatlogs.llm.task": "count_tokens", "neatlogs.llm.model_name": kwargs.get("model", "")},
+                    attributes={
+                        "neatlogs.span.kind": "llm",
+                        "neatlogs.llm.provider": "anthropic",
+                        "neatlogs.llm.task": "count_tokens",
+                        "neatlogs.llm.model_name": kwargs.get("model", ""),
+                    },
                 )
                 try:
                     resp = await orig_count(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
+                    _err(span, e)
+                    raise
                 _finalize_count_tokens(span, resp)
                 return resp
+
         else:
+
             def patched_count(*args, **kwargs):
                 if is_suppressed():
                     return orig_count(*args, **kwargs)
                 span = get_provider_tracer().start_span(
                     name="anthropic.messages.count_tokens",
-                    attributes={"neatlogs.span.kind": "llm", "neatlogs.llm.provider": "anthropic",
-                                "neatlogs.llm.task": "count_tokens", "neatlogs.llm.model_name": kwargs.get("model", "")},
+                    attributes={
+                        "neatlogs.span.kind": "llm",
+                        "neatlogs.llm.provider": "anthropic",
+                        "neatlogs.llm.task": "count_tokens",
+                        "neatlogs.llm.model_name": kwargs.get("model", ""),
+                    },
                 )
                 try:
                     resp = orig_count(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
+                    _err(span, e)
+                    raise
                 _finalize_count_tokens(span, resp)
                 return resp
+
         messages.count_tokens = patched_count
         messages._neatlogs_count_patched = True
 
@@ -675,27 +712,36 @@ def _patch_legacy_completions(completions: Any, is_async: bool) -> None:
         span.end()
 
     if is_async:
+
         async def patched(*args, **kwargs):
             if is_suppressed():
                 return await orig(*args, **kwargs)
-            span = get_provider_tracer().start_span(name="anthropic.completions.create", attributes=_attrs(kwargs))
+            span = get_provider_tracer().start_span(
+                name="anthropic.completions.create", attributes=_attrs(kwargs)
+            )
             start = time.perf_counter()
             try:
                 resp = await orig(*args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             _finalize(span, resp, (time.perf_counter() - start) * 1000)
             return resp
+
     else:
+
         def patched(*args, **kwargs):
             if is_suppressed():
                 return orig(*args, **kwargs)
-            span = get_provider_tracer().start_span(name="anthropic.completions.create", attributes=_attrs(kwargs))
+            span = get_provider_tracer().start_span(
+                name="anthropic.completions.create", attributes=_attrs(kwargs)
+            )
             start = time.perf_counter()
             try:
                 resp = orig(*args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             _finalize(span, resp, (time.perf_counter() - start) * 1000)
             return resp
 
@@ -713,6 +759,7 @@ def _err(span: Any, e: Exception) -> None:
 # Import-replacement: `from neatlogs.anthropic import anthropic`
 # Patches Anthropic/AsyncAnthropic.__init__ so every client is auto-wrapped.
 # ---------------------------------------------------------------------------
+
 
 def _patch_anthropic_module() -> None:
     global _PATCHED, _ORIG_INIT, _ORIG_ASYNC_INIT

--- a/neatlogs/azure_openai.py
+++ b/neatlogs/azure_openai.py
@@ -145,7 +145,9 @@ def _set_chat_input(span: Any, kwargs: dict) -> None:
             if fn.get("description"):
                 span.set_attribute(f"neatlogs.llm.tools.{i}.description", fn["description"])
             if fn.get("parameters"):
-                span.set_attribute(f"neatlogs.llm.tools.{i}.input_schema", serialize(fn["parameters"]))
+                span.set_attribute(
+                    f"neatlogs.llm.tools.{i}.input_schema", serialize(fn["parameters"])
+                )
 
     for param in ("temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty"):
         if param in kwargs and kwargs[param] is not None:
@@ -329,10 +331,13 @@ def _patch_embeddings(embeddings: Any, sync: bool = True) -> None:
         _ok(span, duration_ms)
 
     if sync:
+
         def patched(*args, **kwargs):
             if is_suppressed():
                 return orig(*args, **kwargs)
-            span = get_provider_tracer().start_span(name="azure_openai.embeddings.create", attributes=_start(kwargs))
+            span = get_provider_tracer().start_span(
+                name="azure_openai.embeddings.create", attributes=_start(kwargs)
+            )
             start = time.perf_counter()
             try:
                 response = orig(*args, **kwargs)
@@ -341,11 +346,15 @@ def _patch_embeddings(embeddings: Any, sync: bool = True) -> None:
                 raise
             _finalize(span, response, (time.perf_counter() - start) * 1000)
             return response
+
     else:
+
         async def patched(*args, **kwargs):
             if is_suppressed():
                 return await orig(*args, **kwargs)
-            span = get_provider_tracer().start_span(name="azure_openai.embeddings.create", attributes=_start(kwargs))
+            span = get_provider_tracer().start_span(
+                name="azure_openai.embeddings.create", attributes=_start(kwargs)
+            )
             start = time.perf_counter()
             try:
                 response = await orig(*args, **kwargs)
@@ -405,7 +414,9 @@ def _finalize_response(span: Any, response: Any, duration_ms: float) -> None:
     span.end()
 
 
-def _finalize_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]) -> None:
+def _finalize_stream(
+    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+) -> None:
     text_parts: List[str] = []
     tool_calls_acc: dict = {}
     finish_reason = None
@@ -498,7 +509,9 @@ def _finalize_responses_response(span: Any, response: Any, duration_ms: float) -
     span.end()
 
 
-def _finalize_responses_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]) -> None:
+def _finalize_responses_stream(
+    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+) -> None:
     text_parts: List[str] = []
     model = None
     usage = None
@@ -550,7 +563,9 @@ def _err(span: Any, e: Exception) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _patch_method(resource: Any, method_name: str, flag: str, start_attrs, finalize, is_async: bool) -> None:
+def _patch_method(
+    resource: Any, method_name: str, flag: str, start_attrs, finalize, is_async: bool
+) -> None:
     """
     Wrap resource.<method_name> with a span. start_attrs(kwargs)->dict builds the
     initial attributes; finalize(span, response, duration_ms) records the result.
@@ -561,10 +576,13 @@ def _patch_method(resource: Any, method_name: str, flag: str, start_attrs, final
     orig = getattr(resource, method_name)
 
     if is_async:
+
         async def patched(*args, **kwargs):
             if is_suppressed():
                 return await orig(*args, **kwargs)
-            span = get_provider_tracer().start_span(name=start_attrs.__name__, attributes=start_attrs(kwargs))
+            span = get_provider_tracer().start_span(
+                name=start_attrs.__name__, attributes=start_attrs(kwargs)
+            )
             start = time.perf_counter()
             try:
                 response = await orig(*args, **kwargs)
@@ -574,13 +592,18 @@ def _patch_method(resource: Any, method_name: str, flag: str, start_attrs, final
             try:
                 finalize(span, response, (time.perf_counter() - start) * 1000)
             except Exception:
-                span.set_status(StatusCode.OK); span.end()
+                span.set_status(StatusCode.OK)
+                span.end()
             return response
+
     else:
+
         def patched(*args, **kwargs):
             if is_suppressed():
                 return orig(*args, **kwargs)
-            span = get_provider_tracer().start_span(name=start_attrs.__name__, attributes=start_attrs(kwargs))
+            span = get_provider_tracer().start_span(
+                name=start_attrs.__name__, attributes=start_attrs(kwargs)
+            )
             start = time.perf_counter()
             try:
                 response = orig(*args, **kwargs)
@@ -590,7 +613,8 @@ def _patch_method(resource: Any, method_name: str, flag: str, start_attrs, final
             try:
                 finalize(span, response, (time.perf_counter() - start) * 1000)
             except Exception:
-                span.set_status(StatusCode.OK); span.end()
+                span.set_status(StatusCode.OK)
+                span.end()
             return response
 
     setattr(resource, method_name, patched)
@@ -611,12 +635,20 @@ def _patch_chat_parse(completions: Any, sync: bool = True) -> None:
             "neatlogs.llm.model_name": kwargs.get("model", ""),
             "neatlogs.llm.structured_output": True,
         }
+
     start_attrs.__name__ = "azure_openai.chat.completions.parse"
 
     def finalize(span, response, duration_ms):
         _finalize_response(span, response, duration_ms)
 
-    _patch_method(completions, "parse", "_neatlogs_azure_parse_patched", start_attrs, finalize, is_async=not sync)
+    _patch_method(
+        completions,
+        "parse",
+        "_neatlogs_azure_parse_patched",
+        start_attrs,
+        finalize,
+        is_async=not sync,
+    )
 
 
 def _patch_responses_parse(responses: Any, sync: bool = True) -> None:
@@ -630,12 +662,20 @@ def _patch_responses_parse(responses: Any, sync: bool = True) -> None:
             "neatlogs.llm.input_messages.0.role": "user",
             "neatlogs.llm.input_messages.0.content": serialize(kwargs.get("input", "")),
         }
+
     start_attrs.__name__ = "azure_openai.responses.parse"
 
     def finalize(span, response, duration_ms):
         _finalize_responses_response(span, response, duration_ms)
 
-    _patch_method(responses, "parse", "_neatlogs_azure_parse_patched", start_attrs, finalize, is_async=not sync)
+    _patch_method(
+        responses,
+        "parse",
+        "_neatlogs_azure_parse_patched",
+        start_attrs,
+        finalize,
+        is_async=not sync,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -652,8 +692,11 @@ def _patch_legacy_completions(completions: Any, sync: bool = True) -> None:
             "neatlogs.llm.system": _SYSTEM,
             "neatlogs.llm.model_name": kwargs.get("model", ""),
             "neatlogs.llm.input_messages.0.role": "user",
-            "neatlogs.llm.input_messages.0.content": (prompt if isinstance(prompt, str) else serialize(prompt))[:10000],
+            "neatlogs.llm.input_messages.0.content": (
+                prompt if isinstance(prompt, str) else serialize(prompt)
+            )[:10000],
         }
+
     start_attrs.__name__ = "azure_openai.completions.create"
 
     def finalize(span, response, duration_ms):
@@ -676,7 +719,14 @@ def _patch_legacy_completions(completions: Any, sync: bool = True) -> None:
                 span.set_attribute("neatlogs.llm.token_count.total", usage.total_tokens)
         _ok(span, duration_ms)
 
-    _patch_method(completions, "create", "_neatlogs_azure_legacy_patched", start_attrs, finalize, is_async=not sync)
+    _patch_method(
+        completions,
+        "create",
+        "_neatlogs_azure_legacy_patched",
+        start_attrs,
+        finalize,
+        is_async=not sync,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -685,12 +735,19 @@ def _patch_legacy_completions(completions: Any, sync: bool = True) -> None:
 
 
 def _patch_images(images: Any, sync: bool = True) -> None:
-    for method, span_name in (("generate", "azure_openai.images.generate"),
-                              ("edit", "azure_openai.images.edit"),
-                              ("create_variation", "azure_openai.images.create_variation")):
+    for method, span_name in (
+        ("generate", "azure_openai.images.generate"),
+        ("edit", "azure_openai.images.edit"),
+        ("create_variation", "azure_openai.images.create_variation"),
+    ):
+
         def make(method=method, span_name=span_name):
             def start_attrs(kwargs):
-                attrs = {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": _PROVIDER, "neatlogs.llm.task": "image"}
+                attrs = {
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": _PROVIDER,
+                    "neatlogs.llm.task": "image",
+                }
                 if kwargs.get("model"):
                     attrs["neatlogs.llm.model_name"] = kwargs["model"]
                 if kwargs.get("prompt"):
@@ -698,6 +755,7 @@ def _patch_images(images: Any, sync: bool = True) -> None:
                 if kwargs.get("size"):
                     attrs["neatlogs.image.size"] = str(kwargs["size"])
                 return attrs
+
             start_attrs.__name__ = span_name
 
             def finalize(span, response, duration_ms):
@@ -708,10 +766,13 @@ def _patch_images(images: Any, sync: bool = True) -> None:
                     except TypeError:
                         pass
                 _ok(span, duration_ms)
+
             return start_attrs, finalize
 
         sa, fin = make()
-        _patch_method(images, method, f"_neatlogs_azure_{method}_patched", sa, fin, is_async=not sync)
+        _patch_method(
+            images, method, f"_neatlogs_azure_{method}_patched", sa, fin, is_async=not sync
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -722,8 +783,13 @@ def _patch_images(images: Any, sync: bool = True) -> None:
 def _patch_audio(audio: Any, sync: bool = True) -> None:
     speech = getattr(audio, "speech", None)
     if speech is not None:
+
         def start_attrs(kwargs):
-            attrs = {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": _PROVIDER, "neatlogs.llm.task": "tts"}
+            attrs = {
+                "neatlogs.span.kind": "llm",
+                "neatlogs.llm.provider": _PROVIDER,
+                "neatlogs.llm.task": "tts",
+            }
             if kwargs.get("model"):
                 attrs["neatlogs.llm.model_name"] = kwargs["model"]
             if kwargs.get("input"):
@@ -731,19 +797,33 @@ def _patch_audio(audio: Any, sync: bool = True) -> None:
             if kwargs.get("voice"):
                 attrs["neatlogs.audio.voice"] = str(kwargs["voice"])
             return attrs
+
         start_attrs.__name__ = "azure_openai.audio.speech.create"
-        _patch_method(speech, "create", "_neatlogs_azure_patched", start_attrs, lambda s, r, d: _ok(s, d), is_async=not sync)
+        _patch_method(
+            speech,
+            "create",
+            "_neatlogs_azure_patched",
+            start_attrs,
+            lambda s, r, d: _ok(s, d),
+            is_async=not sync,
+        )
 
     for sub, task in (("transcriptions", "stt"), ("translations", "translation")):
         res = getattr(audio, sub, None)
         if res is None:
             continue
+
         def make(task=task, sub=sub):
             def start_attrs(kwargs):
-                attrs = {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": _PROVIDER, "neatlogs.llm.task": task}
+                attrs = {
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": _PROVIDER,
+                    "neatlogs.llm.task": task,
+                }
                 if kwargs.get("model"):
                     attrs["neatlogs.llm.model_name"] = kwargs["model"]
                 return attrs
+
             start_attrs.__name__ = f"azure_openai.audio.{sub}.create"
 
             def finalize(span, response, duration_ms):
@@ -752,7 +832,9 @@ def _patch_audio(audio: Any, sync: bool = True) -> None:
                     span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
                     span.set_attribute("neatlogs.llm.output_messages.0.content", str(text)[:10000])
                 _ok(span, duration_ms)
+
             return start_attrs, finalize
+
         sa, fin = make()
         _patch_method(res, "create", "_neatlogs_azure_patched", sa, fin, is_async=not sync)
 
@@ -764,25 +846,34 @@ def _patch_audio(audio: Any, sync: bool = True) -> None:
 
 def _patch_moderations(moderations: Any, sync: bool = True) -> None:
     def start_attrs(kwargs):
-        attrs = {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": _PROVIDER, "neatlogs.llm.task": "moderation"}
+        attrs = {
+            "neatlogs.span.kind": "llm",
+            "neatlogs.llm.provider": _PROVIDER,
+            "neatlogs.llm.task": "moderation",
+        }
         if kwargs.get("model"):
             attrs["neatlogs.llm.model_name"] = kwargs["model"]
         inp = kwargs.get("input")
         if inp:
             attrs["input.value"] = (inp if isinstance(inp, str) else serialize(inp))[:10000]
         return attrs
+
     start_attrs.__name__ = "azure_openai.moderations.create"
 
     def finalize(span, response, duration_ms):
         results = getattr(response, "results", None)
         if results:
             try:
-                span.set_attribute("neatlogs.moderation.flagged", bool(getattr(results[0], "flagged", False)))
+                span.set_attribute(
+                    "neatlogs.moderation.flagged", bool(getattr(results[0], "flagged", False))
+                )
             except (TypeError, AttributeError):
                 pass
         _ok(span, duration_ms)
 
-    _patch_method(moderations, "create", "_neatlogs_azure_patched", start_attrs, finalize, is_async=not sync)
+    _patch_method(
+        moderations, "create", "_neatlogs_azure_patched", start_attrs, finalize, is_async=not sync
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -793,6 +884,7 @@ def _patch_moderations(moderations: Any, sync: bool = True) -> None:
 def _patch_batches(batches: Any, sync: bool = True) -> None:
     def start_attrs(kwargs):
         return {"neatlogs.span.kind": "task", "neatlogs.batch.endpoint": kwargs.get("endpoint", "")}
+
     start_attrs.__name__ = "azure_openai.batches.create"
 
     def finalize(span, response, duration_ms):
@@ -804,13 +896,16 @@ def _patch_batches(batches: Any, sync: bool = True) -> None:
             span.set_attribute("neatlogs.batch.status", str(status))
         _ok(span, duration_ms)
 
-    _patch_method(batches, "create", "_neatlogs_azure_patched", start_attrs, finalize, is_async=not sync)
+    _patch_method(
+        batches, "create", "_neatlogs_azure_patched", start_attrs, finalize, is_async=not sync
+    )
 
 
 # ---------------------------------------------------------------------------
 # Import-replacement: `from neatlogs.azure_openai import AzureOpenAI`
 # Patches AzureOpenAI/AsyncAzureOpenAI.__init__ so every client is auto-wrapped.
 # ---------------------------------------------------------------------------
+
 
 def _patch_azure_openai_module() -> None:
     global _PATCHED, _ORIG_INIT, _ORIG_ASYNC_INIT

--- a/neatlogs/bedrock.py
+++ b/neatlogs/bedrock.py
@@ -58,7 +58,7 @@ def _vendor_from_model(model_id: Any) -> str:
     tail = mid.split("/")[-1]
     for prefix in ("us.", "eu.", "apac.", "us-gov."):
         if tail.startswith(prefix):
-            tail = tail[len(prefix):]
+            tail = tail[len(prefix) :]
     vendor = tail.split(".")[0] if "." in tail else ""
     return vendor or "bedrock"
 
@@ -131,9 +131,11 @@ def _set_converse_input(span: Any, kwargs: dict) -> None:
     idx = 0
     system = kwargs.get("system")
     if system:
-        text = " ".join(
-            blk.get("text", "") for blk in system if isinstance(blk, dict)
-        ).strip() if isinstance(system, list) else str(system)
+        text = (
+            " ".join(blk.get("text", "") for blk in system if isinstance(blk, dict)).strip()
+            if isinstance(system, list)
+            else str(system)
+        )
         if text:
             span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", "system")
             span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", text)
@@ -143,7 +145,9 @@ def _set_converse_input(span: Any, kwargs: dict) -> None:
         role = msg.get("role", "user")
         content = msg.get("content", [])
         span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", role)
-        span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", _converse_blocks_to_text(content))
+        span.set_attribute(
+            f"neatlogs.llm.input_messages.{idx}.content", _converse_blocks_to_text(content)
+        )
         idx += 1
 
     cfg = kwargs.get("inferenceConfig") or {}
@@ -203,9 +207,13 @@ def _finalize_converse(span: Any, response: dict, duration_ms: float) -> None:
             text_parts.append(str(block["text"]))
         elif "toolUse" in block:
             tu = block["toolUse"]
-            span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.id", str(tu.get("toolUseId", "")))
+            span.set_attribute(
+                f"neatlogs.llm.tool_calls.{tool_idx}.id", str(tu.get("toolUseId", ""))
+            )
             span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.name", str(tu.get("name", "")))
-            span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.arguments", serialize(tu.get("input", {})))
+            span.set_attribute(
+                f"neatlogs.llm.tool_calls.{tool_idx}.arguments", serialize(tu.get("input", {}))
+            )
             tool_idx += 1
 
     if text_parts:
@@ -322,7 +330,9 @@ def _wrap_converse_stream(stream: Any, span: Any, start: float):
                 if tc.get("id"):
                     span.set_attribute(f"neatlogs.llm.tool_calls.{j}.id", tc["id"])
                 span.set_attribute(f"neatlogs.llm.tool_calls.{j}.name", tc.get("name", ""))
-                span.set_attribute(f"neatlogs.llm.tool_calls.{j}.arguments", tc.get("arguments", ""))
+                span.set_attribute(
+                    f"neatlogs.llm.tool_calls.{j}.arguments", tc.get("arguments", "")
+                )
             if finish_reason:
                 span.set_attribute("neatlogs.llm.finish_reason", str(finish_reason))
             _set_converse_usage(span, usage)
@@ -368,14 +378,23 @@ def _set_invoke_input(span: Any, vendor: str, body: dict) -> None:
             idx += 1
     elif body.get("prompt"):  # Claude legacy / Llama
         span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", "user")
-        span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", str(body["prompt"])[:10000])
+        span.set_attribute(
+            f"neatlogs.llm.input_messages.{idx}.content", str(body["prompt"])[:10000]
+        )
     elif body.get("inputText"):  # Titan
         span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", "user")
-        span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", str(body["inputText"])[:10000])
+        span.set_attribute(
+            f"neatlogs.llm.input_messages.{idx}.content", str(body["inputText"])[:10000]
+        )
 
     # Invocation params (best-effort across vendors)
-    for key, attr in (("temperature", "temperature"), ("top_p", "top_p"), ("max_tokens", "max_tokens"),
-                      ("maxTokens", "max_tokens"), ("max_tokens_to_sample", "max_tokens")):
+    for key, attr in (
+        ("temperature", "temperature"),
+        ("top_p", "top_p"),
+        ("max_tokens", "max_tokens"),
+        ("maxTokens", "max_tokens"),
+        ("max_tokens_to_sample", "max_tokens"),
+    ):
         if body.get(key) is not None:
             span.set_attribute(f"neatlogs.llm.{attr}", body[key])
     cfg = body.get("textGenerationConfig")  # Titan
@@ -396,13 +415,24 @@ def _finalize_invoke(span: Any, vendor: str, body: dict, duration_ms: float) -> 
     if vendor == "anthropic":
         content = body.get("content")
         if isinstance(content, list):  # messages API
-            text = "".join(b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text")
+            text = "".join(
+                b.get("text", "")
+                for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
             tool_idx = 0
             for b in content:
                 if isinstance(b, dict) and b.get("type") == "tool_use":
-                    span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.id", str(b.get("id", "")))
-                    span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.name", str(b.get("name", "")))
-                    span.set_attribute(f"neatlogs.llm.tool_calls.{tool_idx}.arguments", serialize(b.get("input", {})))
+                    span.set_attribute(
+                        f"neatlogs.llm.tool_calls.{tool_idx}.id", str(b.get("id", ""))
+                    )
+                    span.set_attribute(
+                        f"neatlogs.llm.tool_calls.{tool_idx}.name", str(b.get("name", ""))
+                    )
+                    span.set_attribute(
+                        f"neatlogs.llm.tool_calls.{tool_idx}.arguments",
+                        serialize(b.get("input", {})),
+                    )
                     tool_idx += 1
         elif body.get("completion") is not None:  # legacy text completion
             text = body["completion"]

--- a/neatlogs/claude_agent_sdk.py
+++ b/neatlogs/claude_agent_sdk.py
@@ -38,7 +38,9 @@ from opentelemetry import context as otel_context
 from opentelemetry import trace as otel_trace
 from opentelemetry.trace import StatusCode
 
-from ._wrap_utils import attach_as_current, detach as _nl_detach, get_tracer, is_suppressed
+from ._wrap_utils import attach_as_current
+from ._wrap_utils import detach as _nl_detach
+from ._wrap_utils import get_tracer, is_suppressed
 
 _PROVIDER = "claude_agent_sdk"
 _ROOT_SCOPE = "__root__"
@@ -192,12 +194,20 @@ def _wrap_client_method(original, label: str):
 # Per-agent scope + run state
 # ---------------------------------------------------------------------------
 
+
 class _Scope:
     """One agent's tracing scope. The root scope is the orchestrator (keyed _ROOT_SCOPE); each
     subagent (identified by the parent_tool_use_id of the Task call that spawned it) gets its own
     scope lazily, with its AGENT span nested under that Task TOOL span."""
 
-    __slots__ = ("span", "ctx", "input_messages", "assistant_buffer", "final_text", "input_captured")
+    __slots__ = (
+        "span",
+        "ctx",
+        "input_messages",
+        "assistant_buffer",
+        "final_text",
+        "input_captured",
+    )
 
     def __init__(self, span, ctx, input_messages, input_captured):
         self.span = span
@@ -219,8 +229,11 @@ class _TracingQuery:
         self._agent_ctx = agent_ctx
         self._prompt_ref = prompt_ref
         root = _Scope(
-            span=agent_span, ctx=agent_ctx,
-            input_messages=([{"role": "user", "content": prompt_ref["text"]}] if prompt_ref["text"] else []),
+            span=agent_span,
+            ctx=agent_ctx,
+            input_messages=(
+                [{"role": "user", "content": prompt_ref["text"]}] if prompt_ref["text"] else []
+            ),
             input_captured=bool(prompt_ref["text"]),
         )
         self._tool_spans: Dict[str, Any] = {}
@@ -228,7 +241,7 @@ class _TracingQuery:
         self._session_id: Optional[str] = None
         self._model: Optional[str] = None
         self._finished = False
-        self._inner_iter = None    # set on first __anext__ (NOT via __getattr__ — see below)
+        self._inner_iter = None  # set on first __anext__ (NOT via __getattr__ — see below)
 
     # pass through the wrapped Query object's OWN methods (interrupt, set_model, …). CRITICAL: never
     # delegate our internal/dunder attrs (leading underscore) — otherwise `self._inner_iter` etc.
@@ -349,18 +362,23 @@ class _TracingQuery:
             self._flush_turn(root)
 
         parent_tool_span = self._tool_spans.get(parent_id)
-        parent_ctx = (otel_trace.set_span_in_context(parent_tool_span)
-                      if parent_tool_span is not None else root.ctx)
+        parent_ctx = (
+            otel_trace.set_span_in_context(parent_tool_span)
+            if parent_tool_span is not None
+            else root.ctx
+        )
 
         sub_type = str(_get(msg, "subagent_type") or "subagent")
         attrs: Dict[str, Any] = {"neatlogs.span.kind": "agent", "neatlogs.agent.name": sub_type}
         task_desc = _get(msg, "task_description")
         if task_desc:
             attrs["input.value"] = str(task_desc)
-        span = self._tracer.start_span(f"claude_agent.subagent.{sub_type}",
-                                       attributes=attrs, context=parent_ctx)
+        span = self._tracer.start_span(
+            f"claude_agent.subagent.{sub_type}", attributes=attrs, context=parent_ctx
+        )
         scope = _Scope(
-            span=span, ctx=otel_trace.set_span_in_context(span),
+            span=span,
+            ctx=otel_trace.set_span_in_context(span),
             input_messages=([{"role": "user", "content": str(task_desc)}] if task_desc else []),
             input_captured=bool(task_desc),
         )
@@ -443,8 +461,14 @@ class _TracingQuery:
         if content is None:
             content = _get(msg, "content") or []
         if scope.assistant_buffer is None:
-            scope.assistant_buffer = {"text": [], "thinking": [], "tool_calls": [],
-                                      "usage": None, "model": None, "stop_reason": None}
+            scope.assistant_buffer = {
+                "text": [],
+                "thinking": [],
+                "tool_calls": [],
+                "usage": None,
+                "model": None,
+                "stop_reason": None,
+            }
         buf = scope.assistant_buffer
         model = _get(message, "model") or _get(msg, "model")
         if model:
@@ -462,9 +486,13 @@ class _TracingQuery:
             elif bt == "thinking" and isinstance(_get(block, "thinking"), str):
                 buf["thinking"].append(_get(block, "thinking"))
             elif bt == "tool_use":
-                buf["tool_calls"].append({"id": _get(block, "id") or "",
-                                          "name": _get(block, "name") or "",
-                                          "input": _get(block, "input")})
+                buf["tool_calls"].append(
+                    {
+                        "id": _get(block, "id") or "",
+                        "name": _get(block, "name") or "",
+                        "input": _get(block, "input"),
+                    }
+                )
 
     def _flush_turn(self, scope: _Scope) -> None:
         """Emit the buffered model turn as ONE LLM span (nested under this scope's AGENT span), then
@@ -511,8 +539,9 @@ class _TracingQuery:
         if buf["stop_reason"]:
             attrs["neatlogs.llm.finish_reason"] = str(buf["stop_reason"])
 
-        span = self._tracer.start_span(f"claude_agent.llm.{model or 'model'}",
-                                       attributes=attrs, context=scope.ctx)
+        span = self._tracer.start_span(
+            f"claude_agent.llm.{model or 'model'}", attributes=attrs, context=scope.ctx
+        )
         if buf["usage"]:
             _set_usage(span, buf["usage"])
         span.set_status(StatusCode.OK)
@@ -532,12 +561,16 @@ class _TracingQuery:
 
         # open TOOL spans (closed by their tool_result); a Task tool's id becomes a subagent key
         for tc in buf["tool_calls"]:
-            t_attrs = {"neatlogs.span.kind": "tool", "neatlogs.tool.name": str(tc["name"] or ""),
-                       "input.value": _safe_json(tc["input"] or {})}
+            t_attrs = {
+                "neatlogs.span.kind": "tool",
+                "neatlogs.tool.name": str(tc["name"] or ""),
+                "input.value": _safe_json(tc["input"] or {}),
+            }
             if tc["id"]:
                 t_attrs["neatlogs.tool_call.id"] = str(tc["id"])
-            tool_span = self._tracer.start_span(f"claude_agent.tool.{tc['name'] or 'tool'}",
-                                                attributes=t_attrs, context=scope.ctx)
+            tool_span = self._tracer.start_span(
+                f"claude_agent.tool.{tc['name'] or 'tool'}", attributes=t_attrs, context=scope.ctx
+            )
             if tc["id"]:
                 self._tool_spans[tc["id"]] = tool_span
 
@@ -600,8 +633,12 @@ def _block_type(block: Any) -> str:
     if isinstance(block, dict):
         return block.get("type") or ""
     name = type(block).__name__
-    return {"TextBlock": "text", "ThinkingBlock": "thinking",
-            "ToolUseBlock": "tool_use", "ToolResultBlock": "tool_result"}.get(name, "")
+    return {
+        "TextBlock": "text",
+        "ThinkingBlock": "thinking",
+        "ToolUseBlock": "tool_use",
+        "ToolResultBlock": "tool_result",
+    }.get(name, "")
 
 
 def _is_async_iterable(obj: Any) -> bool:

--- a/neatlogs/core/context.py
+++ b/neatlogs/core/context.py
@@ -133,7 +133,9 @@ def trace(
     from .._wrap_utils import (
         _neatlogs_root_kwargs,
         attach_as_current,
-        detach as _nl_detach,
+    )
+    from .._wrap_utils import detach as _nl_detach
+    from .._wrap_utils import (
         get_internal_tracer,
     )
 
@@ -239,9 +241,7 @@ def trace(
     span = tracer.start_span(name, context=parent_ctx)
     span_token = attach_as_current(span)
     try:
-        logger.debug(
-            f"[trace] Creating {'root' if is_root else 'child'} span '{name}'"
-        )
+        logger.debug(f"[trace] Creating {'root' if is_root else 'child'} span '{name}'")
         _set_span_attributes(span, kind, template_string, prompt_variables, version, attributes)
         # Session/end-user belong to the trace root only.
         apply_session_attributes(span, session_id, is_root=is_root)

--- a/neatlogs/core/span_processor.py
+++ b/neatlogs/core/span_processor.py
@@ -42,7 +42,7 @@ def _is_neatlogs_scope_span(span: Any) -> bool:
 # forever. We treat HTTP auto-instrumentation as propagation-only and DROP a span
 # that is BOTH rootless AND an HTTP-scope span (keeping nested HTTP spans intact).
 _HTTP_INSTRUMENTATION_SCOPES = (
-    "opentelemetry.instrumentation.urllib",       # covers urllib and urllib3
+    "opentelemetry.instrumentation.urllib",  # covers urllib and urllib3
     "opentelemetry.instrumentation.requests",
     "opentelemetry.instrumentation.httpx",
     "opentelemetry.instrumentation.aiohttp_client",
@@ -50,8 +50,15 @@ _HTTP_INSTRUMENTATION_SCOPES = (
 )
 
 _AGENTIC_KINDS = {
-    "WORKFLOW", "AGENT", "CHAIN", "TOOL", "RETRIEVER",
-    "EMBEDDING", "GUARDRAIL", "LLM", "MCP_TOOL",
+    "WORKFLOW",
+    "AGENT",
+    "CHAIN",
+    "TOOL",
+    "RETRIEVER",
+    "EMBEDDING",
+    "GUARDRAIL",
+    "LLM",
+    "MCP_TOOL",
 }
 
 # Hosts for third-party framework telemetry that our HTTP auto-instrumentation
@@ -100,7 +107,7 @@ def is_rootless_infra_http(span) -> bool:
         if not scope_name.startswith(_HTTP_INSTRUMENTATION_SCOPES):
             return False
         attrs = span.attributes or {}
-        kind = (attrs.get("openinference.span.kind") or attrs.get("neatlogs.span.kind") or "")
+        kind = attrs.get("openinference.span.kind") or attrs.get("neatlogs.span.kind") or ""
         if str(kind).upper() in _AGENTIC_KINDS:
             return False  # explicitly an agentic root — keep
         return True

--- a/neatlogs/crewai.py
+++ b/neatlogs/crewai.py
@@ -171,7 +171,12 @@ def wrap_crewai(obj: Any) -> Any:
     )
 
     # Flow detection — Flows are their own class hierarchy; patch at the class level.
-    if "flow" in module or hasattr(obj, "_methods") and hasattr(obj, "kickoff") and not hasattr(obj, "tasks"):
+    if (
+        "flow" in module
+        or hasattr(obj, "_methods")
+        and hasattr(obj, "kickoff")
+        and not hasattr(obj, "tasks")
+    ):
         _dbg(f"→ routed to FLOW branch; patching flow class {cls_name} (id={obj_id})")
         _patch_flow_class(type(obj))
         return obj
@@ -185,7 +190,9 @@ def wrap_crewai(obj: Any) -> Any:
         and not hasattr(obj, "tasks")
         and not hasattr(obj, "agents")
     ):
-        _dbg(f"→ routed to STANDALONE AGENT branch (role={getattr(obj, 'role', None)!r}, id={obj_id})")
+        _dbg(
+            f"→ routed to STANDALONE AGENT branch (role={getattr(obj, 'role', None)!r}, id={obj_id})"
+        )
         _patch_agent_kickoff(obj)
         return obj
 
@@ -220,7 +227,9 @@ def _get_crew_attributes(crew: Any) -> dict:
 
     process = getattr(crew, "process", None)
     if process:
-        attrs["neatlogs.crewai.process"] = str(process.value) if hasattr(process, "value") else str(process)
+        attrs["neatlogs.crewai.process"] = (
+            str(process.value) if hasattr(process, "value") else str(process)
+        )
 
     agents = getattr(crew, "agents", None)
     if agents:
@@ -232,6 +241,7 @@ def _get_crew_attributes(crew: Any) -> dict:
 
     try:
         import crewai
+
         attrs["neatlogs.crewai.version"] = getattr(crewai, "__version__", "")
     except (ImportError, AttributeError):
         pass
@@ -270,7 +280,11 @@ def _extract_token_usage(result: Any) -> dict:
     token_usage = getattr(result, "token_usage", None)
     if not token_usage:
         return attrs
-    usage = token_usage if isinstance(token_usage, dict) else (token_usage.__dict__ if hasattr(token_usage, "__dict__") else {})
+    usage = (
+        token_usage
+        if isinstance(token_usage, dict)
+        else (token_usage.__dict__ if hasattr(token_usage, "__dict__") else {})
+    )
     if usage.get("prompt_tokens"):
         attrs["neatlogs.llm.token_count.prompt"] = usage["prompt_tokens"]
     if usage.get("completion_tokens"):
@@ -345,7 +359,8 @@ def _patch_crew_class(CrewCls: Any) -> None:
             _patch_tasks_and_agents(self)
             tracer = get_tracer()
             span = tracer.start_span(
-                name="crewai.crew.kickoff", attributes=_get_crew_attributes(self),
+                name="crewai.crew.kickoff",
+                attributes=_get_crew_attributes(self),
                 **_shared_trace_kwargs(),
             )
             _dbg(f"opened 'crewai.crew.kickoff' WORKFLOW span for crew id={hex(id(self))}")
@@ -356,7 +371,8 @@ def _patch_crew_class(CrewCls: Any) -> None:
             try:
                 result = orig_kickoff(self, *args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 _mark_kickoff(self, False)
                 detach(token)
@@ -383,15 +399,21 @@ def _patch_crew_class(CrewCls: Any) -> None:
             try:
                 results = orig_kfe(self, *args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 detach(token)
             if results is not None:
                 try:
-                    span.set_attribute("output.value", serialize([getattr(r, "raw", str(r)) for r in results])[:10000])
+                    span.set_attribute(
+                        "output.value",
+                        serialize([getattr(r, "raw", str(r)) for r in results])[:10000],
+                    )
                 except TypeError:
                     pass
-            span.set_attribute("neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3))
+            span.set_attribute(
+                "neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3)
+            )
             span.set_status(StatusCode.OK)
             span.end()
             return results
@@ -415,10 +437,13 @@ def _patch_crew_class(CrewCls: Any) -> None:
             try:
                 results = await orig_kfea(self, *args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 detach(token)
-            span.set_attribute("neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3))
+            span.set_attribute(
+                "neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3)
+            )
             span.set_status(StatusCode.OK)
             span.end()
             return results
@@ -459,6 +484,7 @@ def _patch_extra_crew_class_entrypoints(CrewCls: Any) -> None:
                 return span
 
             if is_async:
+
                 async def patched(self, *args, **kwargs):
                     span = _open(self, kwargs)
                     token = attach_as_current(span)
@@ -466,11 +492,13 @@ def _patch_extra_crew_class_entrypoints(CrewCls: Any) -> None:
                     try:
                         result = await orig(self, *args, **kwargs)
                     except Exception as e:
-                        _err(span, e); raise
+                        _err(span, e)
+                        raise
                     finally:
                         detach(token)
                     _finalize_crew_span(span, result, (time.perf_counter() - start) * 1000)
                     return result
+
                 return patched
 
             def patched(self, *args, **kwargs):
@@ -480,11 +508,13 @@ def _patch_extra_crew_class_entrypoints(CrewCls: Any) -> None:
                 try:
                     result = orig(self, *args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
+                    _err(span, e)
+                    raise
                 finally:
                     detach(token)
                 _finalize_crew_span(span, result, (time.perf_counter() - start) * 1000)
                 return result
+
             return patched
 
         setattr(CrewCls, method_name, _make())
@@ -542,12 +572,18 @@ def _patch_task_execute(task: Any) -> None:
             raw = getattr(result, "raw", None) if hasattr(result, "raw") else str(result)
             if raw:
                 span.set_attribute("output.value", str(raw)[:10000])
-        span.set_attribute("neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3))
+        span.set_attribute(
+            "neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3)
+        )
         span.set_status(StatusCode.OK)
         span.end()
 
     # Sync core (covers execute_sync path)
-    sync_method = "_execute_core" if hasattr(task, "_execute_core") else ("execute_sync" if hasattr(task, "execute_sync") else None)
+    sync_method = (
+        "_execute_core"
+        if hasattr(task, "_execute_core")
+        else ("execute_sync" if hasattr(task, "execute_sync") else None)
+    )
     if sync_method:
         orig_sync = getattr(task, sync_method)
 
@@ -559,7 +595,8 @@ def _patch_task_execute(task: Any) -> None:
             try:
                 result = orig_sync(*args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 detach(token)
             _finalize(span, result, start)
@@ -580,7 +617,9 @@ def _patch_task_execute(task: Any) -> None:
             try:
                 future = orig_async(*args, **kwargs)
             except Exception as e:
-                _err(span, e); detach(token); raise
+                _err(span, e)
+                detach(token)
+                raise
             detach(token)
 
             # Attach a done-callback to finalize when the future completes.
@@ -626,18 +665,23 @@ def _patch_agent_execute(agent: Any) -> None:
                 if tool_desc:
                     attrs[f"neatlogs.llm.tools.{i}.description"] = str(tool_desc)[:500]
 
-        span = tracer.start_span(name=f"crewai.agent.{role}" if role else "crewai.agent", attributes=attrs)
+        span = tracer.start_span(
+            name=f"crewai.agent.{role}" if role else "crewai.agent", attributes=attrs
+        )
         token = attach_as_current(span)
         start = time.perf_counter()
         try:
             result = orig(*args, **kwargs)
         except Exception as e:
-            _err(span, e); raise
+            _err(span, e)
+            raise
         finally:
             detach(token)
         if result is not None:
             span.set_attribute("output.value", str(result)[:10000])
-        span.set_attribute("neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3))
+        span.set_attribute(
+            "neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3)
+        )
         span.set_status(StatusCode.OK)
         span.end()
         return result
@@ -684,7 +728,9 @@ def _patch_agent_kickoff(agent: Any) -> None:
         if result is not None:
             raw = getattr(result, "raw", None)
             span.set_attribute("output.value", str(raw if raw is not None else result)[:10000])
-        span.set_attribute("neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3))
+        span.set_attribute(
+            "neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3)
+        )
         span.set_status(StatusCode.OK)
         span.end()
 
@@ -699,7 +745,8 @@ def _patch_agent_kickoff(agent: Any) -> None:
             try:
                 result = orig(*args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 detach(token)
             _finish(span, result, start)
@@ -725,11 +772,13 @@ def _patch_agent_kickoff(agent: Any) -> None:
                 try:
                     result = await orig_async(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
+                    _err(span, e)
+                    raise
                 finally:
                     detach(token)
                 _finish(span, result, start)
                 return result
+
             return patched_async
 
         _safe_setattr(agent, method_name, _make())
@@ -791,13 +840,16 @@ def _patch_flow_class(FlowCls: Any) -> None:
             try:
                 result = orig(self, *args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 _mark_kickoff(self, False)
                 detach(token)
             if result is not None:
                 span.set_attribute("output.value", str(result)[:10000])
-            span.set_attribute("neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3))
+            span.set_attribute(
+                "neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3)
+            )
             span.set_status(StatusCode.OK)
             span.end()
             return result
@@ -819,13 +871,16 @@ def _patch_flow_class(FlowCls: Any) -> None:
             try:
                 result = await orig_async(self, *args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 _mark_kickoff(self, False)
                 detach(token)
             if result is not None:
                 span.set_attribute("output.value", str(result)[:10000])
-            span.set_attribute("neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3))
+            span.set_attribute(
+                "neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3)
+            )
             span.set_status(StatusCode.OK)
             span.end()
             return result
@@ -857,6 +912,7 @@ def _patch_crew_classes() -> None:
     so they're covered for wrapped and bare crews alike."""
     try:
         from crewai.crew import Crew
+
         _patch_crew_class(Crew)
     except Exception as e:
         _dbg(f"could not class-patch Crew: {e}")
@@ -897,7 +953,8 @@ def _patch_tool_run(ToolCls) -> None:
         try:
             result = orig_run(self, *args, **kwargs)
         except Exception as e:
-            _err(span, e); raise
+            _err(span, e)
+            raise
         finally:
             detach(token)
         if result is not None:
@@ -919,7 +976,11 @@ def _patch_structured_tool() -> None:
     if getattr(CrewStructuredTool, "_neatlogs_patched", False):
         return
 
-    target_method = "invoke" if "invoke" in CrewStructuredTool.__dict__ else ("_run" if "_run" in CrewStructuredTool.__dict__ else None)
+    target_method = (
+        "invoke"
+        if "invoke" in CrewStructuredTool.__dict__
+        else ("_run" if "_run" in CrewStructuredTool.__dict__ else None)
+    )
     if not target_method:
         return
     orig = getattr(CrewStructuredTool, target_method)
@@ -939,7 +1000,8 @@ def _patch_structured_tool() -> None:
         try:
             result = orig(self, *args, **kwargs)
         except Exception as e:
-            _err(span, e); raise
+            _err(span, e)
+            raise
         finally:
             detach(token)
         if result is not None:
@@ -960,12 +1022,14 @@ def _patch_llm() -> None:
     targets = []
     try:
         from crewai.llms.base_llm import BaseLLM
+
         targets.append(BaseLLM)
         targets.extend(_all_subclasses(BaseLLM))
     except Exception:
         pass
     try:
         from crewai.llm import LLM
+
         if LLM not in targets:
             targets.append(LLM)
     except Exception:
@@ -1039,7 +1103,13 @@ def _install_litellm_capture() -> None:
                     rec["provider"] = str(hp["custom_llm_provider"])
             # Request params AS SENT (crewai maps max_completion_tokens→max_tokens here).
             params = {}
-            for p in ("temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty"):
+            for p in (
+                "temperature",
+                "top_p",
+                "max_tokens",
+                "frequency_penalty",
+                "presence_penalty",
+            ):
                 v = kwargs.get(p)
                 if v is not None:
                     params[p] = v
@@ -1108,10 +1178,14 @@ def _patch_llm_call(LLM) -> None:
         # alias for max_tokens). The litellm capture below overrides these with the
         # params AS SENT when available — this is the fallback for streaming/mocks.
         req_params = {}
-        for src, dst in (("temperature", "temperature"), ("top_p", "top_p"),
-                         ("max_tokens", "max_tokens"), ("max_completion_tokens", "max_tokens"),
-                         ("frequency_penalty", "frequency_penalty"),
-                         ("presence_penalty", "presence_penalty")):
+        for src, dst in (
+            ("temperature", "temperature"),
+            ("top_p", "top_p"),
+            ("max_tokens", "max_tokens"),
+            ("max_completion_tokens", "max_tokens"),
+            ("frequency_penalty", "frequency_penalty"),
+            ("presence_penalty", "presence_penalty"),
+        ):
             v = getattr(self, src, None)
             if v is not None and dst not in req_params:
                 req_params[dst] = v
@@ -1124,7 +1198,8 @@ def _patch_llm_call(LLM) -> None:
         try:
             result = orig_call(self, messages, *args, **kwargs)
         except Exception as e:
-            _err(span, e); raise
+            _err(span, e)
+            raise
         finally:
             detach(token)
         if result is not None:
@@ -1151,14 +1226,20 @@ def _patch_llm_call(LLM) -> None:
             for k, v in req_params.items():
                 span.set_attribute(f"neatlogs.llm.{k}", v)
 
-        for dst, key in (("prompt", "prompt_tokens"), ("completion", "completion_tokens"),
-                         ("total", "total_tokens"), ("cache_read", "cached_tokens"),
-                         ("reasoning", "reasoning_tokens")):
+        for dst, key in (
+            ("prompt", "prompt_tokens"),
+            ("completion", "completion_tokens"),
+            ("total", "total_tokens"),
+            ("cache_read", "cached_tokens"),
+            ("reasoning", "reasoning_tokens"),
+        ):
             v = rec.get(key)
             if isinstance(v, (int, float)) and v > 0:
                 span.set_attribute(f"neatlogs.llm.token_count.{dst}", v)
 
-        span.set_attribute("neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3))
+        span.set_attribute(
+            "neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3)
+        )
         span.set_status(StatusCode.OK)
         span.end()
         return result

--- a/neatlogs/decorators/_base.py
+++ b/neatlogs/decorators/_base.py
@@ -218,14 +218,12 @@ def _decorate_span(
             @functools.wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
                 from ..core.end_user import apply_end_user_attributes
-                from ..core.session import apply_session_attributes
                 from ..core.log import _CaptureStdoutContext
                 from ..core.mask import register_mask
+                from ..core.session import apply_session_attributes
 
                 is_root = _is_root_span()
-                with neatlogs_span(
-                    __name__, span_name, kind=otel_trace.SpanKind.INTERNAL
-                ) as span:
+                with neatlogs_span(__name__, span_name, kind=otel_trace.SpanKind.INTERNAL) as span:
                     _set_common_span_attrs(
                         span,
                         openinference_kind=openinference_kind,
@@ -237,9 +235,7 @@ def _decorate_span(
                     )
                     # Session/end-user belong to the trace root only.
                     apply_session_attributes(span, session_id, is_root=is_root)
-                    apply_end_user_attributes(
-                        span, end_user_id, end_user_metadata, is_root=is_root
-                    )
+                    apply_end_user_attributes(span, end_user_id, end_user_metadata, is_root=is_root)
                     if mask is not None:
                         span.set_attribute("neatlogs.mask_id", register_mask(mask))
                     if description:
@@ -282,14 +278,12 @@ def _decorate_span(
         @functools.wraps(func)
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             from ..core.end_user import apply_end_user_attributes
-            from ..core.session import apply_session_attributes
             from ..core.log import _CaptureStdoutContext
             from ..core.mask import register_mask
+            from ..core.session import apply_session_attributes
 
             is_root = _is_root_span()
-            with neatlogs_span(
-                __name__, span_name, kind=otel_trace.SpanKind.INTERNAL
-            ) as span:
+            with neatlogs_span(__name__, span_name, kind=otel_trace.SpanKind.INTERNAL) as span:
                 _set_common_span_attrs(
                     span,
                     openinference_kind=openinference_kind,

--- a/neatlogs/dspy.py
+++ b/neatlogs/dspy.py
@@ -87,7 +87,8 @@ def _patch_module_class() -> None:
         try:
             result = orig_call(self, *args, **kwargs)
         except Exception as e:
-            _err(span, e); raise
+            _err(span, e)
+            raise
         finally:
             detach(token)
 
@@ -147,7 +148,9 @@ def _patch_lm_class() -> None:
         if messages and isinstance(messages, list):
             for i, msg in enumerate(messages):
                 role = msg.get("role", "") if isinstance(msg, dict) else getattr(msg, "role", "")
-                content = msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")
+                content = (
+                    msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")
+                )
                 content_str = content if isinstance(content, str) else serialize(content)
                 if role:
                     attrs[f"neatlogs.llm.input_messages.{i}.role"] = role
@@ -173,7 +176,8 @@ def _patch_lm_class() -> None:
         try:
             result = orig_call(self, prompt=prompt, messages=messages, **kwargs)
         except Exception as e:
-            _err(span, e); raise
+            _err(span, e)
+            raise
         finally:
             detach(token)
 
@@ -279,7 +283,9 @@ def _patch_retrieve_class() -> None:
         attrs = {"neatlogs.span.kind": "retriever"}
         if query_or_queries is not None:
             attrs["neatlogs.retrieval.query"] = (
-                query_or_queries if isinstance(query_or_queries, str) else serialize(query_or_queries)
+                query_or_queries
+                if isinstance(query_or_queries, str)
+                else serialize(query_or_queries)
             )[:10000]
         effective_k = k if k is not None else getattr(self, "k", None)
         if effective_k is not None:
@@ -291,7 +297,8 @@ def _patch_retrieve_class() -> None:
         try:
             result = orig_forward(self, query_or_queries, k, *args, **kwargs)
         except Exception as e:
-            _err(span, e); raise
+            _err(span, e)
+            raise
         finally:
             detach(token)
 
@@ -304,7 +311,9 @@ def _patch_retrieve_class() -> None:
             except TypeError:
                 pass
             span.set_attribute("neatlogs.retrieval.documents", serialize(passages)[:10000])
-        span.set_attribute("neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3))
+        span.set_attribute(
+            "neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3)
+        )
         span.set_status(StatusCode.OK)
         span.end()
         return result

--- a/neatlogs/google_adk.py
+++ b/neatlogs/google_adk.py
@@ -16,7 +16,6 @@ from opentelemetry.trace import StatusCode
 
 from ._wrap_utils import attach_as_current, detach, get_tracer, serialize
 
-
 _ADK_HOOKS_INSTALLED = False
 
 # The inner `generate_content` span (trace_inference_result) only receives the
@@ -73,13 +72,16 @@ def _install_adk_telemetry_hooks() -> None:
     # --- LLM calls: trace_call_llm(invocation_context, event_id, llm_request, llm_response, span=None)
     orig_call_llm = getattr(adk_tracing, "trace_call_llm", None)
     if orig_call_llm is not None and not getattr(orig_call_llm, "_neatlogs_wrapped", False):
+
         def patched_trace_call_llm(*args, **kwargs):
             orig_call_llm(*args, **kwargs)
             try:
                 # positional: (invocation_context, event_id, llm_request, llm_response, span?)
                 llm_request = args[2] if len(args) > 2 else kwargs.get("llm_request")
                 llm_response = args[3] if len(args) > 3 else kwargs.get("llm_response")
-                span = (args[4] if len(args) > 4 else kwargs.get("span")) or otel_trace.get_current_span()
+                span = (
+                    args[4] if len(args) > 4 else kwargs.get("span")
+                ) or otel_trace.get_current_span()
                 if span is not None:
                     span.set_attribute("neatlogs.span.kind", "llm")
                     # Emit PROPERLY-ROLED indexed messages (system / user / assistant /
@@ -102,6 +104,7 @@ def _install_adk_telemetry_hooks() -> None:
                         span.set_attribute("neatlogs.llm.output_messages.0.content", out_text)
             except Exception:
                 pass
+
         patched_trace_call_llm._neatlogs_wrapped = True
         _rebind_adk_symbol("trace_call_llm", patched_trace_call_llm, adk_tracing)
 
@@ -111,6 +114,7 @@ def _install_adk_telemetry_hooks() -> None:
     #     first-turn race where the inner span has no input yet.
     orig_use_inf = getattr(adk_tracing, "use_inference_span", None)
     if orig_use_inf is not None and not getattr(orig_use_inf, "_neatlogs_wrapped", False):
+
         def patched_use_inference_span(*args, **kwargs):
             try:
                 llm_request = args[0] if args else kwargs.get("llm_request")
@@ -121,6 +125,7 @@ def _install_adk_telemetry_hooks() -> None:
             except Exception:
                 pass
             return orig_use_inf(*args, **kwargs)
+
         patched_use_inference_span._neatlogs_wrapped = True
         _rebind_adk_symbol("use_inference_span", patched_use_inference_span, adk_tracing)
 
@@ -131,6 +136,7 @@ def _install_adk_telemetry_hooks() -> None:
     #     render empty. Enrich it with the same neatlogs I/O so neither LLM span is blank.
     orig_inf_result = getattr(adk_tracing, "trace_inference_result", None)
     if orig_inf_result is not None and not getattr(orig_inf_result, "_neatlogs_wrapped", False):
+
         def patched_trace_inference_result(*args, **kwargs):
             orig_inf_result(*args, **kwargs)
             try:
@@ -151,7 +157,9 @@ def _install_adk_telemetry_hooks() -> None:
                     if in_msgs:
                         for i, m in enumerate(in_msgs):
                             span.set_attribute(f"neatlogs.llm.input_messages.{i}.role", m["role"])
-                            span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", m["content"])
+                            span.set_attribute(
+                                f"neatlogs.llm.input_messages.{i}.content", m["content"]
+                            )
                         span.set_attribute("input.value", serialize({"messages": in_msgs}))
                     out_text = _adk_llm_response_text(llm_response)
                     if out_text:
@@ -160,12 +168,14 @@ def _install_adk_telemetry_hooks() -> None:
                         span.set_attribute("neatlogs.llm.output_messages.0.content", out_text)
             except Exception:
                 pass
+
         patched_trace_inference_result._neatlogs_wrapped = True
         _rebind_adk_symbol("trace_inference_result", patched_trace_inference_result, adk_tracing)
 
     # --- Tool calls: trace_tool_call(tool, args, function_response_event)
     orig_tool_call = getattr(adk_tracing, "trace_tool_call", None)
     if orig_tool_call is not None and not getattr(orig_tool_call, "_neatlogs_wrapped", False):
+
         def patched_trace_tool_call(*args, **kwargs):
             orig_tool_call(*args, **kwargs)
             try:
@@ -181,12 +191,14 @@ def _install_adk_telemetry_hooks() -> None:
                         span.set_attribute("output.value", out_text)
             except Exception:
                 pass
+
         patched_trace_tool_call._neatlogs_wrapped = True
         _rebind_adk_symbol("trace_tool_call", patched_trace_tool_call, adk_tracing)
 
     # --- Agent invocation: trace_agent_invocation(span, agent, ctx)
     orig_agent_inv = getattr(adk_tracing, "trace_agent_invocation", None)
     if orig_agent_inv is not None and not getattr(orig_agent_inv, "_neatlogs_wrapped", False):
+
         def patched_trace_agent_invocation(*args, **kwargs):
             orig_agent_inv(*args, **kwargs)
             try:
@@ -201,7 +213,11 @@ def _install_adk_telemetry_hooks() -> None:
                         span.set_attribute("neatlogs.llm.input_messages.0.role", "system")
                         span.set_attribute("neatlogs.llm.input_messages.0.content", instruction)
                     # User input for this invocation.
-                    user_text = _content_to_text(getattr(ctx, "user_content", None)) if ctx is not None else ""
+                    user_text = (
+                        _content_to_text(getattr(ctx, "user_content", None))
+                        if ctx is not None
+                        else ""
+                    )
                     if user_text:
                         span.set_attribute("input.value", user_text)
                     name = getattr(agent, "name", None)
@@ -209,6 +225,7 @@ def _install_adk_telemetry_hooks() -> None:
                         span.set_attribute("neatlogs.agent.name", str(name))
             except Exception:
                 pass
+
         patched_trace_agent_invocation._neatlogs_wrapped = True
         _rebind_adk_symbol("trace_agent_invocation", patched_trace_agent_invocation, adk_tracing)
 
@@ -254,7 +271,9 @@ def _content_to_text(content: Any) -> str:
                 continue
             fc = getattr(p, "function_call", None)
             if fc is not None:
-                out.append(f"{getattr(fc, 'name', '')}({serialize(dict(getattr(fc, 'args', {}) or {}))})")
+                out.append(
+                    f"{getattr(fc, 'name', '')}({serialize(dict(getattr(fc, 'args', {}) or {}))})"
+                )
                 continue
             fr = getattr(p, "function_response", None)
             if fr is not None:
@@ -359,8 +378,12 @@ def _collect_events(events) -> tuple:
             for action in (actions if isinstance(actions, list) else [actions]):
                 usage = getattr(action, "usage_metadata", None) or getattr(action, "usage", None)
                 if usage:
-                    input_t = getattr(usage, "prompt_token_count", None) or getattr(usage, "input_tokens", 0)
-                    output_t = getattr(usage, "candidates_token_count", None) or getattr(usage, "output_tokens", 0)
+                    input_t = getattr(usage, "prompt_token_count", None) or getattr(
+                        usage, "input_tokens", 0
+                    )
+                    output_t = getattr(usage, "candidates_token_count", None) or getattr(
+                        usage, "output_tokens", 0
+                    )
                     if input_t:
                         total_input_tokens += input_t
                     if output_t:
@@ -377,10 +400,12 @@ def _collect_events(events) -> tuple:
             for part in parts:
                 fn_call = getattr(part, "function_call", None)
                 if fn_call:
-                    tool_calls.append({
-                        "name": getattr(fn_call, "name", ""),
-                        "arguments": serialize(getattr(fn_call, "args", {})),
-                    })
+                    tool_calls.append(
+                        {
+                            "name": getattr(fn_call, "name", ""),
+                            "arguments": serialize(getattr(fn_call, "args", {})),
+                        }
+                    )
 
     attrs = {}
     if total_input_tokens:
@@ -435,8 +460,12 @@ async def _collect_events_async(events) -> tuple:
             for action in (actions if isinstance(actions, list) else [actions]):
                 usage = getattr(action, "usage_metadata", None) or getattr(action, "usage", None)
                 if usage:
-                    input_t = getattr(usage, "prompt_token_count", None) or getattr(usage, "input_tokens", 0)
-                    output_t = getattr(usage, "candidates_token_count", None) or getattr(usage, "output_tokens", 0)
+                    input_t = getattr(usage, "prompt_token_count", None) or getattr(
+                        usage, "input_tokens", 0
+                    )
+                    output_t = getattr(usage, "candidates_token_count", None) or getattr(
+                        usage, "output_tokens", 0
+                    )
                     if input_t:
                         total_input_tokens += input_t
                     if output_t:
@@ -452,10 +481,12 @@ async def _collect_events_async(events) -> tuple:
             for part in parts:
                 fn_call = getattr(part, "function_call", None)
                 if fn_call:
-                    tool_calls.append({
-                        "name": getattr(fn_call, "name", ""),
-                        "arguments": serialize(getattr(fn_call, "args", {})),
-                    })
+                    tool_calls.append(
+                        {
+                            "name": getattr(fn_call, "name", ""),
+                            "arguments": serialize(getattr(fn_call, "args", {})),
+                        }
+                    )
 
     attrs = {}
     if total_input_tokens:
@@ -506,7 +537,9 @@ def _patch_run(runner: Any) -> None:
         new_message = kwargs.get("new_message")
         if new_message:
             if hasattr(new_message, "parts"):
-                text_parts = [getattr(p, "text", "") for p in new_message.parts if getattr(p, "text", None)]
+                text_parts = [
+                    getattr(p, "text", "") for p in new_message.parts if getattr(p, "text", None)
+                ]
                 if text_parts:
                     attrs["input.value"] = "\n".join(text_parts)
             else:
@@ -564,7 +597,9 @@ def _patch_run_async(runner: Any) -> None:
         new_message = kwargs.get("new_message")
         if new_message:
             if hasattr(new_message, "parts"):
-                text_parts = [getattr(p, "text", "") for p in new_message.parts if getattr(p, "text", None)]
+                text_parts = [
+                    getattr(p, "text", "") for p in new_message.parts if getattr(p, "text", None)
+                ]
                 if text_parts:
                     attrs["input.value"] = "\n".join(text_parts)
             else:

--- a/neatlogs/google_genai.py
+++ b/neatlogs/google_genai.py
@@ -104,6 +104,7 @@ def _patch_models(models: Any) -> None:
     models.generate_content = patched_generate_content
 
     if orig_stream:
+
         def patched_generate_content_stream(*args, **kwargs):
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
@@ -252,7 +253,9 @@ def _text_from_parts(parts: Any) -> str:
             elif fr is not None:
                 name = getattr(fr, "name", "") or ""
                 resp = getattr(fr, "response", None)
-                text_parts.append(serialize({"function_response": {"name": name, "response": resp}}))
+                text_parts.append(
+                    serialize({"function_response": {"name": name, "response": resp}})
+                )
     return "\n".join(text_parts)
 
 
@@ -287,13 +290,19 @@ def _set_input_attributes(span: Any, contents: Any, kwargs: dict) -> None:
     # System instruction
     idx = 0
     if config:
-        system_instruction = getattr(config, "system_instruction", None) if not isinstance(config, dict) else config.get("system_instruction")
+        system_instruction = (
+            getattr(config, "system_instruction", None)
+            if not isinstance(config, dict)
+            else config.get("system_instruction")
+        )
         if system_instruction:
             span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", "system")
             if isinstance(system_instruction, str):
                 span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", system_instruction)
             else:
-                span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", serialize(system_instruction))
+                span.set_attribute(
+                    f"neatlogs.llm.input_messages.{idx}.content", serialize(system_instruction)
+                )
             idx += 1
 
     # Contents — a single string, or a list of turns (str / dict / typed Content).
@@ -315,7 +324,9 @@ def _set_input_attributes(span: Any, contents: Any, kwargs: dict) -> None:
     # Tools
     tools = None
     if config:
-        tools = getattr(config, "tools", None) if not isinstance(config, dict) else config.get("tools")
+        tools = (
+            getattr(config, "tools", None) if not isinstance(config, dict) else config.get("tools")
+        )
     if tools:
         for i, tool in enumerate(tools):
             if isinstance(tool, dict):
@@ -323,13 +334,21 @@ def _set_input_attributes(span: Any, contents: Any, kwargs: dict) -> None:
                 for j, fn in enumerate(fn_decls):
                     span.set_attribute(f"neatlogs.llm.tools.{i + j}.name", fn.get("name", ""))
                     if fn.get("description"):
-                        span.set_attribute(f"neatlogs.llm.tools.{i + j}.description", fn["description"])
+                        span.set_attribute(
+                            f"neatlogs.llm.tools.{i + j}.description", fn["description"]
+                        )
                     if fn.get("parameters"):
-                        span.set_attribute(f"neatlogs.llm.tools.{i + j}.input_schema", serialize(fn["parameters"]))
+                        span.set_attribute(
+                            f"neatlogs.llm.tools.{i + j}.input_schema", serialize(fn["parameters"])
+                        )
 
     # Invocation parameters from config
     if config:
-        cfg = config if isinstance(config, dict) else config.__dict__ if hasattr(config, "__dict__") else {}
+        cfg = (
+            config
+            if isinstance(config, dict)
+            else config.__dict__ if hasattr(config, "__dict__") else {}
+        )
         if isinstance(cfg, dict):
             for param in ("temperature", "top_p", "top_k", "max_output_tokens"):
                 val = cfg.get(param)
@@ -356,9 +375,14 @@ def _finalize_response(span: Any, response: Any, duration_ms: float) -> None:
                 span.set_attribute("neatlogs.llm.output_messages.0.thinking", part.text)
             elif getattr(part, "function_call", None):
                 fc = part.function_call
-                span.set_attribute(f"neatlogs.llm.tool_calls.{tool_call_idx}.name", getattr(fc, "name", ""))
+                span.set_attribute(
+                    f"neatlogs.llm.tool_calls.{tool_call_idx}.name", getattr(fc, "name", "")
+                )
                 args = getattr(fc, "args", None)
-                span.set_attribute(f"neatlogs.llm.tool_calls.{tool_call_idx}.arguments", serialize(args) if args else "{}")
+                span.set_attribute(
+                    f"neatlogs.llm.tool_calls.{tool_call_idx}.arguments",
+                    serialize(args) if args else "{}",
+                )
                 tool_call_idx += 1
 
         finish_reason = getattr(candidate, "finish_reason", None)
@@ -401,7 +425,9 @@ def _set_usage_attributes(span: Any, usage: Any) -> None:
         span.set_attribute("neatlogs.llm.token_count.reasoning", reasoning_tokens)
 
 
-def _finalize_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]) -> None:
+def _finalize_stream(
+    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+) -> None:
     """Finalize a streaming response span from accumulated chunks."""
     text_parts: List[str] = []
     thinking_parts: List[str] = []
@@ -423,10 +449,12 @@ def _finalize_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: 
                     thinking_parts.append(part.text)
                 elif getattr(part, "function_call", None):
                     fc = part.function_call
-                    tool_calls_acc.append({
-                        "name": getattr(fc, "name", ""),
-                        "arguments": serialize(getattr(fc, "args", None) or {}),
-                    })
+                    tool_calls_acc.append(
+                        {
+                            "name": getattr(fc, "name", ""),
+                            "arguments": serialize(getattr(fc, "args", None) or {}),
+                        }
+                    )
 
             fr = getattr(candidate, "finish_reason", None)
             if fr:
@@ -480,10 +508,15 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
         orig = models.embed_content
 
         def _embed_attrs(kwargs):
-            attrs = {"neatlogs.span.kind": "embedding", "neatlogs.embedding.model_name": str(kwargs.get("model", ""))}
+            attrs = {
+                "neatlogs.span.kind": "embedding",
+                "neatlogs.embedding.model_name": str(kwargs.get("model", "")),
+            }
             contents = kwargs.get("contents")
             if contents is not None:
-                attrs["neatlogs.embedding.text"] = (contents if isinstance(contents, str) else serialize(contents))[:10000]
+                attrs["neatlogs.embedding.text"] = (
+                    contents if isinstance(contents, str) else serialize(contents)
+                )[:10000]
             return attrs
 
         def _embed_finalize(span, resp):
@@ -500,25 +533,37 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             span.end()
 
         if is_async:
+
             async def patched_embed(*args, **kwargs):
                 if is_suppressed():
                     return await orig(*args, **kwargs)
-                span = get_provider_tracer().start_span(name="google_genai.models.embed_content", attributes=_embed_attrs(kwargs))
+                span = get_provider_tracer().start_span(
+                    name="google_genai.models.embed_content", attributes=_embed_attrs(kwargs)
+                )
                 try:
                     resp = await orig(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
-                _embed_finalize(span, resp); return resp
+                    _err(span, e)
+                    raise
+                _embed_finalize(span, resp)
+                return resp
+
         else:
+
             def patched_embed(*args, **kwargs):
                 if is_suppressed():
                     return orig(*args, **kwargs)
-                span = get_provider_tracer().start_span(name="google_genai.models.embed_content", attributes=_embed_attrs(kwargs))
+                span = get_provider_tracer().start_span(
+                    name="google_genai.models.embed_content", attributes=_embed_attrs(kwargs)
+                )
                 try:
                     resp = orig(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
-                _embed_finalize(span, resp); return resp
+                    _err(span, e)
+                    raise
+                _embed_finalize(span, resp)
+                return resp
+
         models.embed_content = patched_embed
         models._neatlogs_embed_patched = True
 
@@ -527,8 +572,12 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
         orig_ct = models.count_tokens
 
         def _ct_attrs(kwargs):
-            return {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": "google_genai",
-                    "neatlogs.llm.task": "count_tokens", "neatlogs.llm.model_name": str(kwargs.get("model", ""))}
+            return {
+                "neatlogs.span.kind": "llm",
+                "neatlogs.llm.provider": "google_genai",
+                "neatlogs.llm.task": "count_tokens",
+                "neatlogs.llm.model_name": str(kwargs.get("model", "")),
+            }
 
         def _ct_finalize(span, resp):
             total = getattr(resp, "total_tokens", None)
@@ -538,25 +587,37 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             span.end()
 
         if is_async:
+
             async def patched_ct(*args, **kwargs):
                 if is_suppressed():
                     return await orig_ct(*args, **kwargs)
-                span = get_provider_tracer().start_span(name="google_genai.models.count_tokens", attributes=_ct_attrs(kwargs))
+                span = get_provider_tracer().start_span(
+                    name="google_genai.models.count_tokens", attributes=_ct_attrs(kwargs)
+                )
                 try:
                     resp = await orig_ct(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
-                _ct_finalize(span, resp); return resp
+                    _err(span, e)
+                    raise
+                _ct_finalize(span, resp)
+                return resp
+
         else:
+
             def patched_ct(*args, **kwargs):
                 if is_suppressed():
                     return orig_ct(*args, **kwargs)
-                span = get_provider_tracer().start_span(name="google_genai.models.count_tokens", attributes=_ct_attrs(kwargs))
+                span = get_provider_tracer().start_span(
+                    name="google_genai.models.count_tokens", attributes=_ct_attrs(kwargs)
+                )
                 try:
                     resp = orig_ct(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
-                _ct_finalize(span, resp); return resp
+                    _err(span, e)
+                    raise
+                _ct_finalize(span, resp)
+                return resp
+
         models.count_tokens = patched_ct
         models._neatlogs_count_patched = True
 
@@ -568,12 +629,16 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
 
 def _patch_chat_classes() -> None:
     try:
-        from google.genai.chats import Chat, AsyncChat
+        from google.genai.chats import AsyncChat, Chat
     except Exception:
         return
 
     # Sync Chat.send_message
-    if hasattr(Chat, "send_message") and "send_message" in Chat.__dict__ and not Chat.__dict__.get("_neatlogs_patched", False):
+    if (
+        hasattr(Chat, "send_message")
+        and "send_message" in Chat.__dict__
+        and not Chat.__dict__.get("_neatlogs_patched", False)
+    ):
         orig_send = Chat.send_message
 
         def patched_send(self, message, *args, **kwargs):
@@ -584,7 +649,8 @@ def _patch_chat_classes() -> None:
             try:
                 resp = orig_send(self, message, *args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
             return resp
 
@@ -605,7 +671,11 @@ def _patch_chat_classes() -> None:
         Chat._neatlogs_patched = True
 
     # Async Chat
-    if hasattr(AsyncChat, "send_message") and "send_message" in AsyncChat.__dict__ and not AsyncChat.__dict__.get("_neatlogs_patched", False):
+    if (
+        hasattr(AsyncChat, "send_message")
+        and "send_message" in AsyncChat.__dict__
+        and not AsyncChat.__dict__.get("_neatlogs_patched", False)
+    ):
         orig_asend = AsyncChat.send_message
 
         async def patched_asend(self, message, *args, **kwargs):
@@ -616,7 +686,8 @@ def _patch_chat_classes() -> None:
             try:
                 resp = await orig_asend(self, message, *args, **kwargs)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
             return resp
 
@@ -636,7 +707,8 @@ def _patch_chat_classes() -> None:
                 try:
                     stream = await orig_asend_stream(self, message, *args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
+                    _err(span, e)
+                    raise
                 return AsyncStreamWrapper(stream, span, _finalize_stream)
 
             AsyncChat.send_message_stream = patched_asend_stream
@@ -658,7 +730,10 @@ def _start_chat_span(chat: Any, message: Any, stream: bool) -> Any:
     )
     if message is not None:
         span.set_attribute("neatlogs.llm.input_messages.0.role", "user")
-        span.set_attribute("neatlogs.llm.input_messages.0.content", (message if isinstance(message, str) else serialize(message))[:10000])
+        span.set_attribute(
+            "neatlogs.llm.input_messages.0.content",
+            (message if isinstance(message, str) else serialize(message))[:10000],
+        )
     return span
 
 
@@ -672,6 +747,7 @@ def _err(span: Any, e: Exception) -> None:
 # Import-replacement: `from neatlogs.google_genai import genai`
 # Patches Client.__init__ so every client is auto-wrapped.
 # ---------------------------------------------------------------------------
+
 
 def _patch_google_genai_module() -> None:
     global _PATCHED, _ORIG_INIT

--- a/neatlogs/hermes.py
+++ b/neatlogs/hermes.py
@@ -177,9 +177,11 @@ def _patch_tool_dispatch() -> None:
             span.set_attribute("input.value", serialize(args)[:10000])
         except Exception:
             pass
-        for key, attr in (("session_id", "neatlogs.conversation.id"),
-                          ("tool_call_id", "neatlogs.tool_call.id"),
-                          ("turn_id", "neatlogs.turn.id")):
+        for key, attr in (
+            ("session_id", "neatlogs.conversation.id"),
+            ("tool_call_id", "neatlogs.tool_call.id"),
+            ("turn_id", "neatlogs.turn.id"),
+        ):
             val = kwargs.get(key)
             if val:
                 span.set_attribute(attr, str(val))

--- a/neatlogs/hermes_plugin.py
+++ b/neatlogs/hermes_plugin.py
@@ -60,6 +60,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
 from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
 from opentelemetry.trace import (
     NonRecordingSpan,
     SpanContext,
@@ -67,8 +68,6 @@ from opentelemetry.trace import (
     TraceFlags,
     set_span_in_context,
 )
-
-from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
 
 from ._wrap_utils import configure, get_tracer, serialize
 from .core.logger import get_logger
@@ -89,10 +88,11 @@ class _FixedIdGen(RandomIdGenerator):
     def generate_trace_id(self) -> int:
         return self._trace_id
 
+
 logger = get_logger()
 
 _PROVIDER = "hermes"
-_MAX_TURN_STATE = 256       # bound the leak from turns that never finalize cleanly
+_MAX_TURN_STATE = 256  # bound the leak from turns that never finalize cleanly
 
 
 # ---------------------------------------------------------------------------
@@ -111,11 +111,11 @@ class _TurnState:
     children currently open under it."""
 
     span: Any
-    turn_key: str                     # deterministic-id key for this turn's trace
+    turn_key: str  # deterministic-id key for this turn's trace
     session_id: Optional[str] = None  # owning session — lets cleanup find turns
-    model: Any = None                 # remembered for the root at close
-    input_value: Any = None           # user message, stamped on the root at close
-    llm_spans: Dict[str, Any] = field(default_factory=dict)   # keyed by api_request_id
+    model: Any = None  # remembered for the root at close
+    input_value: Any = None  # user message, stamped on the root at close
+    llm_spans: Dict[str, Any] = field(default_factory=dict)  # keyed by api_request_id
     tool_spans: Dict[str, Any] = field(default_factory=dict)  # keyed by tool span key
     last_updated_at: float = field(default_factory=time.time)
 
@@ -134,8 +134,8 @@ _OPEN_TOOL_SPANS: Dict[str, Any] = {}
 # Delegated-child AGENT spans. A subagent parents under the spawning TURN; the
 # child's own turns (which fire with the CHILD's session_id) parent under the
 # subagent span via _SUBAGENT_BY_SESSION.
-_SUBAGENT_STATE: Dict[str, Any] = {}        # subagent key -> subagent AGENT span
-_SUBAGENT_BY_SESSION: Dict[str, Any] = {}   # child_session_id -> subagent AGENT span
+_SUBAGENT_STATE: Dict[str, Any] = {}  # subagent key -> subagent AGENT span
+_SUBAGENT_BY_SESSION: Dict[str, Any] = {}  # child_session_id -> subagent AGENT span
 # Dangerous-command approval GUARDRAIL spans, keyed by approval key, open between
 # pre_approval_request and post_approval_response.
 _APPROVAL_SPANS: Dict[str, Any] = {}
@@ -178,10 +178,7 @@ def _ensure_configured() -> bool:
 
     # Resolve the endpoint to the SAME canonical default as neatlogs.init()
     # (ingest.neatlogs.com) and honor NEATLOGS_ENDPOINT when set.
-    endpoint = (
-        os.environ.get("NEATLOGS_ENDPOINT", "").strip()
-        or "https://ingest.neatlogs.com"
-    )
+    endpoint = os.environ.get("NEATLOGS_ENDPOINT", "").strip() or "https://ingest.neatlogs.com"
     # workflow_name is an init()/configure() argument, not an env var, so we pass
     # our default directly. configure() only sets wrapper-mode defaults; if
     # neatlogs.init() already ran in this process (mixed library+plugin use),
@@ -257,7 +254,8 @@ def _open_session_db():
     live Hermes writer). Returns None if Hermes isn't importable or the DB is
     absent — callers then fall back to the raw session id."""
     try:
-        from hermes_state import SessionDB, DEFAULT_DB_PATH
+        from hermes_state import DEFAULT_DB_PATH, SessionDB
+
         if not DEFAULT_DB_PATH.exists():
             return None
         return SessionDB(read_only=True)
@@ -337,8 +335,7 @@ def _resolve_session_root(session_id: Any) -> Optional[str]:
     return root
 
 
-def _start_root_span(key: str, name: str, kind: str, *, session_id: Any = None,
-                     model: Any = None):
+def _start_root_span(key: str, name: str, kind: str, *, session_id: Any = None, model: Any = None):
     """Start a span forced to ``key``'s deterministic trace_id + root span_id, so
     it IS the root of that trace. Used for the WORKFLOW turn root and standalone
     kanban task traces. Caller ends it (turn roots stay open across the turn;
@@ -409,8 +406,9 @@ def _emit_completion_marker(key: Any) -> None:
 # ---------------------------------------------------------------------------
 # Turn  (WORKFLOW root) — one per run_conversation / user message = one TRACE
 # ---------------------------------------------------------------------------
-def _ensure_turn(key: str, *, session_id: Any = None, model: Any = None,
-                 user_message: Any = None) -> Optional[_TurnState]:
+def _ensure_turn(
+    key: str, *, session_id: Any = None, model: Any = None, user_message: Any = None
+) -> Optional[_TurnState]:
     """Get-or-create the WORKFLOW turn span that ROOTS this turn's trace. Its
     trace_id + span_id are the deterministic ids for ``key`` (so children and the
     completion marker line up), and it carries ``neatlogs.session.id`` so the
@@ -451,8 +449,9 @@ def _ensure_turn(key: str, *, session_id: Any = None, model: Any = None,
         else:
             # Top-level turn: the WORKFLOW root of its own per-turn trace. Left
             # OPEN across the turn; input/output stamped and ended at turn close.
-            span = _start_root_span(key, "hermes.turn", "workflow",
-                                    session_id=session_id, model=model)
+            span = _start_root_span(
+                key, "hermes.turn", "workflow", session_id=session_id, model=model
+            )
             # A kanban worker (`hermes chat -q "work kanban task <id>"`) is a
             # subprocess dedicated to ONE task, pinned via env. Tag its turn roots
             # with the task identity so they're attributable to the task — the
@@ -497,12 +496,20 @@ def on_session_start(**kwargs: Any) -> None:
 def on_pre_llm_call(**kwargs: Any) -> None:
     """Turn begins — open the WORKFLOW turn trace and remember the user input."""
     try:
-        key = _turn_key(kwargs.get("turn_id"), kwargs.get("api_request_id"),
-                        kwargs.get("session_id"), kwargs.get("task_id"))
+        key = _turn_key(
+            kwargs.get("turn_id"),
+            kwargs.get("api_request_id"),
+            kwargs.get("session_id"),
+            kwargs.get("task_id"),
+        )
         if not key:
             return
-        state = _ensure_turn(key, session_id=kwargs.get("session_id"),
-                             model=kwargs.get("model"), user_message=kwargs.get("user_message"))
+        state = _ensure_turn(
+            key,
+            session_id=kwargs.get("session_id"),
+            model=kwargs.get("model"),
+            user_message=kwargs.get("user_message"),
+        )
         # If the API layer opened the turn first (no user_message then), backfill
         # the input/model now so the root carries them at close.
         if state is not None:
@@ -519,8 +526,12 @@ def on_post_llm_call(**kwargs: Any) -> None:
     """Turn ends — stamp input+output on the WORKFLOW root, close it, and finalize
     this turn's trace with a completion marker."""
     try:
-        key = _turn_key(kwargs.get("turn_id"), kwargs.get("api_request_id"),
-                        kwargs.get("session_id"), kwargs.get("task_id"))
+        key = _turn_key(
+            kwargs.get("turn_id"),
+            kwargs.get("api_request_id"),
+            kwargs.get("session_id"),
+            kwargs.get("task_id"),
+        )
         if not key:
             return
         with _STATE_LOCK:
@@ -561,8 +572,12 @@ def _finalize_turn_trace(state: _TurnState) -> None:
 def on_pre_api_request(**kwargs: Any) -> None:
     """Provider attempt begins — open an LLM child under the turn span."""
     try:
-        key = _turn_key(kwargs.get("turn_id"), kwargs.get("api_request_id"),
-                        kwargs.get("session_id"), kwargs.get("task_id"))
+        key = _turn_key(
+            kwargs.get("turn_id"),
+            kwargs.get("api_request_id"),
+            kwargs.get("session_id"),
+            kwargs.get("task_id"),
+        )
         if not key:
             return
         # A turn may begin at the API layer (legacy paths skip pre_llm_call).
@@ -606,8 +621,12 @@ def on_api_request_error(**kwargs: Any) -> None:
 
 def _finish_api_span(kwargs: Dict[str, Any], *, error: bool) -> None:
     try:
-        key = _turn_key(kwargs.get("turn_id"), kwargs.get("api_request_id"),
-                        kwargs.get("session_id"), kwargs.get("task_id"))
+        key = _turn_key(
+            kwargs.get("turn_id"),
+            kwargs.get("api_request_id"),
+            kwargs.get("session_id"),
+            kwargs.get("task_id"),
+        )
         if not key:
             return
         with _STATE_LOCK:
@@ -743,8 +762,12 @@ def _resolve_open_turn(kwargs: Dict[str, Any]) -> Optional[_TurnState]:
     session's most-recent open turn, then (single live turn) that one. Returns
     None if truly no turn is open — the caller then skips rather than orphaning."""
     with _STATE_LOCK:
-        key = _turn_key(kwargs.get("turn_id"), kwargs.get("api_request_id"),
-                        kwargs.get("session_id"), kwargs.get("task_id"))
+        key = _turn_key(
+            kwargs.get("turn_id"),
+            kwargs.get("api_request_id"),
+            kwargs.get("session_id"),
+            kwargs.get("task_id"),
+        )
         state = _TURN_STATE.get(key) if key else None
         if state is not None:
             return state

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -106,6 +106,8 @@ def _foreign_llm_instrumentor_installed():
             # find_spec can raise for namespace-package edge cases; treat as absent.
             continue
     return None
+
+
 _meter_provider = None
 _log_provider = None
 _span_processor = None
@@ -451,9 +453,7 @@ def init(
         # is merely INSTALLED (importable), we pre-emptively keep a private provider
         # and leave the global slot free for the co-tenant to own — no isolate=True
         # required from the customer.
-        _foreign_installed = (
-            None if isolate is False else _foreign_llm_instrumentor_installed()
-        )
+        _foreign_installed = None if isolate is False else _foreign_llm_instrumentor_installed()
         if isolate is True or _foreign_installed is not None:
             _isolated_provider = True
             if debug:

--- a/neatlogs/instrumentation/manager.py
+++ b/neatlogs/instrumentation/manager.py
@@ -102,9 +102,7 @@ class InstrumentationManager:
         try:
             from openinference.instrumentation.mcp import MCPInstrumentor
 
-            MCPInstrumentor().instrument(
-                tracer_provider=provider_for_openinference(self.provider)
-            )
+            MCPInstrumentor().instrument(tracer_provider=provider_for_openinference(self.provider))
             self.instrumented.add("mcp")
             if self.debug:
                 logger.info("✅ MCP (OpenInference)")
@@ -499,6 +497,7 @@ class InstrumentationManager:
                 if isinstance(value, str):
                     return value
                 import json as _json
+
                 return _json.dumps(value, default=str)[:4000]
             except Exception:
                 return str(value)[:4000]
@@ -512,6 +511,7 @@ class InstrumentationManager:
         orig_output = getattr(_gr, "run_single_output_guardrail", None)
 
         if orig_input is not None:
+
             @wraps(orig_input)
             async def _wrapped_input(agent, guardrail, input, context, *a, **k):
                 token = _gc.GUARDRAIL_INPUT_VAR.set(_to_text(input))
@@ -519,9 +519,11 @@ class InstrumentationManager:
                     return await orig_input(agent, guardrail, input, context, *a, **k)
                 finally:
                     _gc.GUARDRAIL_INPUT_VAR.reset(token)
+
             _gr.run_single_input_guardrail = _wrapped_input
 
         if orig_output is not None:
+
             @wraps(orig_output)
             async def _wrapped_output(guardrail, agent, agent_output, context, *a, **k):
                 token = _gc.GUARDRAIL_INPUT_VAR.set(_to_text(agent_output))
@@ -529,6 +531,7 @@ class InstrumentationManager:
                     return await orig_output(guardrail, agent, agent_output, context, *a, **k)
                 finally:
                     _gc.GUARDRAIL_INPUT_VAR.reset(token)
+
             _gr.run_single_output_guardrail = _wrapped_output
 
         _gr._NEATLOGS_PATCHED_GUARDRAIL_INPUT = True
@@ -551,10 +554,10 @@ class InstrumentationManager:
         This stays correct even if OI renames its internal span bookkeeping.
         """
         try:
+            from agents.tracing.span_data import GuardrailSpanData
             from openinference.instrumentation.openai_agents._processor import (
                 OpenInferenceTracingProcessor,
             )
-            from agents.tracing.span_data import GuardrailSpanData
         except Exception:
             return
 
@@ -576,6 +579,7 @@ class InstrumentationManager:
                 if isinstance(getattr(span, "span_data", None), GuardrailSpanData):
                     # OI created its otel span during orig_start; grab the active one.
                     from opentelemetry import trace as _trace
+
                     current = _trace.get_current_span()
                     if current is not None:
                         guardrail_spans[span.span_id] = current
@@ -590,12 +594,15 @@ class InstrumentationManager:
                     if otel_span is not None:
                         otel_span.set_attribute("guardrail.name", data.name)
                         otel_span.set_attribute("guardrail.triggered", bool(data.triggered))
-                        otel_span.set_attribute("neatlogs.guardrail.passed", not bool(data.triggered))
+                        otel_span.set_attribute(
+                            "neatlogs.guardrail.passed", not bool(data.triggered)
+                        )
                         otel_span.set_attribute(
                             "neatlogs.guardrail.output",
                             "tripwire triggered (blocked)" if data.triggered else "passed",
                         )
                         from neatlogs.instrumentation._guardrail_ctx import GUARDRAIL_INPUT_VAR
+
                         _gr_input = GUARDRAIL_INPUT_VAR.get()
                         if _gr_input:
                             otel_span.set_attribute("neatlogs.guardrail.input", _gr_input)
@@ -914,8 +921,14 @@ class InstrumentationManager:
             def _run_type_kind(run):
                 rt = str(getattr(run, "run_type", "") or "").lower()
                 # OpenInference run_type -> neatlogs kind (only the mapping we gate on)
-                return {"llm": "llm", "tool": "tool", "retriever": "retriever",
-                        "embedding": "embedding", "chain": "chain", "agent": "agent"}.get(rt, rt)
+                return {
+                    "llm": "llm",
+                    "tool": "tool",
+                    "retriever": "retriever",
+                    "embedding": "embedding",
+                    "chain": "chain",
+                    "agent": "agent",
+                }.get(rt, rt)
 
             def _maybe_open_auto_root(self, run):
                 if getattr(run, "parent_run_id", None):
@@ -1155,6 +1168,7 @@ class InstrumentationManager:
         """
         try:
             from crewai.agents.crew_agent_executor import CrewAgentExecutor
+
             from .._wrap_utils import neatlogs_span
 
             original = CrewAgentExecutor._handle_native_tool_calls

--- a/neatlogs/langchain.py
+++ b/neatlogs/langchain.py
@@ -91,7 +91,9 @@ def _set_invocation_params(span: Any, kwargs: Dict[str, Any]) -> None:
 
     stop = invocation_params.get("stop")
     if stop is not None:
-        span.set_attribute("neatlogs.llm.stop_sequences", serialize(stop) if isinstance(stop, list) else str(stop))
+        span.set_attribute(
+            "neatlogs.llm.stop_sequences", serialize(stop) if isinstance(stop, list) else str(stop)
+        )
 
     if invocation_params.get("stream") or invocation_params.get("streaming"):
         span.set_attribute("neatlogs.llm.is_streaming", True)
@@ -327,7 +329,9 @@ class NeatlogsCallbackHandler(AsyncCallbackHandler, BaseCallbackHandler):
                 if isinstance(content, str):
                     span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", content)
                 else:
-                    span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", serialize(content))
+                    span.set_attribute(
+                        f"neatlogs.llm.input_messages.{idx}.content", serialize(content)
+                    )
                 idx += 1
 
         self._spans[run_id] = span
@@ -419,13 +423,21 @@ class NeatlogsCallbackHandler(AsyncCallbackHandler, BaseCallbackHandler):
                         content = getattr(message, "content", "")
                         if content and not text:
                             span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
-                            span.set_attribute("neatlogs.llm.output_messages.0.content", content if isinstance(content, str) else serialize(content))
+                            span.set_attribute(
+                                "neatlogs.llm.output_messages.0.content",
+                                content if isinstance(content, str) else serialize(content),
+                            )
 
                         tool_calls = getattr(message, "tool_calls", None)
                         if tool_calls:
                             for j, tc in enumerate(tool_calls):
-                                span.set_attribute(f"neatlogs.llm.tool_calls.{j}.name", tc.get("name", ""))
-                                span.set_attribute(f"neatlogs.llm.tool_calls.{j}.arguments", serialize(tc.get("args", {})))
+                                span.set_attribute(
+                                    f"neatlogs.llm.tool_calls.{j}.name", tc.get("name", "")
+                                )
+                                span.set_attribute(
+                                    f"neatlogs.llm.tool_calls.{j}.arguments",
+                                    serialize(tc.get("args", {})),
+                                )
                                 if tc.get("id"):
                                     span.set_attribute(f"neatlogs.llm.tool_calls.{j}.id", tc["id"])
 
@@ -438,16 +450,24 @@ class NeatlogsCallbackHandler(AsyncCallbackHandler, BaseCallbackHandler):
                                     f"{tc.get('name', '')}({serialize(tc.get('args', {}))})"
                                     for tc in tool_calls
                                 )
-                                span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
-                                span.set_attribute("neatlogs.llm.output_messages.0.content", rendered)
+                                span.set_attribute(
+                                    "neatlogs.llm.output_messages.0.role", "assistant"
+                                )
+                                span.set_attribute(
+                                    "neatlogs.llm.output_messages.0.content", rendered
+                                )
 
                         thinking_blocks = getattr(message, "thinking_blocks", None)
                         if thinking_blocks:
                             thinking_text = "".join(
-                                block.get("thinking", "") for block in thinking_blocks if isinstance(block, dict)
+                                block.get("thinking", "")
+                                for block in thinking_blocks
+                                if isinstance(block, dict)
                             )
                             if thinking_text:
-                                span.set_attribute("neatlogs.llm.output_messages.0.thinking", thinking_text)
+                                span.set_attribute(
+                                    "neatlogs.llm.output_messages.0.thinking", thinking_text
+                                )
 
                     gen_info = getattr(gen, "generation_info", None) or {}
                     finish_reason = gen_info.get("finish_reason")
@@ -461,15 +481,24 @@ class NeatlogsCallbackHandler(AsyncCallbackHandler, BaseCallbackHandler):
             if "prompt_tokens" in token_usage:
                 span.set_attribute("neatlogs.llm.token_count.prompt", token_usage["prompt_tokens"])
             if "completion_tokens" in token_usage:
-                span.set_attribute("neatlogs.llm.token_count.completion", token_usage["completion_tokens"])
+                span.set_attribute(
+                    "neatlogs.llm.token_count.completion", token_usage["completion_tokens"]
+                )
             if "total_tokens" in token_usage:
                 span.set_attribute("neatlogs.llm.token_count.total", token_usage["total_tokens"])
             if "cache_read_input_tokens" in token_usage:
-                span.set_attribute("neatlogs.llm.token_count.cache_read", token_usage["cache_read_input_tokens"])
+                span.set_attribute(
+                    "neatlogs.llm.token_count.cache_read", token_usage["cache_read_input_tokens"]
+                )
             if "cache_creation_input_tokens" in token_usage:
-                span.set_attribute("neatlogs.llm.token_count.cache_write", token_usage["cache_creation_input_tokens"])
+                span.set_attribute(
+                    "neatlogs.llm.token_count.cache_write",
+                    token_usage["cache_creation_input_tokens"],
+                )
             if "reasoning_tokens" in token_usage:
-                span.set_attribute("neatlogs.llm.token_count.reasoning", token_usage["reasoning_tokens"])
+                span.set_attribute(
+                    "neatlogs.llm.token_count.reasoning", token_usage["reasoning_tokens"]
+                )
 
         model_name = llm_output.get("model_name") or llm_output.get("model")
         if model_name:
@@ -624,7 +653,9 @@ class NeatlogsCallbackHandler(AsyncCallbackHandler, BaseCallbackHandler):
         **kwargs: Any,
     ) -> None:
         tracer = get_tracer()
-        name = (serialized or {}).get("name") or ((serialized or {}).get("id", [""])[-1] if (serialized or {}).get("id") else "retriever")
+        name = (serialized or {}).get("name") or (
+            (serialized or {}).get("id", [""])[-1] if (serialized or {}).get("id") else "retriever"
+        )
         ctx = self._start_ctx(parent_run_id, run_id, "retriever")
 
         span = tracer.start_span(
@@ -659,7 +690,9 @@ class NeatlogsCallbackHandler(AsyncCallbackHandler, BaseCallbackHandler):
             for i, doc in enumerate(documents[:10]):
                 content = getattr(doc, "page_content", None)
                 if content:
-                    span.set_attribute(f"neatlogs.retrieval.documents.{i}.content", str(content)[:2000])
+                    span.set_attribute(
+                        f"neatlogs.retrieval.documents.{i}.content", str(content)[:2000]
+                    )
         span.set_status(StatusCode.OK)
         span.end()
         self._end_auto_root(run_id)
@@ -691,7 +724,9 @@ class NeatlogsCallbackHandler(AsyncCallbackHandler, BaseCallbackHandler):
         parent_run_id: Optional[UUID] = None,
         **kwargs: Any,
     ) -> None:
-        span = self._spans.get(run_id) or (self._spans.get(parent_run_id) if parent_run_id else None)
+        span = self._spans.get(run_id) or (
+            self._spans.get(parent_run_id) if parent_run_id else None
+        )
         if not span:
             return
         tool = getattr(action, "tool", None)
@@ -712,7 +747,9 @@ class NeatlogsCallbackHandler(AsyncCallbackHandler, BaseCallbackHandler):
         parent_run_id: Optional[UUID] = None,
         **kwargs: Any,
     ) -> None:
-        span = self._spans.get(run_id) or (self._spans.get(parent_run_id) if parent_run_id else None)
+        span = self._spans.get(run_id) or (
+            self._spans.get(parent_run_id) if parent_run_id else None
+        )
         if not span:
             return
         return_values = getattr(finish, "return_values", None)
@@ -732,7 +769,9 @@ class NeatlogsCallbackHandler(AsyncCallbackHandler, BaseCallbackHandler):
     ) -> None:
         tracer = get_tracer()
         serialized = serialized or {}
-        name = serialized.get("name", "") or (serialized.get("id", [""])[-1] if serialized.get("id") else "tool")
+        name = serialized.get("name", "") or (
+            serialized.get("id", [""])[-1] if serialized.get("id") else "tool"
+        )
 
         ctx = self._start_ctx(parent_run_id, run_id, "tool")
 

--- a/neatlogs/openai.py
+++ b/neatlogs/openai.py
@@ -144,7 +144,9 @@ def _patch_completions(completions: Any) -> None:
             else:
                 span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", serialize(content))
             if msg.get("tool_call_id"):
-                span.set_attribute(f"neatlogs.llm.input_messages.{i}.tool_call_id", msg["tool_call_id"])
+                span.set_attribute(
+                    f"neatlogs.llm.input_messages.{i}.tool_call_id", msg["tool_call_id"]
+                )
 
         # Tools
         tools = kwargs.get("tools")
@@ -155,10 +157,18 @@ def _patch_completions(completions: Any) -> None:
                 if fn.get("description"):
                     span.set_attribute(f"neatlogs.llm.tools.{i}.description", fn["description"])
                 if fn.get("parameters"):
-                    span.set_attribute(f"neatlogs.llm.tools.{i}.input_schema", serialize(fn["parameters"]))
+                    span.set_attribute(
+                        f"neatlogs.llm.tools.{i}.input_schema", serialize(fn["parameters"])
+                    )
 
         # Invocation parameters
-        for param in ("temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty"):
+        for param in (
+            "temperature",
+            "top_p",
+            "max_tokens",
+            "frequency_penalty",
+            "presence_penalty",
+        ):
             if param in kwargs and kwargs[param] is not None:
                 span.set_attribute(f"neatlogs.llm.{param}", kwargs[param])
 
@@ -235,9 +245,17 @@ def _patch_async_completions(completions: Any) -> None:
                 if fn.get("description"):
                     span.set_attribute(f"neatlogs.llm.tools.{i}.description", fn["description"])
                 if fn.get("parameters"):
-                    span.set_attribute(f"neatlogs.llm.tools.{i}.input_schema", serialize(fn["parameters"]))
+                    span.set_attribute(
+                        f"neatlogs.llm.tools.{i}.input_schema", serialize(fn["parameters"])
+                    )
 
-        for param in ("temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty"):
+        for param in (
+            "temperature",
+            "top_p",
+            "max_tokens",
+            "frequency_penalty",
+            "presence_penalty",
+        ):
             if param in kwargs and kwargs[param] is not None:
                 span.set_attribute(f"neatlogs.llm.{param}", kwargs[param])
 
@@ -373,7 +391,9 @@ def _finalize_response(span: Any, response: Any, duration_ms: float) -> None:
     span.end()
 
 
-def _finalize_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]) -> None:
+def _finalize_stream(
+    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+) -> None:
     """Finalize a streaming response span from accumulated chunks."""
     text_parts: List[str] = []
     tool_calls_acc: dict = {}
@@ -493,7 +513,9 @@ def _finalize_responses_response(span: Any, response: Any, duration_ms: float) -
 # ---------------------------------------------------------------------------
 
 
-def _patch_method(resource: Any, method_name: str, flag: str, start_attrs, finalize, is_async: bool) -> None:
+def _patch_method(
+    resource: Any, method_name: str, flag: str, start_attrs, finalize, is_async: bool
+) -> None:
     """
     Wrap resource.<method_name> with a span. start_attrs(kwargs)->dict builds the
     initial attributes; finalize(span, response) records the result. Idempotent
@@ -504,6 +526,7 @@ def _patch_method(resource: Any, method_name: str, flag: str, start_attrs, final
     orig = getattr(resource, method_name)
 
     if is_async:
+
         async def patched(*args, **kwargs):
             if is_suppressed():
                 return await orig(*args, **kwargs)
@@ -513,13 +536,19 @@ def _patch_method(resource: Any, method_name: str, flag: str, start_attrs, final
             try:
                 response = await orig(*args, **kwargs)
             except Exception as e:
-                span.set_status(StatusCode.ERROR, str(e)); span.record_exception(e); span.end(); raise
+                span.set_status(StatusCode.ERROR, str(e))
+                span.record_exception(e)
+                span.end()
+                raise
             try:
                 finalize(span, response, (time.perf_counter() - start) * 1000)
             except Exception:
-                span.set_status(StatusCode.OK); span.end()
+                span.set_status(StatusCode.OK)
+                span.end()
             return response
+
     else:
+
         def patched(*args, **kwargs):
             if is_suppressed():
                 return orig(*args, **kwargs)
@@ -529,11 +558,15 @@ def _patch_method(resource: Any, method_name: str, flag: str, start_attrs, final
             try:
                 response = orig(*args, **kwargs)
             except Exception as e:
-                span.set_status(StatusCode.ERROR, str(e)); span.record_exception(e); span.end(); raise
+                span.set_status(StatusCode.ERROR, str(e))
+                span.record_exception(e)
+                span.end()
+                raise
             try:
                 finalize(span, response, (time.perf_counter() - start) * 1000)
             except Exception:
-                span.set_status(StatusCode.OK); span.end()
+                span.set_status(StatusCode.OK)
+                span.end()
             return response
 
     setattr(resource, method_name, patched)
@@ -578,7 +611,10 @@ def _patch_async_responses(responses: Any) -> None:
         try:
             response = await orig_create(*args, **kwargs)
         except Exception as e:
-            span.set_status(StatusCode.ERROR, str(e)); span.record_exception(e); span.end(); raise
+            span.set_status(StatusCode.ERROR, str(e))
+            span.record_exception(e)
+            span.end()
+            raise
         if is_stream:
             return AsyncStreamWrapper(response, span, _finalize_responses_stream)
         _finalize_responses_response(span, response, (time.perf_counter() - start) * 1000)
@@ -588,7 +624,9 @@ def _patch_async_responses(responses: Any) -> None:
     responses._neatlogs_patched = True
 
 
-def _finalize_responses_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]) -> None:
+def _finalize_responses_stream(
+    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+) -> None:
     """Finalize a streaming Responses API span (events carry .type / .delta / .response)."""
     text_parts: List[str] = []
     model = None
@@ -643,12 +681,15 @@ def _patch_chat_parse(completions: Any, sync: bool = True) -> None:
             "neatlogs.llm.model_name": kwargs.get("model", ""),
             "neatlogs.llm.structured_output": True,
         }
+
     start_attrs.__name__ = "openai.chat.completions.parse"
 
     def finalize(span, response, duration_ms):
         _finalize_response(span, response, duration_ms)
 
-    _patch_method(completions, "parse", "_neatlogs_parse_patched", start_attrs, finalize, is_async=not sync)
+    _patch_method(
+        completions, "parse", "_neatlogs_parse_patched", start_attrs, finalize, is_async=not sync
+    )
 
 
 def _patch_responses_parse(responses: Any, sync: bool = True) -> None:
@@ -661,12 +702,15 @@ def _patch_responses_parse(responses: Any, sync: bool = True) -> None:
             "neatlogs.llm.input_messages.0.role": "user",
             "neatlogs.llm.input_messages.0.content": serialize(kwargs.get("input", "")),
         }
+
     start_attrs.__name__ = "openai.responses.parse"
 
     def finalize(span, response, duration_ms):
         _finalize_responses_response(span, response, duration_ms)
 
-    _patch_method(responses, "parse", "_neatlogs_parse_patched", start_attrs, finalize, is_async=not sync)
+    _patch_method(
+        responses, "parse", "_neatlogs_parse_patched", start_attrs, finalize, is_async=not sync
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -686,6 +730,7 @@ def _patch_embeddings(embeddings: Any, sync: bool = True) -> None:
         elif isinstance(inp, list):
             attrs["neatlogs.embedding.text"] = serialize(inp[:20])[:10000]
         return attrs
+
     start_attrs.__name__ = "openai.embeddings.create"
 
     def finalize(span, response, duration_ms):
@@ -708,7 +753,9 @@ def _patch_embeddings(embeddings: Any, sync: bool = True) -> None:
             span.set_attribute("neatlogs.embedding.model_name", model)
         _ok(span, duration_ms)
 
-    _patch_method(embeddings, "create", "_neatlogs_patched", start_attrs, finalize, is_async=not sync)
+    _patch_method(
+        embeddings, "create", "_neatlogs_patched", start_attrs, finalize, is_async=not sync
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -725,8 +772,11 @@ def _patch_legacy_completions(completions: Any, sync: bool = True) -> None:
             "neatlogs.llm.system": "openai",
             "neatlogs.llm.model_name": kwargs.get("model", ""),
             "neatlogs.llm.input_messages.0.role": "user",
-            "neatlogs.llm.input_messages.0.content": (prompt if isinstance(prompt, str) else serialize(prompt))[:10000],
+            "neatlogs.llm.input_messages.0.content": (
+                prompt if isinstance(prompt, str) else serialize(prompt)
+            )[:10000],
         }
+
     start_attrs.__name__ = "openai.completions.create"
 
     def finalize(span, response, duration_ms):
@@ -749,7 +799,9 @@ def _patch_legacy_completions(completions: Any, sync: bool = True) -> None:
                 span.set_attribute("neatlogs.llm.token_count.total", usage.total_tokens)
         _ok(span, duration_ms)
 
-    _patch_method(completions, "create", "_neatlogs_legacy_patched", start_attrs, finalize, is_async=not sync)
+    _patch_method(
+        completions, "create", "_neatlogs_legacy_patched", start_attrs, finalize, is_async=not sync
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -758,12 +810,19 @@ def _patch_legacy_completions(completions: Any, sync: bool = True) -> None:
 
 
 def _patch_images(images: Any, sync: bool = True) -> None:
-    for method, span_name in (("generate", "openai.images.generate"),
-                              ("edit", "openai.images.edit"),
-                              ("create_variation", "openai.images.create_variation")):
+    for method, span_name in (
+        ("generate", "openai.images.generate"),
+        ("edit", "openai.images.edit"),
+        ("create_variation", "openai.images.create_variation"),
+    ):
+
         def make(method=method, span_name=span_name):
             def start_attrs(kwargs):
-                attrs = {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": "openai", "neatlogs.llm.task": "image"}
+                attrs = {
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": "openai",
+                    "neatlogs.llm.task": "image",
+                }
                 if kwargs.get("model"):
                     attrs["neatlogs.llm.model_name"] = kwargs["model"]
                 if kwargs.get("prompt"):
@@ -771,6 +830,7 @@ def _patch_images(images: Any, sync: bool = True) -> None:
                 if kwargs.get("size"):
                     attrs["neatlogs.image.size"] = str(kwargs["size"])
                 return attrs
+
             start_attrs.__name__ = span_name
 
             def finalize(span, response, duration_ms):
@@ -781,6 +841,7 @@ def _patch_images(images: Any, sync: bool = True) -> None:
                     except TypeError:
                         pass
                 _ok(span, duration_ms)
+
             return start_attrs, finalize
 
         sa, fin = make()
@@ -795,8 +856,13 @@ def _patch_images(images: Any, sync: bool = True) -> None:
 def _patch_audio(audio: Any, sync: bool = True) -> None:
     speech = getattr(audio, "speech", None)
     if speech is not None:
+
         def start_attrs(kwargs):
-            attrs = {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": "openai", "neatlogs.llm.task": "tts"}
+            attrs = {
+                "neatlogs.span.kind": "llm",
+                "neatlogs.llm.provider": "openai",
+                "neatlogs.llm.task": "tts",
+            }
             if kwargs.get("model"):
                 attrs["neatlogs.llm.model_name"] = kwargs["model"]
             if kwargs.get("input"):
@@ -804,19 +870,33 @@ def _patch_audio(audio: Any, sync: bool = True) -> None:
             if kwargs.get("voice"):
                 attrs["neatlogs.audio.voice"] = str(kwargs["voice"])
             return attrs
+
         start_attrs.__name__ = "openai.audio.speech.create"
-        _patch_method(speech, "create", "_neatlogs_patched", start_attrs, lambda s, r, d: _ok(s, d), is_async=not sync)
+        _patch_method(
+            speech,
+            "create",
+            "_neatlogs_patched",
+            start_attrs,
+            lambda s, r, d: _ok(s, d),
+            is_async=not sync,
+        )
 
     for sub, task in (("transcriptions", "stt"), ("translations", "translation")):
         res = getattr(audio, sub, None)
         if res is None:
             continue
+
         def make(task=task, sub=sub):
             def start_attrs(kwargs):
-                attrs = {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": "openai", "neatlogs.llm.task": task}
+                attrs = {
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": "openai",
+                    "neatlogs.llm.task": task,
+                }
                 if kwargs.get("model"):
                     attrs["neatlogs.llm.model_name"] = kwargs["model"]
                 return attrs
+
             start_attrs.__name__ = f"openai.audio.{sub}.create"
 
             def finalize(span, response, duration_ms):
@@ -825,7 +905,9 @@ def _patch_audio(audio: Any, sync: bool = True) -> None:
                     span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
                     span.set_attribute("neatlogs.llm.output_messages.0.content", str(text)[:10000])
                 _ok(span, duration_ms)
+
             return start_attrs, finalize
+
         sa, fin = make()
         _patch_method(res, "create", "_neatlogs_patched", sa, fin, is_async=not sync)
 
@@ -837,25 +919,34 @@ def _patch_audio(audio: Any, sync: bool = True) -> None:
 
 def _patch_moderations(moderations: Any, sync: bool = True) -> None:
     def start_attrs(kwargs):
-        attrs = {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": "openai", "neatlogs.llm.task": "moderation"}
+        attrs = {
+            "neatlogs.span.kind": "llm",
+            "neatlogs.llm.provider": "openai",
+            "neatlogs.llm.task": "moderation",
+        }
         if kwargs.get("model"):
             attrs["neatlogs.llm.model_name"] = kwargs["model"]
         inp = kwargs.get("input")
         if inp:
             attrs["input.value"] = (inp if isinstance(inp, str) else serialize(inp))[:10000]
         return attrs
+
     start_attrs.__name__ = "openai.moderations.create"
 
     def finalize(span, response, duration_ms):
         results = getattr(response, "results", None)
         if results:
             try:
-                span.set_attribute("neatlogs.moderation.flagged", bool(getattr(results[0], "flagged", False)))
+                span.set_attribute(
+                    "neatlogs.moderation.flagged", bool(getattr(results[0], "flagged", False))
+                )
             except (TypeError, AttributeError):
                 pass
         _ok(span, duration_ms)
 
-    _patch_method(moderations, "create", "_neatlogs_patched", start_attrs, finalize, is_async=not sync)
+    _patch_method(
+        moderations, "create", "_neatlogs_patched", start_attrs, finalize, is_async=not sync
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -865,8 +956,12 @@ def _patch_moderations(moderations: Any, sync: bool = True) -> None:
 
 def _patch_batches(batches: Any, sync: bool = True) -> None:
     def start_attrs(kwargs):
-        attrs = {"neatlogs.span.kind": "task", "neatlogs.batch.endpoint": kwargs.get("endpoint", "")}
+        attrs = {
+            "neatlogs.span.kind": "task",
+            "neatlogs.batch.endpoint": kwargs.get("endpoint", ""),
+        }
         return attrs
+
     start_attrs.__name__ = "openai.batches.create"
 
     def finalize(span, response, duration_ms):
@@ -885,6 +980,7 @@ def _patch_batches(batches: Any, sync: bool = True) -> None:
 # Import-replacement: `from neatlogs.openai import openai`
 # Patches OpenAI/AsyncOpenAI.__init__ so every client is auto-wrapped.
 # ---------------------------------------------------------------------------
+
 
 def _patch_openai_module() -> None:
     global _PATCHED, _ORIG_INIT, _ORIG_ASYNC_INIT

--- a/neatlogs/openai_agents.py
+++ b/neatlogs/openai_agents.py
@@ -82,7 +82,9 @@ class _NeatlogsTraceProcessor:
         if token:
             detach(token)
         if start:
-            span.set_attribute("neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3))
+            span.set_attribute(
+                "neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3)
+            )
         self._root_input_done.discard(key)
         span.set_status(StatusCode.OK)
         span.end()
@@ -101,9 +103,12 @@ class _NeatlogsTraceProcessor:
         attrs, name = _build_start_attrs(span_type, data)
 
         if parent_span is not None:
-            from opentelemetry import trace as _ot
             from opentelemetry import context as _ctx
-            otel_span = tracer.start_span(name=name, attributes=attrs, context=_ot.set_span_in_context(parent_span))
+            from opentelemetry import trace as _ot
+
+            otel_span = tracer.start_span(
+                name=name, attributes=attrs, context=_ot.set_span_in_context(parent_span)
+            )
         else:
             otel_span = tracer.start_span(name=name, attributes=attrs)
 
@@ -156,7 +161,9 @@ class _NeatlogsTraceProcessor:
             otel_span.set_status(StatusCode.OK)
 
         if start:
-            otel_span.set_attribute("neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3))
+            otel_span.set_attribute(
+                "neatlogs.llm.metrics.duration_ms", round((time.perf_counter() - start) * 1000, 3)
+            )
         otel_span.end()
 
     def shutdown(self) -> None:
@@ -209,7 +216,9 @@ def _build_start_attrs(span_type: str, data: Any):
         attrs = {"neatlogs.span.kind": "tool", "neatlogs.tool.name": str(name)}
         tool_input = getattr(data, "input", None)
         if tool_input is not None:
-            attrs["input.value"] = tool_input if isinstance(tool_input, str) else serialize(tool_input)
+            attrs["input.value"] = (
+                tool_input if isinstance(tool_input, str) else serialize(tool_input)
+            )
         return attrs, f"openai_agents.tool.{name}"
 
     if span_type == "handoff":
@@ -331,7 +340,9 @@ def _latest_user_turn(input_msgs: Any) -> str:
     for msg in reversed(input_msgs):
         role = msg.get("role", "") if isinstance(msg, dict) else getattr(msg, "role", "")
         if role == "user":
-            content = msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")
+            content = (
+                msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")
+            )
             if content:
                 return content if isinstance(content, str) else serialize(content)
     return ""
@@ -342,7 +353,9 @@ def _set_input_messages(attrs: dict, input_msgs: Any) -> None:
         if isinstance(input_msgs, str):
             attrs["neatlogs.llm.input_messages.0.role"] = "user"
             attrs["neatlogs.llm.input_messages.0.content"] = input_msgs[:10000]
-            attrs["input.value"] = serialize({"messages": [{"role": "user", "content": input_msgs[:10000]}]})
+            attrs["input.value"] = serialize(
+                {"messages": [{"role": "user", "content": input_msgs[:10000]}]}
+            )
         return
     msgs: list = []
     for i, msg in enumerate(input_msgs):
@@ -368,14 +381,22 @@ def _set_output_messages(otel_span: Any, output: Any) -> None:
     if isinstance(output, list):
         for i, msg in enumerate(output):
             role = msg.get("role", "assistant") if isinstance(msg, dict) else "assistant"
-            content = msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")
+            content = (
+                msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")
+            )
             otel_span.set_attribute(f"neatlogs.llm.output_messages.{i}.role", role)
             if content:
-                otel_span.set_attribute(f"neatlogs.llm.output_messages.{i}.content", (content if isinstance(content, str) else serialize(content))[:10000])
+                otel_span.set_attribute(
+                    f"neatlogs.llm.output_messages.{i}.content",
+                    (content if isinstance(content, str) else serialize(content))[:10000],
+                )
     elif hasattr(output, "content"):
         otel_span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
         c = output.content
-        otel_span.set_attribute("neatlogs.llm.output_messages.0.content", (c if isinstance(c, str) else serialize(c))[:10000])
+        otel_span.set_attribute(
+            "neatlogs.llm.output_messages.0.content",
+            (c if isinstance(c, str) else serialize(c))[:10000],
+        )
     elif isinstance(output, str):
         otel_span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
         otel_span.set_attribute("neatlogs.llm.output_messages.0.content", output[:10000])
@@ -398,10 +419,16 @@ def _assistant_output_text(span_type: str, data: Any) -> str:
     if isinstance(output, list):
         parts: list = []
         for msg in output:
-            role = msg.get("role", "assistant") if isinstance(msg, dict) else getattr(msg, "role", "assistant")
+            role = (
+                msg.get("role", "assistant")
+                if isinstance(msg, dict)
+                else getattr(msg, "role", "assistant")
+            )
             if role != "assistant":
                 continue
-            content = msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")
+            content = (
+                msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")
+            )
             if content:
                 parts.append(content if isinstance(content, str) else serialize(content))
         return "\n".join(parts)
@@ -420,7 +447,9 @@ def _set_usage(otel_span: Any, usage: Any) -> None:
         total = usage.get("total_tokens")
     else:
         input_tokens = getattr(usage, "input_tokens", None) or getattr(usage, "prompt_tokens", None)
-        output_tokens = getattr(usage, "output_tokens", None) or getattr(usage, "completion_tokens", None)
+        output_tokens = getattr(usage, "output_tokens", None) or getattr(
+            usage, "completion_tokens", None
+        )
         total = getattr(usage, "total_tokens", None)
     if input_tokens:
         otel_span.set_attribute("neatlogs.llm.token_count.prompt", input_tokens)

--- a/neatlogs/openrouter.py
+++ b/neatlogs/openrouter.py
@@ -135,7 +135,9 @@ def _set_invocation_params(span: Any, kwargs: dict) -> None:
             params[key] = val
             # max_output_tokens normalizes to the max_tokens individual attr.
             attr = "max_tokens" if key == "max_output_tokens" else key
-            span.set_attribute(f"neatlogs.llm.{attr}", val if not isinstance(val, (list, dict)) else serialize(val))
+            span.set_attribute(
+                f"neatlogs.llm.{attr}", val if not isinstance(val, (list, dict)) else serialize(val)
+            )
     if params:
         span.set_attribute("neatlogs.llm.invocation_parameters", serialize(params))
 
@@ -169,7 +171,9 @@ def _set_chat_input(span: Any, kwargs: dict) -> None:
                 span.set_attribute(f"neatlogs.llm.tools.{i}.description", desc)
             schema = _get(fn, "parameters", None)
             if schema:
-                span.set_attribute(f"neatlogs.llm.tools.{i}.input_schema", serialize(_plain(schema)))
+                span.set_attribute(
+                    f"neatlogs.llm.tools.{i}.input_schema", serialize(_plain(schema))
+                )
 
 
 def _get(obj: Any, key: str, default: Any) -> Any:
@@ -223,6 +227,7 @@ def _patch_chat(chat: Any) -> None:
         return span
 
     if callable(orig_send):
+
         def patched_send(*args, **kwargs):
             if is_suppressed():
                 return orig_send(*args, **kwargs)
@@ -242,6 +247,7 @@ def _patch_chat(chat: Any) -> None:
         chat.send = patched_send
 
     if callable(orig_send_async):
+
         async def patched_send_async(*args, **kwargs):
             if is_suppressed():
                 return await orig_send_async(*args, **kwargs)
@@ -304,7 +310,9 @@ def _finalize_chat(span: Any, response: Any, duration_ms: float) -> None:
     _ok(span, duration_ms)
 
 
-def _finalize_chat_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]) -> None:
+def _finalize_chat_stream(
+    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+) -> None:
     text_parts: List[str] = []
     tool_calls_acc: dict = {}
     finish_reason = None
@@ -415,7 +423,9 @@ def _patch_responses(responses: Any) -> None:
                 "neatlogs.llm.input_messages.0.content",
                 inp if isinstance(inp, str) else serialize(_plain(inp)),
             )
-            span.set_attribute("input.value", inp if isinstance(inp, str) else serialize(_plain(inp)))
+            span.set_attribute(
+                "input.value", inp if isinstance(inp, str) else serialize(_plain(inp))
+            )
         instructions = kwargs.get("instructions")
         if isinstance(instructions, str) and instructions:
             span.set_attribute("neatlogs.llm.system_prompt", instructions)
@@ -423,6 +433,7 @@ def _patch_responses(responses: Any) -> None:
         return span
 
     if callable(orig_send):
+
         def patched_send(*args, **kwargs):
             if is_suppressed():
                 return orig_send(*args, **kwargs)
@@ -442,6 +453,7 @@ def _patch_responses(responses: Any) -> None:
         responses.send = patched_send
 
     if callable(orig_send_async):
+
         async def patched_send_async(*args, **kwargs):
             if is_suppressed():
                 return await orig_send_async(*args, **kwargs)
@@ -500,7 +512,9 @@ def _finalize_responses(span: Any, response: Any, duration_ms: float) -> None:
     _ok(span, duration_ms)
 
 
-def _finalize_responses_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]) -> None:
+def _finalize_responses_stream(
+    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+) -> None:
     text_parts: List[str] = []
     model = None
     usage = None
@@ -564,7 +578,9 @@ def _patch_embeddings(embeddings: Any) -> None:
                 "neatlogs.span.kind": "embedding",
                 "neatlogs.llm.provider": _PROVIDER,
                 "neatlogs.embedding.model_name": kwargs.get("model", ""),
-                "neatlogs.embedding.text": (inp if isinstance(inp, str) else serialize(_plain(inp)))[:10000],
+                "neatlogs.embedding.text": (
+                    inp if isinstance(inp, str) else serialize(_plain(inp))
+                )[:10000],
             },
         )
         start = time.perf_counter()
@@ -586,7 +602,9 @@ def _patch_embeddings(embeddings: Any) -> None:
 def _finalize_embeddings(span: Any, response: Any, duration_ms: float) -> None:
     # response is a CreateEmbeddingsResponse wrapper; the body may be under
     # common attribute names — probe a few.
-    body = _first_present(response, ("data", "object_", "create_embeddings_response_body", "result"))
+    body = _first_present(
+        response, ("data", "object_", "create_embeddings_response_body", "result")
+    )
     data = _get(response, "data", None)
     if data is None and body is not None and body is not response:
         data = _get(body, "data", None)

--- a/neatlogs/prompt/client.py
+++ b/neatlogs/prompt/client.py
@@ -241,7 +241,9 @@ class PromptClient:
             if not entry.is_expired():
                 return entry.value
             # Stale — return immediately, refresh in background
-            self._background_refresh(cache_key, name, label=label, version=version, ttl=cache_ttl_seconds)
+            self._background_refresh(
+                cache_key, name, label=label, version=version, ttl=cache_ttl_seconds
+            )
             return entry.value
 
         # Cold miss — must fetch synchronously
@@ -797,7 +799,9 @@ class AsyncPromptClient:
             if not entry.is_expired():
                 return entry.value
             # Stale — return immediately, refresh in background task
-            self._background_refresh(cache_key, name, label=label, version=version, ttl=cache_ttl_seconds)
+            self._background_refresh(
+                cache_key, name, label=label, version=version, ttl=cache_ttl_seconds
+            )
             return entry.value
 
         # Cold miss — must fetch

--- a/neatlogs/pydantic_ai.py
+++ b/neatlogs/pydantic_ai.py
@@ -54,7 +54,9 @@ def _get_agent_attributes(agent: Any) -> dict:
 
     model = getattr(agent, "model", None)
     if model is not None:
-        model_name = getattr(model, "model_name", None) or getattr(model, "name", None) or str(model)
+        model_name = (
+            getattr(model, "model_name", None) or getattr(model, "name", None) or str(model)
+        )
         attrs["neatlogs.llm.model_name"] = str(model_name)
 
     name = getattr(agent, "name", None)
@@ -91,10 +93,14 @@ def _extract_usage(result: Any) -> dict:
 
     prompt = getattr(usage_obj, "input_tokens", None)
     if prompt is None:
-        prompt = getattr(usage_obj, "request_tokens", None) or getattr(usage_obj, "prompt_tokens", None)
+        prompt = getattr(usage_obj, "request_tokens", None) or getattr(
+            usage_obj, "prompt_tokens", None
+        )
     completion = getattr(usage_obj, "output_tokens", None)
     if completion is None:
-        completion = getattr(usage_obj, "response_tokens", None) or getattr(usage_obj, "completion_tokens", None)
+        completion = getattr(usage_obj, "response_tokens", None) or getattr(
+            usage_obj, "completion_tokens", None
+        )
     total = getattr(usage_obj, "total_tokens", None)
     cache_read = getattr(usage_obj, "cache_read_tokens", None)
     cache_write = getattr(usage_obj, "cache_write_tokens", None)
@@ -129,7 +135,9 @@ def _finalize_run_span(span: Any, result: Any, duration_ms: float) -> None:
 
     output = _result_output(result)
     if output is not None:
-        span.set_attribute("output.value", (output if isinstance(output, str) else serialize(output)))
+        span.set_attribute(
+            "output.value", (output if isinstance(output, str) else serialize(output))
+        )
 
     for attr_name, value in _extract_usage(result).items():
         span.set_attribute(attr_name, value)
@@ -172,7 +180,8 @@ def _patch_run(agent: Any) -> None:
         try:
             result = await orig_run(*args, **kwargs)
         except Exception as e:
-            _err(span, e); raise
+            _err(span, e)
+            raise
         finally:
             _agent_span_active.reset(guard)
             detach(token)
@@ -209,7 +218,8 @@ def _patch_run_sync(agent: Any) -> None:
         try:
             result = orig_run_sync(*args, **kwargs)
         except Exception as e:
-            _err(span, e); raise
+            _err(span, e)
+            raise
         finally:
             _agent_span_active.reset(guard)
             detach(token)
@@ -397,7 +407,11 @@ def _patch_model_class(model_cls=None) -> None:
         return
     # Only patch a subclass if it actually defines its own request method;
     # otherwise it inherits an already-patched base.
-    if model_cls is not None and "request" not in target.__dict__ and "request_stream" not in target.__dict__:
+    if (
+        model_cls is not None
+        and "request" not in target.__dict__
+        and "request_stream" not in target.__dict__
+    ):
         return
 
     def _set_request_inputs(span, messages):
@@ -455,7 +469,10 @@ def _patch_model_class(model_cls=None) -> None:
                     if name:
                         span.set_attribute(f"neatlogs.llm.tool_calls.{j}.name", name)
                     if args is not None:
-                        span.set_attribute(f"neatlogs.llm.tool_calls.{j}.arguments", args if isinstance(args, str) else serialize(args))
+                        span.set_attribute(
+                            f"neatlogs.llm.tool_calls.{j}.arguments",
+                            args if isinstance(args, str) else serialize(args),
+                        )
                     if tc_id:
                         span.set_attribute(f"neatlogs.llm.tool_calls.{j}.id", str(tc_id))
                     tool_calls.append({"name": name, "arguments": args})
@@ -507,7 +524,11 @@ def _patch_model_class(model_cls=None) -> None:
     def _model_name(self):
         return getattr(self, "model_name", None) or str(self)
 
-    if hasattr(target, "request") and "request" in target.__dict__ or (model_cls is None and hasattr(target, "request")):
+    if (
+        hasattr(target, "request")
+        and "request" in target.__dict__
+        or (model_cls is None and hasattr(target, "request"))
+    ):
         orig_request = target.request
 
         async def patched_request(self, messages, *a, **k):
@@ -519,7 +540,8 @@ def _patch_model_class(model_cls=None) -> None:
             try:
                 response = await orig_request(self, messages, *a, **k)
             except Exception as e:
-                _err(span, e); raise
+                _err(span, e)
+                raise
             finally:
                 detach(token)
             _finalize_request(span, response)
@@ -527,7 +549,9 @@ def _patch_model_class(model_cls=None) -> None:
 
         target.request = patched_request
 
-    if (hasattr(target, "request_stream") and "request_stream" in target.__dict__) or (model_cls is None and hasattr(target, "request_stream")):
+    if (hasattr(target, "request_stream") and "request_stream" in target.__dict__) or (
+        model_cls is None and hasattr(target, "request_stream")
+    ):
         orig_request_stream = target.request_stream
 
         def patched_request_stream(self, messages, *a, **k):
@@ -557,7 +581,9 @@ class _ModelStreamCtx:
         self._streamed = None
 
     async def __aenter__(self):
-        self._span = get_tracer().start_span(name="pydantic_ai.model.request_stream", attributes=self._attrs)
+        self._span = get_tracer().start_span(
+            name="pydantic_ai.model.request_stream", attributes=self._attrs
+        )
         self._set_inputs(self._span, self._messages)
         self._token = attach_as_current(self._span)
         self._streamed = await self._cm.__aenter__()
@@ -579,7 +605,9 @@ class _ModelStreamCtx:
                     text = self._streamed.get() if hasattr(self._streamed, "get") else None
                     if text:
                         self._span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
-                        self._span.set_attribute("neatlogs.llm.output_messages.0.content", str(text))
+                        self._span.set_attribute(
+                            "neatlogs.llm.output_messages.0.content", str(text)
+                        )
                 except Exception:
                     pass
                 usage = getattr(self._streamed, "usage", None)
@@ -590,9 +618,13 @@ class _ModelStreamCtx:
                         usage = None
                 if usage:
                     if getattr(usage, "input_tokens", None):
-                        self._span.set_attribute("neatlogs.llm.token_count.prompt", usage.input_tokens)
+                        self._span.set_attribute(
+                            "neatlogs.llm.token_count.prompt", usage.input_tokens
+                        )
                     if getattr(usage, "output_tokens", None):
-                        self._span.set_attribute("neatlogs.llm.token_count.completion", usage.output_tokens)
+                        self._span.set_attribute(
+                            "neatlogs.llm.token_count.completion", usage.output_tokens
+                        )
                 self._span.set_status(StatusCode.OK)
             self._span.end()
 
@@ -623,7 +655,8 @@ def _patch_toolset_class() -> None:
         try:
             result = await orig_call_tool(self, name, tool_args, ctx, tool, *a, **k)
         except Exception as e:
-            _err(span, e); raise
+            _err(span, e)
+            raise
         finally:
             detach(token)
         if result is not None:

--- a/neatlogs/strands.py
+++ b/neatlogs/strands.py
@@ -77,13 +77,15 @@ def _install_event_hook() -> None:
                 op = str((span.attributes or {}).get("gen_ai.operation.name", "")).lower()
             except Exception:
                 op = ""
-            is_tool = op == "execute_tool" or "gen_ai.tool.name" in (getattr(span, "attributes", {}) or {})
+            is_tool = op == "execute_tool" or "gen_ai.tool.name" in (
+                getattr(span, "attributes", {}) or {}
+            )
             in_key = "neatlogs.tool.input" if is_tool else None
             out_key = "neatlogs.tool.output" if is_tool else None
 
             # Input-side messages: gen_ai.{system,user,assistant,tool}.message
             if event_name.startswith("gen_ai.") and event_name.endswith(".message"):
-                role = event_name[len("gen_ai."):-len(".message")]
+                role = event_name[len("gen_ai.") : -len(".message")]
                 content = _strands_event_text(ev_attrs.get("content"))
                 if content:
                     if is_tool:
@@ -102,7 +104,9 @@ def _install_event_hook() -> None:
                     else:
                         span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
                         span.set_attribute("neatlogs.llm.output_messages.0.content", out)
-                        span.set_attribute("neatlogs.llm.output", serialize({"role": "assistant", "content": out}))
+                        span.set_attribute(
+                            "neatlogs.llm.output", serialize({"role": "assistant", "content": out})
+                        )
         except Exception:
             pass
 

--- a/neatlogs/vertex_ai.py
+++ b/neatlogs/vertex_ai.py
@@ -120,6 +120,7 @@ def _patch_models(models: Any) -> None:
     models.generate_content = patched_generate_content
 
     if orig_stream:
+
         def patched_generate_content_stream(*args, **kwargs):
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
@@ -210,7 +211,9 @@ def _set_input_attributes(span: Any, contents: Any, kwargs: dict) -> None:
             if isinstance(system_instruction, str):
                 span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", system_instruction)
             else:
-                span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", serialize(system_instruction))
+                span.set_attribute(
+                    f"neatlogs.llm.input_messages.{idx}.content", serialize(system_instruction)
+                )
             idx += 1
 
     if isinstance(contents, str):
@@ -233,9 +236,13 @@ def _set_input_attributes(span: Any, contents: Any, kwargs: dict) -> None:
                     elif isinstance(part, dict) and part.get("text"):
                         text_parts.append(part["text"])
                 if text_parts:
-                    span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", "\n".join(text_parts))
+                    span.set_attribute(
+                        f"neatlogs.llm.input_messages.{idx}.content", "\n".join(text_parts)
+                    )
                 else:
-                    span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", serialize(parts))
+                    span.set_attribute(
+                        f"neatlogs.llm.input_messages.{idx}.content", serialize(parts)
+                    )
                 idx += 1
             else:
                 span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", "user")
@@ -247,7 +254,9 @@ def _set_input_attributes(span: Any, contents: Any, kwargs: dict) -> None:
 
     tools = None
     if config:
-        tools = getattr(config, "tools", None) if not isinstance(config, dict) else config.get("tools")
+        tools = (
+            getattr(config, "tools", None) if not isinstance(config, dict) else config.get("tools")
+        )
     if tools:
         for i, tool in enumerate(tools):
             if isinstance(tool, dict):
@@ -255,18 +264,32 @@ def _set_input_attributes(span: Any, contents: Any, kwargs: dict) -> None:
                 for j, fn in enumerate(fn_decls):
                     span.set_attribute(f"neatlogs.llm.tools.{i + j}.name", fn.get("name", ""))
                     if fn.get("description"):
-                        span.set_attribute(f"neatlogs.llm.tools.{i + j}.description", fn["description"])
+                        span.set_attribute(
+                            f"neatlogs.llm.tools.{i + j}.description", fn["description"]
+                        )
                     if fn.get("parameters"):
-                        span.set_attribute(f"neatlogs.llm.tools.{i + j}.input_schema", serialize(fn["parameters"]))
+                        span.set_attribute(
+                            f"neatlogs.llm.tools.{i + j}.input_schema", serialize(fn["parameters"])
+                        )
 
     if config:
-        cfg = config if isinstance(config, dict) else config.__dict__ if hasattr(config, "__dict__") else {}
+        cfg = (
+            config
+            if isinstance(config, dict)
+            else config.__dict__ if hasattr(config, "__dict__") else {}
+        )
         if isinstance(cfg, dict):
             # Set individual attrs AND the invocation_parameters blob: the backend
             # surfaces model settings to the UI ONLY from the JSON blob.
             params = {}
-            for param in ("temperature", "top_p", "top_k", "max_output_tokens",
-                          "frequency_penalty", "presence_penalty"):
+            for param in (
+                "temperature",
+                "top_p",
+                "top_k",
+                "max_output_tokens",
+                "frequency_penalty",
+                "presence_penalty",
+            ):
                 val = cfg.get(param)
                 if val is not None:
                     attr_name = "max_tokens" if param == "max_output_tokens" else param
@@ -294,9 +317,14 @@ def _finalize_response(span: Any, response: Any, duration_ms: float) -> None:
                 span.set_attribute("neatlogs.llm.output_messages.0.thinking", part.text)
             elif getattr(part, "function_call", None):
                 fc = part.function_call
-                span.set_attribute(f"neatlogs.llm.tool_calls.{tool_call_idx}.name", getattr(fc, "name", ""))
+                span.set_attribute(
+                    f"neatlogs.llm.tool_calls.{tool_call_idx}.name", getattr(fc, "name", "")
+                )
                 args = getattr(fc, "args", None)
-                span.set_attribute(f"neatlogs.llm.tool_calls.{tool_call_idx}.arguments", serialize(args) if args else "{}")
+                span.set_attribute(
+                    f"neatlogs.llm.tool_calls.{tool_call_idx}.arguments",
+                    serialize(args) if args else "{}",
+                )
                 tool_call_idx += 1
 
         finish_reason = getattr(candidate, "finish_reason", None)
@@ -339,7 +367,9 @@ def _set_usage_attributes(span: Any, usage: Any) -> None:
         span.set_attribute("neatlogs.llm.token_count.reasoning", reasoning_tokens)
 
 
-def _finalize_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]) -> None:
+def _finalize_stream(
+    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+) -> None:
     """Finalize a streaming response span from accumulated chunks."""
     text_parts: List[str] = []
     thinking_parts: List[str] = []
@@ -361,10 +391,12 @@ def _finalize_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: 
                     thinking_parts.append(part.text)
                 elif getattr(part, "function_call", None):
                     fc = part.function_call
-                    tool_calls_acc.append({
-                        "name": getattr(fc, "name", ""),
-                        "arguments": serialize(getattr(fc, "args", None) or {}),
-                    })
+                    tool_calls_acc.append(
+                        {
+                            "name": getattr(fc, "name", ""),
+                            "arguments": serialize(getattr(fc, "args", None) or {}),
+                        }
+                    )
 
             fr = getattr(candidate, "finish_reason", None)
             if fr:
@@ -413,7 +445,9 @@ def _finalize_stream(span: Any, chunks: List[Any], duration_ms: float, ttft_ms: 
 
 def _patch_models_extra(models: Any, is_async: bool) -> None:
     # embed_content
-    if hasattr(models, "embed_content") and not getattr(models, "_neatlogs_vertex_embed_patched", False):
+    if hasattr(models, "embed_content") and not getattr(
+        models, "_neatlogs_vertex_embed_patched", False
+    ):
         orig = models.embed_content
 
         def _embed_attrs(kwargs):
@@ -424,7 +458,9 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             }
             contents = kwargs.get("contents")
             if contents is not None:
-                attrs["neatlogs.embedding.text"] = (contents if isinstance(contents, str) else serialize(contents))[:10000]
+                attrs["neatlogs.embedding.text"] = (
+                    contents if isinstance(contents, str) else serialize(contents)
+                )[:10000]
             return attrs
 
         def _embed_finalize(span, resp):
@@ -441,35 +477,53 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             span.end()
 
         if is_async:
+
             async def patched_embed(*args, **kwargs):
                 if is_suppressed():
                     return await orig(*args, **kwargs)
-                span = get_provider_tracer().start_span(name="vertex_ai.models.embed_content", attributes=_embed_attrs(kwargs))
+                span = get_provider_tracer().start_span(
+                    name="vertex_ai.models.embed_content", attributes=_embed_attrs(kwargs)
+                )
                 try:
                     resp = await orig(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
-                _embed_finalize(span, resp); return resp
+                    _err(span, e)
+                    raise
+                _embed_finalize(span, resp)
+                return resp
+
         else:
+
             def patched_embed(*args, **kwargs):
                 if is_suppressed():
                     return orig(*args, **kwargs)
-                span = get_provider_tracer().start_span(name="vertex_ai.models.embed_content", attributes=_embed_attrs(kwargs))
+                span = get_provider_tracer().start_span(
+                    name="vertex_ai.models.embed_content", attributes=_embed_attrs(kwargs)
+                )
                 try:
                     resp = orig(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
-                _embed_finalize(span, resp); return resp
+                    _err(span, e)
+                    raise
+                _embed_finalize(span, resp)
+                return resp
+
         models.embed_content = patched_embed
         models._neatlogs_vertex_embed_patched = True
 
     # count_tokens
-    if hasattr(models, "count_tokens") and not getattr(models, "_neatlogs_vertex_count_patched", False):
+    if hasattr(models, "count_tokens") and not getattr(
+        models, "_neatlogs_vertex_count_patched", False
+    ):
         orig_ct = models.count_tokens
 
         def _ct_attrs(kwargs):
-            return {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": _PROVIDER,
-                    "neatlogs.llm.task": "count_tokens", "neatlogs.llm.model_name": str(kwargs.get("model", ""))}
+            return {
+                "neatlogs.span.kind": "llm",
+                "neatlogs.llm.provider": _PROVIDER,
+                "neatlogs.llm.task": "count_tokens",
+                "neatlogs.llm.model_name": str(kwargs.get("model", "")),
+            }
 
         def _ct_finalize(span, resp):
             total = getattr(resp, "total_tokens", None)
@@ -479,25 +533,37 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             span.end()
 
         if is_async:
+
             async def patched_ct(*args, **kwargs):
                 if is_suppressed():
                     return await orig_ct(*args, **kwargs)
-                span = get_provider_tracer().start_span(name="vertex_ai.models.count_tokens", attributes=_ct_attrs(kwargs))
+                span = get_provider_tracer().start_span(
+                    name="vertex_ai.models.count_tokens", attributes=_ct_attrs(kwargs)
+                )
                 try:
                     resp = await orig_ct(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
-                _ct_finalize(span, resp); return resp
+                    _err(span, e)
+                    raise
+                _ct_finalize(span, resp)
+                return resp
+
         else:
+
             def patched_ct(*args, **kwargs):
                 if is_suppressed():
                     return orig_ct(*args, **kwargs)
-                span = get_provider_tracer().start_span(name="vertex_ai.models.count_tokens", attributes=_ct_attrs(kwargs))
+                span = get_provider_tracer().start_span(
+                    name="vertex_ai.models.count_tokens", attributes=_ct_attrs(kwargs)
+                )
                 try:
                     resp = orig_ct(*args, **kwargs)
                 except Exception as e:
-                    _err(span, e); raise
-                _ct_finalize(span, resp); return resp
+                    _err(span, e)
+                    raise
+                _ct_finalize(span, resp)
+                return resp
+
         models.count_tokens = patched_ct
         models._neatlogs_vertex_count_patched = True
 
@@ -612,6 +678,7 @@ def _err(span: Any, e: Exception) -> None:
 # Import-replacement: `from neatlogs.vertex_ai import genai`
 # Patches Client.__init__ so every Vertex-mode client is auto-wrapped.
 # ---------------------------------------------------------------------------
+
 
 def _patch_vertex_ai_module() -> None:
     global _PATCHED, _ORIG_INIT

--- a/tests/integration/test_azure_openai_instrumentation.py
+++ b/tests/integration/test_azure_openai_instrumentation.py
@@ -8,7 +8,6 @@ with provider="azure" and the canonical neatlogs.* attributes.
 from types import SimpleNamespace
 
 import pytest
-
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -21,6 +20,7 @@ def _setup_tracer(exporter):
     # Reset the process-global wrapper-tracer cache so each test binds to its
     # own provider (correct in production; leaks across tests otherwise).
     import neatlogs._wrap_utils as _wu
+
     _wu._wrapper_tracer = None
     return provider
 
@@ -122,7 +122,9 @@ class TestAzureOpenAIInstrumentation:
         wrap_azure_openai_client(client)
 
         with pytest.raises(RuntimeError):
-            client.chat.completions.create(model="gpt-4o", messages=[{"role": "user", "content": "Hi"}])
+            client.chat.completions.create(
+                model="gpt-4o", messages=[{"role": "user", "content": "Hi"}]
+            )
 
         spans = in_memory_span_exporter.get_finished_spans()
         assert len(spans) == 1

--- a/tests/integration/test_bedrock_instrumentation.py
+++ b/tests/integration/test_bedrock_instrumentation.py
@@ -10,7 +10,6 @@ import json
 from types import SimpleNamespace
 
 import pytest
-
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -23,6 +22,7 @@ def _setup_tracer(exporter):
     # Reset the process-global wrapper-tracer cache so each test binds to its
     # own provider (correct in production; leaks across tests otherwise).
     import neatlogs._wrap_utils as _wu
+
     _wu._wrapper_tracer = None
     return provider
 
@@ -112,9 +112,7 @@ class TestBedrockInvokeModel:
         client = _fake_bedrock_client(invoke_model=invoke_model)
         wrap_bedrock_client(client)
 
-        req_body = json.dumps(
-            {"messages": [{"role": "user", "content": "Hi"}], "max_tokens": 100}
-        )
+        req_body = json.dumps({"messages": [{"role": "user", "content": "Hi"}], "max_tokens": 100})
         resp = client.invoke_model(modelId="anthropic.claude-3-haiku-20240307-v1:0", body=req_body)
 
         # Body must still be readable by the caller.

--- a/tests/integration/test_claude_agent_sdk_instrumentation.py
+++ b/tests/integration/test_claude_agent_sdk_instrumentation.py
@@ -17,7 +17,6 @@ import sys
 import types
 
 import pytest
-
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -28,31 +27,43 @@ def _setup_tracer(exporter):
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
     import neatlogs._wrap_utils as _wu
+
     _wu._wrapper_tracer = None
     return provider
 
 
 def _run(coro):
     import asyncio
+
     return asyncio.run(coro)
 
 
 # message factories (dict-shaped, like the SDK's typed messages read via attrs/keys) ----------
 
+
 def _system(session_id="sess-1", model="claude-haiku-4-5"):
     return {"type": "system", "session_id": session_id, "model": model}
 
 
-def _assistant(text=None, tool_use=None, usage=None, model="claude-haiku-4-5",
-               stop_reason=None, parent_tool_use_id=None, subagent_type=None):
+def _assistant(
+    text=None,
+    tool_use=None,
+    usage=None,
+    model="claude-haiku-4-5",
+    stop_reason=None,
+    parent_tool_use_id=None,
+    subagent_type=None,
+):
     content = []
     if text is not None:
         content.append({"type": "text", "text": text})
     if tool_use is not None:
         content.append({"type": "tool_use", **tool_use})
-    msg = {"type": "assistant", "parent_tool_use_id": parent_tool_use_id,
-           "message": {"content": content, "model": model, "usage": usage,
-                       "stop_reason": stop_reason}}
+    msg = {
+        "type": "assistant",
+        "parent_tool_use_id": parent_tool_use_id,
+        "message": {"content": content, "model": model, "usage": usage, "stop_reason": stop_reason},
+    }
     # the SDK tags a subagent's own messages with subagent_type (the wrapper reads it to name the
     # nested AGENT span — same as the TS reference's msg.subagent_type)
     if subagent_type is not None:
@@ -61,14 +72,31 @@ def _assistant(text=None, tool_use=None, usage=None, model="claude-haiku-4-5",
 
 
 def _user_tool_result(tool_use_id, output, is_error=False, parent_tool_use_id=None):
-    return {"type": "user", "parent_tool_use_id": parent_tool_use_id,
-            "message": {"content": [{"type": "tool_result", "tool_use_id": tool_use_id,
-                                     "content": output, "is_error": is_error}]}}
+    return {
+        "type": "user",
+        "parent_tool_use_id": parent_tool_use_id,
+        "message": {
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": output,
+                    "is_error": is_error,
+                }
+            ]
+        },
+    }
 
 
 def _result(text="final answer", usage=None, total_cost_usd=None, num_turns=None, is_error=False):
-    return {"type": "result", "result": text, "usage": usage,
-            "total_cost_usd": total_cost_usd, "num_turns": num_turns, "is_error": is_error}
+    return {
+        "type": "result",
+        "result": text,
+        "usage": usage,
+        "total_cost_usd": total_cost_usd,
+        "num_turns": num_turns,
+        "is_error": is_error,
+    }
 
 
 @pytest.fixture
@@ -84,6 +112,7 @@ def fake_cas(monkeypatch):
     mod.ClaudeSDKClient = None
     monkeypatch.setitem(sys.modules, "claude_agent_sdk", mod)
     import neatlogs.claude_agent_sdk as c
+
     c._PATCHED = False
     c._ORIGINALS.clear()
     yield mod
@@ -105,6 +134,7 @@ def _consume(mod, prompt="how are my agents?"):
         async for m in mod.query(prompt=prompt):
             out.append(m.get("type"))
         return out
+
     return _run(go())
 
 
@@ -115,41 +145,61 @@ def _kinds(spans, k):
 class TestClaudeAgentSDKInstrumentation:
     def test_agent_is_root_no_workflow(self, fake_cas, in_memory_span_exporter):
         # the canonical design: AGENT is the trace root, NO WORKFLOW wrapper
-        _set_script([
-            _system(),
-            _assistant(text="checking", tool_use={"id": "t1", "name": "triage_signal", "input": {"signal": "X"}},
-                       usage={"input_tokens": 1200, "output_tokens": 90}),
-            _user_tool_result("t1", "fired 322 times"),
-            _assistant(text="all good", usage={"input_tokens": 1500, "output_tokens": 40},
-                       stop_reason="end_turn"),
-            _result(text="final answer", usage={"input_tokens": 2700, "output_tokens": 130}),
-        ])
+        _set_script(
+            [
+                _system(),
+                _assistant(
+                    text="checking",
+                    tool_use={"id": "t1", "name": "triage_signal", "input": {"signal": "X"}},
+                    usage={"input_tokens": 1200, "output_tokens": 90},
+                ),
+                _user_tool_result("t1", "fired 322 times"),
+                _assistant(
+                    text="all good",
+                    usage={"input_tokens": 1500, "output_tokens": 40},
+                    stop_reason="end_turn",
+                ),
+                _result(text="final answer", usage={"input_tokens": 2700, "output_tokens": 130}),
+            ]
+        )
         _setup_tracer(in_memory_span_exporter)
         from neatlogs.claude_agent_sdk import wrap_claude_agent_sdk
+
         wrap_claude_agent_sdk(fake_cas)
         _consume(fake_cas)
 
         spans = in_memory_span_exporter.get_finished_spans()
-        assert len(_kinds(spans, "workflow")) == 0          # NO workflow wrapper
+        assert len(_kinds(spans, "workflow")) == 0  # NO workflow wrapper
         agents = _kinds(spans, "agent")
         assert len(agents) == 1
         root = agents[0]
         assert root.name == "claude_agent.query"
-        assert root.parent is None                          # it IS the trace root
+        assert root.parent is None  # it IS the trace root
         assert root.attributes.get("neatlogs.agent.framework") == "claude_agent_sdk"
 
     def test_one_llm_span_per_buffered_turn(self, fake_cas, in_memory_span_exporter):
         # turn 1 = text + tool_use (one model turn across blocks); turn 2 = final text → 2 LLM spans
-        _set_script([
-            _system(),
-            _assistant(text="let me check", tool_use={"id": "t1", "name": "triage_signal", "input": {"signal": "X"}},
-                       usage={"input_tokens": 1200, "output_tokens": 90}, stop_reason="tool_use"),
-            _user_tool_result("t1", "ok"),
-            _assistant(text="done", usage={"input_tokens": 1500, "output_tokens": 40}, stop_reason="end_turn"),
-            _result(),
-        ])
+        _set_script(
+            [
+                _system(),
+                _assistant(
+                    text="let me check",
+                    tool_use={"id": "t1", "name": "triage_signal", "input": {"signal": "X"}},
+                    usage={"input_tokens": 1200, "output_tokens": 90},
+                    stop_reason="tool_use",
+                ),
+                _user_tool_result("t1", "ok"),
+                _assistant(
+                    text="done",
+                    usage={"input_tokens": 1500, "output_tokens": 40},
+                    stop_reason="end_turn",
+                ),
+                _result(),
+            ]
+        )
         _setup_tracer(in_memory_span_exporter)
         from neatlogs.claude_agent_sdk import wrap_claude_agent_sdk
+
         wrap_claude_agent_sdk(fake_cas)
         _consume(fake_cas)
         spans = in_memory_span_exporter.get_finished_spans()
@@ -169,15 +219,20 @@ class TestClaudeAgentSDKInstrumentation:
         assert a.get("neatlogs.llm.input_messages.0.role") == "user"
 
     def test_tool_span_opened_then_closed_by_tool_result(self, fake_cas, in_memory_span_exporter):
-        _set_script([
-            _system(),
-            _assistant(tool_use={"id": "t1", "name": "triage_signal", "input": {"signal": "X"}},
-                       usage={"input_tokens": 10, "output_tokens": 5}),
-            _user_tool_result("t1", "fired 322 times"),
-            _result(),
-        ])
+        _set_script(
+            [
+                _system(),
+                _assistant(
+                    tool_use={"id": "t1", "name": "triage_signal", "input": {"signal": "X"}},
+                    usage={"input_tokens": 10, "output_tokens": 5},
+                ),
+                _user_tool_result("t1", "fired 322 times"),
+                _result(),
+            ]
+        )
         _setup_tracer(in_memory_span_exporter)
         from neatlogs.claude_agent_sdk import wrap_claude_agent_sdk
+
         wrap_claude_agent_sdk(fake_cas)
         _consume(fake_cas)
         spans = in_memory_span_exporter.get_finished_spans()
@@ -186,19 +241,24 @@ class TestClaudeAgentSDKInstrumentation:
         a = tool[0].attributes
         assert a.get("neatlogs.tool.name") == "triage_signal"
         assert a.get("neatlogs.tool_call.id") == "t1"
-        assert "signal" in a.get("input.value", "")            # tool args
-        assert "fired 322" in a.get("output.value", "")        # closed by the matching tool_result
+        assert "signal" in a.get("input.value", "")  # tool args
+        assert "fired 322" in a.get("output.value", "")  # closed by the matching tool_result
 
     def test_tool_error_marks_tool_span_error(self, fake_cas, in_memory_span_exporter):
-        _set_script([
-            _system(),
-            _assistant(tool_use={"id": "t1", "name": "bad_tool", "input": {}},
-                       usage={"input_tokens": 1, "output_tokens": 1}),
-            _user_tool_result("t1", "boom", is_error=True),
-            _result(),
-        ])
+        _set_script(
+            [
+                _system(),
+                _assistant(
+                    tool_use={"id": "t1", "name": "bad_tool", "input": {}},
+                    usage={"input_tokens": 1, "output_tokens": 1},
+                ),
+                _user_tool_result("t1", "boom", is_error=True),
+                _result(),
+            ]
+        )
         _setup_tracer(in_memory_span_exporter)
         from neatlogs.claude_agent_sdk import wrap_claude_agent_sdk
+
         wrap_claude_agent_sdk(fake_cas)
         _consume(fake_cas)
         spans = in_memory_span_exporter.get_finished_spans()
@@ -208,25 +268,43 @@ class TestClaudeAgentSDKInstrumentation:
 
     def test_subagent_nests_under_task_tool(self, fake_cas, in_memory_span_exporter):
         # orchestrator spawns a Task (id=task1); the subagent's messages carry parent_tool_use_id=task1
-        _set_script([
-            _system(),
-            _assistant(tool_use={"id": "task1", "name": "Task",
-                                 "input": {"subagent_type": "investigator"}},
-                       usage={"input_tokens": 100, "output_tokens": 20}),
-            # subagent activity (parent_tool_use_id = the Task id; tagged with subagent_type)
-            _assistant(text="subagent working", parent_tool_use_id="task1", subagent_type="investigator",
-                       usage={"input_tokens": 50, "output_tokens": 10},
-                       tool_use={"id": "s1", "name": "run_query", "input": {"q": "x"}}),
-            _user_tool_result("s1", "rows", parent_tool_use_id="task1"),
-            _assistant(text="subagent done", parent_tool_use_id="task1", subagent_type="investigator",
-                       usage={"input_tokens": 60, "output_tokens": 5}),
-            # Task tool result closes the orchestrator's Task TOOL span
-            _user_tool_result("task1", "subagent result"),
-            _assistant(text="orchestrator done", usage={"input_tokens": 200, "output_tokens": 8}),
-            _result(),
-        ])
+        _set_script(
+            [
+                _system(),
+                _assistant(
+                    tool_use={
+                        "id": "task1",
+                        "name": "Task",
+                        "input": {"subagent_type": "investigator"},
+                    },
+                    usage={"input_tokens": 100, "output_tokens": 20},
+                ),
+                # subagent activity (parent_tool_use_id = the Task id; tagged with subagent_type)
+                _assistant(
+                    text="subagent working",
+                    parent_tool_use_id="task1",
+                    subagent_type="investigator",
+                    usage={"input_tokens": 50, "output_tokens": 10},
+                    tool_use={"id": "s1", "name": "run_query", "input": {"q": "x"}},
+                ),
+                _user_tool_result("s1", "rows", parent_tool_use_id="task1"),
+                _assistant(
+                    text="subagent done",
+                    parent_tool_use_id="task1",
+                    subagent_type="investigator",
+                    usage={"input_tokens": 60, "output_tokens": 5},
+                ),
+                # Task tool result closes the orchestrator's Task TOOL span
+                _user_tool_result("task1", "subagent result"),
+                _assistant(
+                    text="orchestrator done", usage={"input_tokens": 200, "output_tokens": 8}
+                ),
+                _result(),
+            ]
+        )
         _setup_tracer(in_memory_span_exporter)
         from neatlogs.claude_agent_sdk import wrap_claude_agent_sdk
+
         wrap_claude_agent_sdk(fake_cas)
         _consume(fake_cas)
         spans = in_memory_span_exporter.get_finished_spans()
@@ -235,21 +313,30 @@ class TestClaudeAgentSDKInstrumentation:
         assert len(agents) == 2
         root = next(s for s in agents if s.name == "claude_agent.query")
         sub = next(s for s in agents if s.name == "claude_agent.subagent.investigator")
-        task_tool = next(s for s in _kinds(spans, "tool") if s.attributes.get("neatlogs.tool.name") == "Task")
+        task_tool = next(
+            s for s in _kinds(spans, "tool") if s.attributes.get("neatlogs.tool.name") == "Task"
+        )
         # subagent AGENT nests under the Task TOOL span; everything one trace
         assert sub.parent is not None and sub.parent.span_id == task_tool.context.span_id
         assert len({s.context.trace_id for s in agents}) == 1
         assert sub.attributes.get("neatlogs.agent.name") == "investigator"
 
     def test_result_sets_agent_attrs_and_output(self, fake_cas, in_memory_span_exporter):
-        _set_script([
-            _system(session_id="sess-42", model="claude-haiku-4-5"),
-            _assistant(text="answer", usage={"input_tokens": 5, "output_tokens": 3}),
-            _result(text="final answer", usage={"input_tokens": 2700, "output_tokens": 130},
-                    total_cost_usd=0.0123, num_turns=2),
-        ])
+        _set_script(
+            [
+                _system(session_id="sess-42", model="claude-haiku-4-5"),
+                _assistant(text="answer", usage={"input_tokens": 5, "output_tokens": 3}),
+                _result(
+                    text="final answer",
+                    usage={"input_tokens": 2700, "output_tokens": 130},
+                    total_cost_usd=0.0123,
+                    num_turns=2,
+                ),
+            ]
+        )
         _setup_tracer(in_memory_span_exporter)
         from neatlogs.claude_agent_sdk import wrap_claude_agent_sdk
+
         wrap_claude_agent_sdk(fake_cas)
         _consume(fake_cas)
         spans = in_memory_span_exporter.get_finished_spans()
@@ -264,9 +351,16 @@ class TestClaudeAgentSDKInstrumentation:
         assert a.get("neatlogs.llm.token_count.prompt") == 2700
 
     def test_string_prompt_captured_as_input(self, fake_cas, in_memory_span_exporter):
-        _set_script([_system(), _assistant(text="hi", usage={"input_tokens": 1, "output_tokens": 1}), _result()])
+        _set_script(
+            [
+                _system(),
+                _assistant(text="hi", usage={"input_tokens": 1, "output_tokens": 1}),
+                _result(),
+            ]
+        )
         _setup_tracer(in_memory_span_exporter)
         from neatlogs.claude_agent_sdk import wrap_claude_agent_sdk
+
         wrap_claude_agent_sdk(fake_cas)
         _consume(fake_cas, prompt="how are my agents?")
         spans = in_memory_span_exporter.get_finished_spans()
@@ -274,50 +368,78 @@ class TestClaudeAgentSDKInstrumentation:
         assert "agents" in root.attributes.get("input.value", "")
 
     def test_wrap_via_dispatcher(self, fake_cas, in_memory_span_exporter):
-        _set_script([_system(), _assistant(text="x", usage={"input_tokens": 1, "output_tokens": 1}), _result()])
+        _set_script(
+            [
+                _system(),
+                _assistant(text="x", usage={"input_tokens": 1, "output_tokens": 1}),
+                _result(),
+            ]
+        )
         _setup_tracer(in_memory_span_exporter)
         import neatlogs
+
         neatlogs.wrap(fake_cas)
         _consume(fake_cas)
         spans = in_memory_span_exporter.get_finished_spans()
         assert _kinds(spans, "agent")
 
     def test_idempotent_double_wrap(self, fake_cas, in_memory_span_exporter):
-        _set_script([_system(), _assistant(text="x", usage={"input_tokens": 1, "output_tokens": 1}), _result()])
+        _set_script(
+            [
+                _system(),
+                _assistant(text="x", usage={"input_tokens": 1, "output_tokens": 1}),
+                _result(),
+            ]
+        )
         _setup_tracer(in_memory_span_exporter)
         from neatlogs.claude_agent_sdk import wrap_claude_agent_sdk
+
         wrap_claude_agent_sdk(fake_cas)
         wrap_claude_agent_sdk(fake_cas)
         _consume(fake_cas)
         spans = in_memory_span_exporter.get_finished_spans()
-        assert len(_kinds(spans, "agent")) == 1            # not double-wrapped
+        assert len(_kinds(spans, "agent")) == 1  # not double-wrapped
 
     def test_no_uncon_sumed_agent_attrs(self, fake_cas, in_memory_span_exporter):
         # every neatlogs.agent.* / neatlogs.* key we emit must be a real canonical key (no invented
         # cosmetic attrs). These are the keys the TS reference + attribute-mapping.json establish.
-        _set_script([
-            _system(session_id="s", model="m"),
-            _assistant(text="a", usage={"input_tokens": 1, "output_tokens": 1}),
-            _result(total_cost_usd=0.01, num_turns=1),
-        ])
+        _set_script(
+            [
+                _system(session_id="s", model="m"),
+                _assistant(text="a", usage={"input_tokens": 1, "output_tokens": 1}),
+                _result(total_cost_usd=0.01, num_turns=1),
+            ]
+        )
         _setup_tracer(in_memory_span_exporter)
         from neatlogs.claude_agent_sdk import wrap_claude_agent_sdk
+
         wrap_claude_agent_sdk(fake_cas)
         _consume(fake_cas)
         spans = in_memory_span_exporter.get_finished_spans()
         root = _kinds(spans, "agent")[0]
         CANONICAL_AGENT = {
-            "neatlogs.agent.framework", "neatlogs.agent.name", "neatlogs.agent.model",
-            "neatlogs.agent.cost_usd", "neatlogs.agent.num_turns", "neatlogs.agent.is_error",
+            "neatlogs.agent.framework",
+            "neatlogs.agent.name",
+            "neatlogs.agent.model",
+            "neatlogs.agent.cost_usd",
+            "neatlogs.agent.num_turns",
+            "neatlogs.agent.is_error",
         }
         emitted = {k for k in root.attributes if k.startswith("neatlogs.agent.")}
         assert emitted <= CANONICAL_AGENT, f"unexpected agent attrs: {emitted - CANONICAL_AGENT}"
 
     def test_fail_open_on_tracer_error(self, fake_cas, in_memory_span_exporter, monkeypatch):
-        _set_script([_system(), _assistant(text="x", usage={"input_tokens": 1, "output_tokens": 1}), _result()])
+        _set_script(
+            [
+                _system(),
+                _assistant(text="x", usage={"input_tokens": 1, "output_tokens": 1}),
+                _result(),
+            ]
+        )
         _setup_tracer(in_memory_span_exporter)
-        from neatlogs.claude_agent_sdk import wrap_claude_agent_sdk
         import neatlogs.claude_agent_sdk as c
+        from neatlogs.claude_agent_sdk import wrap_claude_agent_sdk
+
         monkeypatch.setattr(c, "get_tracer", lambda: (_ for _ in ()).throw(RuntimeError("down")))
         wrap_claude_agent_sdk(fake_cas)
         # iteration must still complete despite tracing failure
@@ -328,11 +450,13 @@ class TestClaudeAgentSDKInstrumentation:
         (AssistantMessage/UserMessage/SystemMessage/ResultMessage) with NO `type`/`message` fields —
         dispatch is by CLASS NAME, content is typed blocks. The dict-shaped fakes above did NOT catch
         that the wrapper read msg['type'] (always None on objects) → zero LLM/TOOL spans live. This
-        builds messages from object-like shims matching the real classes' field names + class names."""
-        import sys, types
+        builds messages from object-like shims matching the real classes' field names + class names.
+        """
+        import sys
+        import types
 
         def _obj(cls_name, **fields):
-            return type(cls_name, (), fields)()   # an instance whose class NAME drives dispatch
+            return type(cls_name, (), fields)()  # an instance whose class NAME drives dispatch
 
         def TextBlock(text):
             return _obj("TextBlock", text=text)
@@ -341,32 +465,64 @@ class TestClaudeAgentSDKInstrumentation:
             return _obj("ToolUseBlock", id=id, name=name, input=inp)
 
         def ToolResultBlock(tool_use_id, content, is_error=False):
-            return _obj("ToolResultBlock", tool_use_id=tool_use_id, content=content, is_error=is_error)
+            return _obj(
+                "ToolResultBlock", tool_use_id=tool_use_id, content=content, is_error=is_error
+            )
 
         # real objects: NO 'type' field, content DIRECTLY on the message, no '.message' wrapper
         msgs = [
-            _obj("SystemMessage", subtype="init", data={"session_id": "s1", "model": "claude-haiku-4-5"}),
-            _obj("AssistantMessage", parent_tool_use_id=None, model="claude-haiku-4-5",
-                 stop_reason="tool_use", usage={"input_tokens": 10, "output_tokens": 5},
-                 content=[TextBlock("checking"), ToolUseBlock("t1", "triage_signal", {"signal": "X"})]),
-            _obj("UserMessage", parent_tool_use_id=None,
-                 content=[ToolResultBlock("t1", "fired 322 times")], tool_use_result=None),
-            _obj("AssistantMessage", parent_tool_use_id=None, model="claude-haiku-4-5",
-                 stop_reason="end_turn", usage={"input_tokens": 12, "output_tokens": 3},
-                 content=[TextBlock("all good")]),
-            _obj("ResultMessage", subtype="success", result="final answer", is_error=False,
-                 num_turns=2, total_cost_usd=0.0123, session_id="s1",
-                 usage={"input_tokens": 2700, "output_tokens": 130}),
+            _obj(
+                "SystemMessage",
+                subtype="init",
+                data={"session_id": "s1", "model": "claude-haiku-4-5"},
+            ),
+            _obj(
+                "AssistantMessage",
+                parent_tool_use_id=None,
+                model="claude-haiku-4-5",
+                stop_reason="tool_use",
+                usage={"input_tokens": 10, "output_tokens": 5},
+                content=[
+                    TextBlock("checking"),
+                    ToolUseBlock("t1", "triage_signal", {"signal": "X"}),
+                ],
+            ),
+            _obj(
+                "UserMessage",
+                parent_tool_use_id=None,
+                content=[ToolResultBlock("t1", "fired 322 times")],
+                tool_use_result=None,
+            ),
+            _obj(
+                "AssistantMessage",
+                parent_tool_use_id=None,
+                model="claude-haiku-4-5",
+                stop_reason="end_turn",
+                usage={"input_tokens": 12, "output_tokens": 3},
+                content=[TextBlock("all good")],
+            ),
+            _obj(
+                "ResultMessage",
+                subtype="success",
+                result="final answer",
+                is_error=False,
+                num_turns=2,
+                total_cost_usd=0.0123,
+                session_id="s1",
+                usage={"input_tokens": 2700, "output_tokens": 130},
+            ),
         ]
         mod = types.ModuleType("claude_agent_sdk")
 
         async def query(*, prompt=None, options=None):
             for m in msgs:
                 yield m
+
         mod.query = query
         mod.ClaudeSDKClient = None
         monkeypatch.setitem(sys.modules, "claude_agent_sdk", mod)
         import neatlogs.claude_agent_sdk as c
+
         c._PATCHED = False
         c._ORIGINALS.clear()
 
@@ -379,12 +535,15 @@ class TestClaudeAgentSDKInstrumentation:
         assert len(_kinds(spans, "agent")) == 1
         assert len(_kinds(spans, "llm")) == 2, "object-shaped assistant turns produced no LLM spans"
         assert len(_kinds(spans, "tool")) == 1, "object-shaped tool_use produced no TOOL span"
-        llm = next(s for s in _kinds(spans, "llm")
-                   if s.attributes.get("neatlogs.llm.token_count.prompt") == 10)
+        llm = next(
+            s
+            for s in _kinds(spans, "llm")
+            if s.attributes.get("neatlogs.llm.token_count.prompt") == 10
+        )
         assert llm.attributes.get("neatlogs.llm.model_name") == "claude-haiku-4-5"
         assert llm.attributes.get("neatlogs.llm.tool_calls.0.name") == "triage_signal"
         tool = _kinds(spans, "tool")[0]
-        assert "fired 322" in tool.attributes.get("output.value", "")   # closed by ToolResultBlock
+        assert "fired 322" in tool.attributes.get("output.value", "")  # closed by ToolResultBlock
         root = _kinds(spans, "agent")[0]
         assert root.attributes.get("neatlogs.conversation.id") == "s1"
         assert root.attributes.get("neatlogs.agent.cost_usd") == 0.0123
@@ -401,21 +560,29 @@ class TestQueryObjectShape:
     """The real SDK's query() returns a Query OBJECT (with its own methods/attrs + a permissive
     __getattr__), NOT a bare async generator. A wrapper that stored internal state via getattr/
     __getattr__ delegation broke iteration on the real object (live: only the first span emitted,
-    the rest of the stream was lost). This guards that the wrapper iterates a Query-object correctly."""
+    the rest of the stream was lost). This guards that the wrapper iterates a Query-object correctly.
+    """
 
-    def test_iterates_query_object_with_permissive_getattr(self, in_memory_span_exporter, monkeypatch):
-        import sys, types
+    def test_iterates_query_object_with_permissive_getattr(
+        self, in_memory_span_exporter, monkeypatch
+    ):
+        import sys
+        import types
 
         class FakeQuery:
             """Mimics the SDK Query object: async-iterable + permissive __getattr__ (returns a no-op
             for any unknown attr, like a proxy) — the shape that broke the wrapper."""
+
             def __init__(self, msgs):
                 self._msgs = msgs
+
             def __aiter__(self):
                 async def gen():
                     for m in self._msgs:
                         yield m
+
                 return gen()
+
             def __getattr__(self, name):
                 # permissive proxy: any unknown attribute returns a callable no-op (this is what
                 # made `getattr(self, "_inner_iter", None)` NOT return None in the buggy wrapper)
@@ -423,22 +590,42 @@ class TestQueryObjectShape:
 
         msgs = [
             {"type": "system", "session_id": "s", "model": "m"},
-            {"type": "assistant", "parent_tool_use_id": None,
-             "message": {"content": [{"type": "text", "text": "hi"},
-                                     {"type": "tool_use", "id": "t1", "name": "tool_x", "input": {}}],
-                         "model": "m", "usage": {"input_tokens": 5, "output_tokens": 2}}},
-            {"type": "user", "parent_tool_use_id": None,
-             "message": {"content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]}},
-            {"type": "assistant", "parent_tool_use_id": None,
-             "message": {"content": [{"type": "text", "text": "done"}], "model": "m",
-                         "usage": {"input_tokens": 6, "output_tokens": 1}}},
+            {
+                "type": "assistant",
+                "parent_tool_use_id": None,
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "hi"},
+                        {"type": "tool_use", "id": "t1", "name": "tool_x", "input": {}},
+                    ],
+                    "model": "m",
+                    "usage": {"input_tokens": 5, "output_tokens": 2},
+                },
+            },
+            {
+                "type": "user",
+                "parent_tool_use_id": None,
+                "message": {
+                    "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
+                },
+            },
+            {
+                "type": "assistant",
+                "parent_tool_use_id": None,
+                "message": {
+                    "content": [{"type": "text", "text": "done"}],
+                    "model": "m",
+                    "usage": {"input_tokens": 6, "output_tokens": 1},
+                },
+            },
             {"type": "result", "result": "final", "usage": None},
         ]
         mod = types.ModuleType("claude_agent_sdk")
-        mod.query = lambda *, prompt=None, options=None: FakeQuery(msgs)   # returns an OBJECT
+        mod.query = lambda *, prompt=None, options=None: FakeQuery(msgs)  # returns an OBJECT
         mod.ClaudeSDKClient = None
         monkeypatch.setitem(sys.modules, "claude_agent_sdk", mod)
         import neatlogs.claude_agent_sdk as c
+
         c._PATCHED = False
         c._ORIGINALS.clear()
 
@@ -449,7 +636,9 @@ class TestQueryObjectShape:
         spans = in_memory_span_exporter.get_finished_spans()
         # the WHOLE stream must be traced (the bug lost everything after the first span)
         assert len(_kinds(spans, "agent")) == 1
-        assert len(_kinds(spans, "llm")) == 2, "Query-object iteration dropped LLM spans (the live bug)"
+        assert (
+            len(_kinds(spans, "llm")) == 2
+        ), "Query-object iteration dropped LLM spans (the live bug)"
         assert len(_kinds(spans, "tool")) == 1, "Query-object iteration dropped TOOL spans"
         c._unpatch_claude_agent_sdk()
         c._PATCHED = False

--- a/tests/integration/test_hermes_instrumentation.py
+++ b/tests/integration/test_hermes_instrumentation.py
@@ -11,7 +11,6 @@ import sys
 import types
 
 import pytest
-
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -24,6 +23,7 @@ def _setup_tracer(exporter):
     # Reset the process-global wrapper-tracer cache so each test binds to its
     # own provider (correct in production; leaks across tests otherwise).
     import neatlogs._wrap_utils as _wu
+
     _wu._wrapper_tracer = None
     return provider
 
@@ -63,6 +63,7 @@ def fake_hermes(monkeypatch):
 
     # Reset the neatlogs.hermes patch flag so each test patches fresh classes.
     import neatlogs.hermes as h
+
     h._PATCHED = False
     yield {"AIAgent": AIAgent, "ToolRegistry": ToolRegistry}
     h._PATCHED = False

--- a/tests/integration/test_langchain_instrumentation.py
+++ b/tests/integration/test_langchain_instrumentation.py
@@ -188,10 +188,7 @@ class TestLangChainInstrumentation:
 
         # The traced LLM call should carry the response output.
         llm_output = " ".join(
-            str(v)
-            for s in llm_spans
-            for k, v in s.attributes.items()
-            if "output" in k.lower()
+            str(v) for s in llm_spans for k, v in s.attributes.items() if "output" in k.lower()
         ).lower()
         assert "test response" in llm_output
 
@@ -394,13 +391,12 @@ class TestLangChainInstrumentation:
             except ImportError:
                 pytest.skip("RetrievalQA not available")
 
-        from langchain_openai import ChatOpenAI, OpenAIEmbeddings
-
         # A real (tiny) BaseRetriever returning fixed docs. RetrievalQA validates
         # that `retriever` is a BaseRetriever instance (pydantic), so a bare Mock is
         # rejected — use a real subclass that avoids any actual vector DB dependency.
         from langchain_core.documents import Document
         from langchain_core.retrievers import BaseRetriever
+        from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
         fixed_docs = [
             Document(

--- a/tests/integration/test_openai_agents_instrumentation.py
+++ b/tests/integration/test_openai_agents_instrumentation.py
@@ -56,9 +56,7 @@ def create_mock_response(content=None, tool_calls=None):
                 "id": "msg_mock",
                 "role": "assistant",
                 "status": "completed",
-                "content": [
-                    {"type": "output_text", "text": content, "annotations": []}
-                ],
+                "content": [{"type": "output_text", "text": content, "annotations": []}],
             }
         )
 
@@ -286,8 +284,7 @@ class TestOpenAIAgentsInstrumentation:
         # Check for the dedicated handoff span (kind=agent, name contains 'handoff',
         # or carries the handoff_from attribute).
         assert any(
-            "handoff" in s.name.lower()
-            or any("handoff" in k.lower() for k in s.attributes)
+            "handoff" in s.name.lower() or any("handoff" in k.lower() for k in s.attributes)
             for s in spans
         ), "Handoff span missing"
 

--- a/tests/integration/test_openai_instrumentation.py
+++ b/tests/integration/test_openai_instrumentation.py
@@ -44,6 +44,7 @@ class TestOpenAIInstrumentation:
         # The neatlogs wrapper caches its Tracer process-globally; clear it so it
         # rebinds to THIS test's provider (parity with the other wrapper tests).
         import neatlogs._wrap_utils as _wu
+
         _wu._wrapper_tracer = None
 
         # 2. Initialize neatlogs (mocking preventing real network calls)

--- a/tests/integration/test_openrouter_instrumentation.py
+++ b/tests/integration/test_openrouter_instrumentation.py
@@ -10,7 +10,6 @@ reads for model settings.
 from types import SimpleNamespace
 
 import pytest
-
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -21,6 +20,7 @@ def _setup_tracer(exporter):
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
     import neatlogs._wrap_utils as _wu
+
     _wu._wrapper_tracer = None
     return provider
 
@@ -49,7 +49,9 @@ class TestOpenRouterChat:
                     SimpleNamespace(
                         index=0,
                         finish_reason="stop",
-                        message=SimpleNamespace(role="assistant", content="Hello from OpenRouter", tool_calls=None),
+                        message=SimpleNamespace(
+                            role="assistant", content="Hello from OpenRouter", tool_calls=None
+                        ),
                     )
                 ],
                 usage=SimpleNamespace(prompt_tokens=16, completion_tokens=8, total_tokens=24),
@@ -87,6 +89,7 @@ class TestOpenRouterChat:
         assert attrs.get("neatlogs.llm.top_p") == 0.9
         assert attrs.get("neatlogs.llm.max_tokens") == 256
         import json
+
         blob = json.loads(attrs.get("neatlogs.llm.invocation_parameters"))
         assert blob == {"temperature": 0.3, "top_p": 0.9, "max_tokens": 256}
 
@@ -100,11 +103,16 @@ class TestOpenRouterChat:
             return SimpleNamespace(model="openai/gpt-4o-mini", choices=[choice], usage=usage)
 
         def send(**kwargs):
-            return iter([
-                _chunk("Hello"),
-                _chunk(" world"),
-                _chunk(finish="stop", usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8)),
-            ])
+            return iter(
+                [
+                    _chunk("Hello"),
+                    _chunk(" world"),
+                    _chunk(
+                        finish="stop",
+                        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+                    ),
+                ]
+            )
 
         client = _fake_client(chat=send)
         wrap_openrouter_client(client)
@@ -127,6 +135,7 @@ class TestOpenRouterChat:
         assert attrs.get("neatlogs.llm.token_count.completion") == 3
         assert attrs.get("neatlogs.llm.finish_reason") == "stop"
         import json
+
         assert json.loads(attrs.get("neatlogs.llm.invocation_parameters")) == {"temperature": 0.5}
 
 
@@ -159,7 +168,10 @@ class TestOpenRouterResponses:
         # max_output_tokens normalizes to the max_tokens individual attr + blob.
         assert attrs.get("neatlogs.llm.max_tokens") == 128
         import json
-        assert json.loads(attrs.get("neatlogs.llm.invocation_parameters")) == {"max_output_tokens": 128}
+
+        assert json.loads(attrs.get("neatlogs.llm.invocation_parameters")) == {
+            "max_output_tokens": 128
+        }
 
 
 class TestOpenRouterEmbeddingsRerank:
@@ -191,8 +203,12 @@ class TestOpenRouterEmbeddingsRerank:
             return SimpleNamespace(
                 model="cohere/rerank-v3.5",
                 results=[
-                    SimpleNamespace(index=1, relevance_score=0.9, document=SimpleNamespace(text="doc B")),
-                    SimpleNamespace(index=0, relevance_score=0.2, document=SimpleNamespace(text="doc A")),
+                    SimpleNamespace(
+                        index=1, relevance_score=0.9, document=SimpleNamespace(text="doc B")
+                    ),
+                    SimpleNamespace(
+                        index=0, relevance_score=0.2, document=SimpleNamespace(text="doc A")
+                    ),
                 ],
             )
 

--- a/tests/integration/test_vertex_ai_instrumentation.py
+++ b/tests/integration/test_vertex_ai_instrumentation.py
@@ -8,7 +8,6 @@ Vertex mode with provider="vertex_ai" / system="vertexai".
 from types import SimpleNamespace
 
 import pytest
-
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -22,6 +21,7 @@ def _setup_tracer(exporter):
     # (the cache is process-global and correct in production, where init() sets
     # the provider once, but leaks across tests).
     import neatlogs._wrap_utils as _wu
+
     _wu._wrapper_tracer = None
     return provider
 
@@ -90,7 +90,9 @@ class TestVertexAIInstrumentation:
         def generate_content(*args, **kwargs):
             raise RuntimeError("vertex boom")
 
-        client = SimpleNamespace(vertexai=True, models=SimpleNamespace(generate_content=generate_content))
+        client = SimpleNamespace(
+            vertexai=True, models=SimpleNamespace(generate_content=generate_content)
+        )
         wrap_vertex_ai_client(client)
 
         with pytest.raises(RuntimeError):

--- a/tests/integration/test_wrapper_hierarchy_live.py
+++ b/tests/integration/test_wrapper_hierarchy_live.py
@@ -21,7 +21,6 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-
 # ---------------------------------------------------------------------------
 # Key loading + fixtures
 # ---------------------------------------------------------------------------
@@ -41,7 +40,13 @@ def _load_keys() -> None:
                     continue
                 k, _, v = line.partition("=")
                 k, v = k.strip(), v.strip().strip('"').strip("'")
-                if k in _WANT_KEYS and k not in os.environ and v and "your-" not in v and "xxx" not in v.lower():
+                if (
+                    k in _WANT_KEYS
+                    and k not in os.environ
+                    and v
+                    and "your-" not in v
+                    and "xxx" not in v.lower()
+                ):
                     os.environ[k] = v
         except OSError:
             continue
@@ -60,6 +65,7 @@ def _exporter():
     # The neatlogs wrapper caches a tracer from the first provider it sees; reset
     # it so each test's spans flow into this test's exporter.
     import neatlogs._wrap_utils as wu
+
     wu._wrapper_tracer = None
     return exp, prov
 
@@ -77,17 +83,31 @@ def _kinds(exp):
 
 def _names(exp):
     from collections import Counter
-    return Counter(s.name for s in exp.get_finished_spans() if s.attributes.get("neatlogs.span.kind"))
+
+    return Counter(
+        s.name for s in exp.get_finished_spans() if s.attributes.get("neatlogs.span.kind")
+    )
 
 
 def _trace_count(exp):
-    return len({s.context.trace_id for s in exp.get_finished_spans() if s.attributes.get("neatlogs.span.kind")})
+    return len(
+        {
+            s.context.trace_id
+            for s in exp.get_finished_spans()
+            if s.attributes.get("neatlogs.span.kind")
+        }
+    )
 
 
-needs_openai = pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
-needs_anthropic = pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set")
+needs_openai = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
+)
+needs_anthropic = pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set"
+)
 needs_google = pytest.mark.skipif(
-    not (os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")), reason="GOOGLE/GEMINI key not set"
+    not (os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")),
+    reason="GOOGLE/GEMINI key not set",
 )
 
 OPENAI_MODEL = "gpt-4o-mini"
@@ -102,12 +122,20 @@ GEMINI_MODEL = "gemini-2.5-flash"
 @needs_openai
 def test_openai_resources():
     exp, _ = _exporter()
-    import neatlogs
     import openai
 
+    import neatlogs
+
     c = neatlogs.wrap(openai.OpenAI())
-    c.chat.completions.create(model=OPENAI_MODEL, messages=[{"role": "user", "content": "hi"}], max_tokens=5)
-    for _ in c.chat.completions.create(model=OPENAI_MODEL, messages=[{"role": "user", "content": "count to 3"}], max_tokens=10, stream=True):
+    c.chat.completions.create(
+        model=OPENAI_MODEL, messages=[{"role": "user", "content": "hi"}], max_tokens=5
+    )
+    for _ in c.chat.completions.create(
+        model=OPENAI_MODEL,
+        messages=[{"role": "user", "content": "count to 3"}],
+        max_tokens=10,
+        stream=True,
+    ):
         pass
     c.embeddings.create(model="text-embedding-3-small", input="hello")
 
@@ -120,13 +148,19 @@ def test_openai_resources():
 @needs_anthropic
 def test_anthropic_resources():
     exp, _ = _exporter()
-    import neatlogs
     import anthropic
+
+    import neatlogs
 
     model = "claude-haiku-4-5-20251001"
     c = neatlogs.wrap(anthropic.Anthropic())
     c.messages.create(model=model, max_tokens=10, messages=[{"role": "user", "content": "hi"}])
-    for _ in c.messages.create(model=model, max_tokens=10, messages=[{"role": "user", "content": "count to 3"}], stream=True):
+    for _ in c.messages.create(
+        model=model,
+        max_tokens=10,
+        messages=[{"role": "user", "content": "count to 3"}],
+        stream=True,
+    ):
         pass
     c.messages.count_tokens(model=model, messages=[{"role": "user", "content": "hello there"}])
 
@@ -138,8 +172,9 @@ def test_anthropic_resources():
 @needs_google
 def test_google_genai_resources():
     exp, _ = _exporter()
-    import neatlogs
     from google import genai
+
+    import neatlogs
 
     c = neatlogs.wrap(genai.Client())
     c.models.generate_content(model=GEMINI_MODEL, contents="say hi")
@@ -161,8 +196,9 @@ def test_google_genai_resources():
 @needs_openai
 def test_dspy_hierarchy():
     exp, _ = _exporter()
-    import neatlogs
     import dspy
+
+    import neatlogs
 
     neatlogs.wrap(dspy.Predict("question -> answer"))
     dspy.configure(lm=dspy.LM(f"openai/{OPENAI_MODEL}", max_tokens=100))
@@ -177,8 +213,9 @@ def test_dspy_hierarchy():
 @needs_openai
 def test_pydantic_ai_hierarchy():
     exp, _ = _exporter()
-    import neatlogs
     from pydantic_ai import Agent
+
+    import neatlogs
 
     agent = Agent(f"openai:{OPENAI_MODEL}")
 
@@ -188,7 +225,9 @@ def test_pydantic_ai_hierarchy():
         return "ZX-9981-QQ"
 
     neatlogs.wrap(agent)
-    agent.run_sync("Get the secret access code for 'mainframe' using the tool. Return only the code.")
+    agent.run_sync(
+        "Get the secret access code for 'mainframe' using the tool. Return only the code."
+    )
 
     kinds = set(_kinds(exp))
     assert {"AGENT", "LLM", "TOOL"} <= kinds
@@ -200,19 +239,29 @@ def test_pydantic_ai_hierarchy():
 def test_crewai_hierarchy():
     exp, _ = _exporter()
     os.environ["CREWAI_TRACING_ENABLED"] = "false"
-    import neatlogs
-    from crewai import Agent, Task, Crew
+    from crewai import Agent, Crew, Task
     from crewai.tools import tool
+
+    import neatlogs
 
     @tool("get_secret_code")
     def get_secret_code(item: str) -> str:
         "Returns the secret access code for a given item."
         return "ZX-9981-QQ"
 
-    ag = Agent(role="lookup", goal="find codes via tools", backstory="x",
-               tools=[get_secret_code], llm=OPENAI_MODEL, verbose=False)
-    tk = Task(description="Find the secret access code for 'mainframe' using the tool. Return only the code.",
-              expected_output="code", agent=ag)
+    ag = Agent(
+        role="lookup",
+        goal="find codes via tools",
+        backstory="x",
+        tools=[get_secret_code],
+        llm=OPENAI_MODEL,
+        verbose=False,
+    )
+    tk = Task(
+        description="Find the secret access code for 'mainframe' using the tool. Return only the code.",
+        expected_output="code",
+        agent=ag,
+    )
     crew = Crew(agents=[ag], tasks=[tk], verbose=False)
     neatlogs.wrap(crew)
     crew.kickoff()
@@ -225,8 +274,9 @@ def test_crewai_hierarchy():
 @needs_openai
 def test_openai_agents_hierarchy():
     exp, _ = _exporter()
-    import neatlogs
     from agents import Agent, Runner, function_tool, set_trace_processors
+
+    import neatlogs
 
     set_trace_processors([neatlogs.openai_agents_processor()])
 
@@ -235,8 +285,15 @@ def test_openai_agents_hierarchy():
         "Return the secret access code for an item."
         return "ZX-9981-QQ"
 
-    agent = Agent(name="lookup", instructions="Use tools to answer.", tools=[get_secret_code], model=OPENAI_MODEL)
-    Runner.run_sync(agent, "Secret access code for 'mainframe'? Use the tool, return only the code.")
+    agent = Agent(
+        name="lookup",
+        instructions="Use tools to answer.",
+        tools=[get_secret_code],
+        model=OPENAI_MODEL,
+    )
+    Runner.run_sync(
+        agent, "Secret access code for 'mainframe'? Use the tool, return only the code."
+    )
 
     kinds = set(_kinds(exp))
     assert {"WORKFLOW", "AGENT", "LLM", "TOOL"} <= kinds
@@ -246,10 +303,11 @@ def test_openai_agents_hierarchy():
 @needs_openai
 def test_langchain_hierarchy():
     exp, _ = _exporter()
-    import neatlogs
-    from langchain_openai import ChatOpenAI
     from langchain_core.tools import tool
+    from langchain_openai import ChatOpenAI
     from langgraph.prebuilt import create_react_agent
+
+    import neatlogs
 
     @tool
     def get_secret_code(item: str) -> str:
@@ -259,7 +317,11 @@ def test_langchain_hierarchy():
     agent = create_react_agent(ChatOpenAI(model=OPENAI_MODEL, temperature=0), [get_secret_code])
     handler = neatlogs.langchain_handler()
     agent.invoke(
-        {"messages": [("user", "Secret access code for 'mainframe'? Use the tool, return only the code.")]},
+        {
+            "messages": [
+                ("user", "Secret access code for 'mainframe'? Use the tool, return only the code.")
+            ]
+        },
         config={"callbacks": [handler]},
     )
 
@@ -270,5 +332,6 @@ def test_langchain_hierarchy():
     # the dominant trace holds the chain root + most spans rather than ==1.
     spans = [s for s in exp.get_finished_spans() if s.attributes.get("neatlogs.span.kind")]
     from collections import Counter
+
     dominant = Counter(s.context.trace_id for s in spans).most_common(1)[0][1]
     assert dominant >= len(spans) - 2

--- a/tests/unit/test_google_genai_content_roles.py
+++ b/tests/unit/test_google_genai_content_roles.py
@@ -12,7 +12,6 @@ import json
 
 from neatlogs.google_genai import _normalize_content_item, _text_from_parts
 
-
 # --- lightweight stand-ins for typed genai objects (no SDK needed) ----------
 
 
@@ -46,9 +45,7 @@ def test_plain_string_is_user():
 
 
 def test_dict_content_keeps_role_and_text():
-    assert _normalize_content_item(
-        {"role": "model", "parts": [{"text": "hi"}]}
-    ) == ("model", "hi")
+    assert _normalize_content_item({"role": "model", "parts": [{"text": "hi"}]}) == ("model", "hi")
 
 
 def test_typed_content_user_role_and_text():

--- a/tests/unit/test_mask_application.py
+++ b/tests/unit/test_mask_application.py
@@ -24,6 +24,7 @@ from neatlogs.core.span_processor import NeatlogsSpanProcessor
 
 class _MutableAttrs(dict):
     """Stand-in for OTel BoundedAttributes: a mutable mapping."""
+
     _immutable = False
 
 
@@ -31,9 +32,7 @@ def _make_span(attrs, name="child", trace_id=0x1, span_id=0x2, parent_id=None):
     """Minimal ReadableSpan-like object the processor's on_end reads from."""
     ctx = SimpleNamespace(trace_id=trace_id, span_id=span_id)
     parent = SimpleNamespace(span_id=parent_id) if parent_id is not None else None
-    status = SimpleNamespace(
-        status_code=SimpleNamespace(name="OK"), description=None
-    )
+    status = SimpleNamespace(status_code=SimpleNamespace(name="OK"), description=None)
     scope = SimpleNamespace(name="neatlogs.test")
     a = _MutableAttrs(attrs)
     return SimpleNamespace(
@@ -61,17 +60,20 @@ def _counting_mask(counter, tag):
             if isinstance(v, str) and any(h in k.lower() for h in ("input", "output", "value")):
                 attrs[k] = f"[{tag}#{counter['n']}]" + v
         return span
+
     return mask
 
 
 def test_global_mask_applied_once_and_exported():
     counter = {"n": 0}
     proc = NeatlogsSpanProcessor(mask=_counting_mask(counter, "G"))
-    span = _make_span({
-        "openinference.span.kind": "CHAIN",
-        "input.value": "IN",
-        "output.value": "OUT",
-    })
+    span = _make_span(
+        {
+            "openinference.span.kind": "CHAIN",
+            "input.value": "IN",
+            "output.value": "OUT",
+        }
+    )
     proc.on_end(span)
 
     assert counter["n"] == 1, f"global mask applied {counter['n']}x, expected 1"
@@ -85,17 +87,20 @@ def test_per_span_mask_without_global_reaches_export():
     counter = {"n": 0}
     proc = NeatlogsSpanProcessor(mask=None)  # no global mask
     mask_id = register_mask(_counting_mask(counter, "S"))
-    span = _make_span({
-        "openinference.span.kind": "CHAIN",
-        "neatlogs.mask_id": mask_id,
-        "input.value": "IN",
-        "output.value": "OUT",
-    })
+    span = _make_span(
+        {
+            "openinference.span.kind": "CHAIN",
+            "neatlogs.mask_id": mask_id,
+            "input.value": "IN",
+            "output.value": "OUT",
+        }
+    )
     proc.on_end(span)
 
     assert counter["n"] == 1, f"per-span mask applied {counter['n']}x, expected 1"
-    assert span._attributes["input.value"] == "[S#1]IN", \
-        "per-span mask did not reach the exported span"
+    assert (
+        span._attributes["input.value"] == "[S#1]IN"
+    ), "per-span mask did not reach the exported span"
     assert span._attributes["output.value"] == "[S#1]OUT"
 
 
@@ -103,11 +108,13 @@ def test_per_span_mask_takes_precedence_over_global():
     gcount, scount = {"n": 0}, {"n": 0}
     proc = NeatlogsSpanProcessor(mask=_counting_mask(gcount, "G"))
     mask_id = register_mask(_counting_mask(scount, "S"))
-    span = _make_span({
-        "openinference.span.kind": "CHAIN",
-        "neatlogs.mask_id": mask_id,
-        "input.value": "IN",
-    })
+    span = _make_span(
+        {
+            "openinference.span.kind": "CHAIN",
+            "neatlogs.mask_id": mask_id,
+            "input.value": "IN",
+        }
+    )
     proc.on_end(span)
 
     assert scount["n"] == 1, "per-span mask should run exactly once"
@@ -117,14 +124,17 @@ def test_per_span_mask_takes_precedence_over_global():
 
 def test_no_mask_leaves_values_untouched():
     proc = NeatlogsSpanProcessor(mask=None)
-    span = _make_span({
-        "openinference.span.kind": "CHAIN",
-        "input.value": "IN",
-    })
+    span = _make_span(
+        {
+            "openinference.span.kind": "CHAIN",
+            "input.value": "IN",
+        }
+    )
     proc.on_end(span)
     assert span._attributes["input.value"] == "IN"
 
 
 if __name__ == "__main__":
     import sys
+
     sys.exit(pytest.main([__file__, "-v", "-p", "no:logfire"]))

--- a/tests/unit/test_openinference_isolation.py
+++ b/tests/unit/test_openinference_isolation.py
@@ -1,10 +1,10 @@
+from openinference.instrumentation import OITracer, TraceConfig
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace.propagation import _SPAN_KEY
-from openinference.instrumentation import OITracer, TraceConfig
 
 from neatlogs._wrap_utils import set_neatlogs_provider
 from neatlogs.instrumentation.openinference_isolation import (

--- a/tests/unit/test_propagation_isolation.py
+++ b/tests/unit/test_propagation_isolation.py
@@ -6,17 +6,18 @@ The private-provider design promises two things at a service boundary:
   2. Neatlogs NEVER injects a co-tenant's span (Datadog/openlit/langfuse). When
      only a foreign span is active, inject is a no-op and the carrier is clean.
 """
+
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from neatlogs._wrap_utils import (
+    _has_active_recording_parent,
+    _neatlogs_root_kwargs,
     attach_as_current,
     detach,
     set_neatlogs_provider,
-    _has_active_recording_parent,
-    _neatlogs_root_kwargs,
 )
 from neatlogs.core.propagation import extract_trace_context, inject_trace_context
 

--- a/tests/unit/test_session_identity.py
+++ b/tests/unit/test_session_identity.py
@@ -35,9 +35,7 @@ def test_apply_session_attributes_root(tracer_provider, in_memory_span_exporter)
     assert spans[0].attributes.get(SESSION_ID_KEY) == "chat_123"
 
 
-def test_apply_session_attributes_non_root_ignored(
-    tracer_provider, in_memory_span_exporter
-):
+def test_apply_session_attributes_non_root_ignored(tracer_provider, in_memory_span_exporter):
     _install(tracer_provider)
     tracer = trace.get_tracer(__name__)
     with tracer.start_as_current_span("child") as span:
@@ -47,9 +45,7 @@ def test_apply_session_attributes_non_root_ignored(
     assert SESSION_ID_KEY not in spans[0].attributes
 
 
-def test_apply_session_attributes_empty_noop(
-    tracer_provider, in_memory_span_exporter
-):
+def test_apply_session_attributes_empty_noop(tracer_provider, in_memory_span_exporter):
     _install(tracer_provider)
     tracer = trace.get_tracer(__name__)
     with tracer.start_as_current_span("root") as span:
@@ -64,9 +60,7 @@ def test_apply_session_attributes_empty_noop(
 # ---------------------------------------------------------------------------
 
 
-def test_span_decorator_sets_session_on_root(
-    tracer_provider, in_memory_span_exporter
-):
+def test_span_decorator_sets_session_on_root(tracer_provider, in_memory_span_exporter):
     _install(tracer_provider)
 
     @neatlogs_span(kind="WORKFLOW", session_id="chat_123")
@@ -80,9 +74,7 @@ def test_span_decorator_sets_session_on_root(
     assert root.attributes.get(SESSION_ID_KEY) == "chat_123"
 
 
-def test_span_decorator_child_does_not_inherit_session(
-    tracer_provider, in_memory_span_exporter
-):
+def test_span_decorator_child_does_not_inherit_session(tracer_provider, in_memory_span_exporter):
     _install(tracer_provider)
 
     @neatlogs_span(kind="CHAIN")
@@ -144,9 +136,7 @@ def test_wrap_context_stamps_workflow_metadata_on_auto_root(
 
     class OpenAI:
         def __init__(self):
-            self.chat = SimpleNamespace(
-                completions=SimpleNamespace(create=self._create)
-            )
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
 
         def _create(self, **kwargs):
             return SimpleNamespace(
@@ -256,9 +246,7 @@ def test_processor_stamps_identify_on_bare_framework_root():
 
     with identify(session_id="conv_fw", end_user_id="u_fw"):
         # Mimic a framework auto-root: a plain root span, no apply_* call.
-        root = tracer.start_span(
-            "LangGraph", attributes={"neatlogs.span.kind": "workflow"}
-        )
+        root = tracer.start_span("LangGraph", attributes={"neatlogs.span.kind": "workflow"})
         root.end()
 
     root = next(s for s in exporter.get_finished_spans() if s.name == "LangGraph")
@@ -275,9 +263,7 @@ def test_processor_stamps_wrap_context_metadata_on_framework_root():
 
     class Framework:
         def run(self):
-            root = tracer.start_span(
-                "LangGraph", attributes={"neatlogs.span.kind": "workflow"}
-            )
+            root = tracer.start_span("LangGraph", attributes={"neatlogs.span.kind": "workflow"})
             root.end()
 
     wrapped = with_wrap_context(
@@ -314,12 +300,8 @@ def test_processor_skips_child_spans():
     tracer = trace.get_tracer(__name__)
 
     with identify(session_id="conv_fw"):
-        with tracer.start_as_current_span(
-            "root", attributes={"neatlogs.span.kind": "workflow"}
-        ):
-            with tracer.start_as_current_span(
-                "child", attributes={"neatlogs.span.kind": "LLM"}
-            ):
+        with tracer.start_as_current_span("root", attributes={"neatlogs.span.kind": "workflow"}):
+            with tracer.start_as_current_span("child", attributes={"neatlogs.span.kind": "LLM"}):
                 pass
 
     child = next(s for s in exporter.get_finished_spans() if s.name == "child")
@@ -332,9 +314,7 @@ def test_processor_noop_without_identify():
     _install(provider)
     tracer = trace.get_tracer(__name__)
 
-    with tracer.start_as_current_span(
-        "bare", attributes={"neatlogs.span.kind": "workflow"}
-    ):
+    with tracer.start_as_current_span("bare", attributes={"neatlogs.span.kind": "workflow"}):
         pass
 
     root = next(s for s in exporter.get_finished_spans() if s.name == "bare")


### PR DESCRIPTION
## Summary

Stabilizes the SDK CI workflow by separating formatting from the Python test matrix, pinning CI-only tools and direct unit-test dependencies, applying the repository formatter baseline, and documenting the maintenance workflow for future contributors.

## Problem / context

CI had been failing across Python 3.10-3.13 before unit tests ran. The failed runs showed Black rejecting 40 existing files. Because Black and isort were installed without version pins inside every matrix job, formatter releases could change the result over time and the same repository-wide formatting failure was repeated four times.

This is the CI follow-up to #64 and is intentionally separate from the released SDK change.

## What changed

- Applied Black 26.1.0 and isort 7.0.0 formatting to `neatlogs/` and `tests/`.
- Added `.github/requirements-lint.txt` with pinned formatter versions.
- Added `.github/requirements-test.txt` with direct unit-test dependencies pinned to versions recorded in `poetry.lock`.
- Moved Black and isort into one dedicated Python 3.13 lint job.
- Kept unit tests on Python 3.10, 3.11, 3.12, and 3.13.
- Updated checkout and setup-python actions to v7.
- Added `CONTRIBUTING.md` with local commands, formatter-baseline rules, CI pin maintenance, clean-environment verification, Python-matrix updates, troubleshooting, and the pre-review checklist.

## Impact

- User / SDK behavior: no intended runtime behavior change; source and test changes are formatter-only.
- Contributors: the full CI maintenance process is now documented in the repository.
- CI: formatting runs once, unit tests retain full supported-version coverage, and direct CI dependency resolution is more stable.
- Data / operations: no database, migration, deployment, or data impact.
- Security: no authentication, authorization, secret, or network behavior changes.

## Test plan

Fresh verification after rebasing onto current `main`:

- `black --check neatlogs tests` — 95 files unchanged
- `isort --check-only neatlogs tests` — passed
- `pytest -q tests/unit` on Python 3.13.12 — 90 passed
- `git diff --check` — passed
- Formatter reproduction audit — all 41 changed Python files exactly reproduced from `main` using the pinned Black and isort versions
- Semantic AST audit — zero non-import logical changes
- [GitHub Actions](https://github.com/neatlogs/neatlogs/actions/runs/30996598528) — lint and unit tests passed on Python 3.10, 3.11, 3.12, and 3.13

## Rollout / follow-ups

Merge-only CI and documentation change; no SDK release is required. Transitive pip dependencies are not fully locked, and the contributor guide documents how to handle a reproducible transitive dependency regression.

## Linear

No Linear issue; CI maintenance follow-up to #64.