### PR TITLE
fix(crewai): preserve tool telemetry fidelity

### DIFF
--- a/neatlogs/crewai.py
+++ b/neatlogs/crewai.py
@@ -45,6 +45,24 @@ _CLASS_HOOKS_INSTALLED = False
 _LLM_INPUT_CAPTURE_LIMIT = 1 * 1024 * 1024
 
 
+def _crewai_span_attributes(kind: str) -> dict[str, Any]:
+    return {
+        "neatlogs.span.kind": kind,
+        "neatlogs.framework": "crewai",
+    }
+
+
+def _serialize_crewai_io(value: Any) -> str:
+    """Serialize CrewAI tool I/O without discarding data before export."""
+    try:
+        return json.dumps(value, default=str, ensure_ascii=False)
+    except Exception:
+        try:
+            return str(value)
+        except Exception:
+            return f"<unserializable {type(value).__name__}>"
+
+
 def _shared_trace_kwargs() -> dict:
     """Context for the crewai.crew.kickoff root span.
 
@@ -211,7 +229,7 @@ def wrap_crewai(obj: Any) -> Any:
 
 
 def _get_crew_attributes(crew: Any) -> dict:
-    attrs = {"neatlogs.span.kind": "workflow"}
+    attrs = _crewai_span_attributes("workflow")
 
     name = getattr(crew, "name", None) or getattr(crew, "_name", None)
     if name:
@@ -550,7 +568,7 @@ def _patch_task_execute(task: Any) -> None:
         return
 
     def _attrs():
-        attrs = {"neatlogs.span.kind": "task"}
+        attrs = _crewai_span_attributes("task")
         task_id = getattr(task, "id", None)
         if task_id:
             attrs["neatlogs.task.id"] = str(task_id)
@@ -648,7 +666,7 @@ def _patch_agent_execute(agent: Any) -> None:
 
     def patched_execute_task(*args, **kwargs):
         tracer = get_tracer()
-        attrs = {"neatlogs.span.kind": "agent"}
+        attrs = _crewai_span_attributes("agent")
         role = getattr(agent, "role", "")
         if role:
             attrs["neatlogs.agent.role"] = role
@@ -691,7 +709,7 @@ def _patch_agent_execute(agent: Any) -> None:
 
 
 def _agent_span_attributes(agent: Any) -> dict:
-    attrs = {"neatlogs.span.kind": "agent"}
+    attrs = _crewai_span_attributes("agent")
     role = getattr(agent, "role", "")
     if role:
         attrs["neatlogs.agent.role"] = role
@@ -819,11 +837,14 @@ def _patch_flow_class(FlowCls: Any) -> None:
         return
 
     def _attrs(flow):
-        return {
-            "neatlogs.span.kind": "workflow",
-            "neatlogs.workflow.type": "flow",
-            "neatlogs.workflow.name": type(flow).__name__,
-        }
+        attrs = _crewai_span_attributes("workflow")
+        attrs.update(
+            {
+                "neatlogs.workflow.type": "flow",
+                "neatlogs.workflow.name": type(flow).__name__,
+            }
+        )
+        return attrs
 
     if "kickoff" in FlowCls.__dict__:
         orig = FlowCls.kickoff
@@ -937,16 +958,16 @@ def _patch_tool_run(ToolCls) -> None:
 
     def patched_run(self, *args, **kwargs):
         tracer = get_tracer()
-        attrs = {"neatlogs.span.kind": "tool"}
+        attrs = _crewai_span_attributes("tool")
         name = getattr(self, "name", None) or type(self).__name__
         attrs["neatlogs.tool.name"] = str(name)
         desc = getattr(self, "description", None)
         if desc:
             attrs["neatlogs.tool.description"] = str(desc)[:500]
         if kwargs:
-            attrs["input.value"] = serialize(kwargs)[:10000]
+            attrs["input.value"] = _serialize_crewai_io(kwargs)
         elif args:
-            attrs["input.value"] = serialize(args)[:10000]
+            attrs["input.value"] = _serialize_crewai_io(args)
 
         span = tracer.start_span(name=f"crewai.tool.{name}", attributes=attrs)
         token = attach_as_current(span)
@@ -958,7 +979,7 @@ def _patch_tool_run(ToolCls) -> None:
         finally:
             detach(token)
         if result is not None:
-            span.set_attribute("output.value", str(result)[:10000])
+            span.set_attribute("output.value", _serialize_crewai_io(result))
         span.set_status(StatusCode.OK)
         span.end()
         return result
@@ -988,13 +1009,14 @@ def _patch_structured_tool() -> None:
     def patched(self, *args, **kwargs):
         tracer = get_tracer()
         name = getattr(self, "name", None) or type(self).__name__
-        attrs = {"neatlogs.span.kind": "tool", "neatlogs.tool.name": str(name)}
+        attrs = _crewai_span_attributes("tool")
+        attrs["neatlogs.tool.name"] = str(name)
         desc = getattr(self, "description", None)
         if desc:
             attrs["neatlogs.tool.description"] = str(desc)[:500]
         payload = kwargs if kwargs else (args[0] if args else None)
         if payload is not None:
-            attrs["input.value"] = serialize(payload)[:10000]
+            attrs["input.value"] = _serialize_crewai_io(payload)
         span = tracer.start_span(name=f"crewai.tool.{name}", attributes=attrs)
         token = attach_as_current(span)
         try:
@@ -1005,7 +1027,7 @@ def _patch_structured_tool() -> None:
         finally:
             detach(token)
         if result is not None:
-            span.set_attribute("output.value", str(result)[:10000])
+            span.set_attribute("output.value", _serialize_crewai_io(result))
         span.set_status(StatusCode.OK)
         span.end()
         return result
@@ -1139,7 +1161,8 @@ def _patch_llm_call(LLM) -> None:
 
     def patched_call(self, messages, *args, **kwargs):
         tracer = get_tracer()
-        attrs = {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": "crewai"}
+        attrs = _crewai_span_attributes("llm")
+        attrs["neatlogs.llm.provider"] = "crewai"
         model = getattr(self, "model", None)
         if model:
             attrs["neatlogs.llm.model_name"] = str(model)

--- a/tests/unit/test_crewai_tool_fidelity.py
+++ b/tests/unit/test_crewai_tool_fidelity.py
@@ -1,0 +1,276 @@
+import importlib
+import json
+import sys
+import types
+from datetime import datetime, timezone
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import StatusCode
+
+import neatlogs
+
+
+def _install_test_tracer(in_memory_span_exporter) -> None:
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+    trace.set_tracer_provider(provider)
+    neatlogs.init(api_key="test-key", disable_export=True, instrumentations=[])
+
+
+def _crewai_module():
+    return importlib.import_module("neatlogs.crewai")
+
+
+def _finished_span(in_memory_span_exporter, name: str):
+    return next(span for span in in_memory_span_exporter.get_finished_spans() if span.name == name)
+
+
+def test_base_tool_preserves_long_structured_input_output_and_return_value(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+    input_tail = "TOOL_INPUT_TAIL_AFTER_10000"
+    output_tail = "TOOL_OUTPUT_TAIL_AFTER_10000"
+    received = {}
+    result = {"items": ["o" * 120_000, output_tail]}
+
+    class FakeTool:
+        name = "long_tool"
+        description = "Returns a long structured result"
+
+        def run(self, *args, **kwargs):
+            received["args"] = args
+            received["kwargs"] = kwargs
+            return result
+
+    crewai_instrumentation._patch_tool_run(FakeTool)
+    argument = {"query": f"{'i' * 120_000}{input_tail}"}
+    returned = FakeTool().run(payload=argument)
+
+    assert returned is result
+    assert received == {"args": (), "kwargs": {"payload": argument}}
+
+    tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.long_tool")
+    captured_input = tool_span.attributes["input.value"]
+    captured_output = tool_span.attributes["output.value"]
+    assert input_tail in captured_input
+    assert output_tail in captured_output
+    assert len(captured_input) > 100_000
+    assert len(captured_output) > 100_000
+    assert json.loads(captured_input) == {"payload": argument}
+    assert json.loads(captured_output) == result
+    assert tool_span.attributes["neatlogs.framework"] == "crewai"
+    assert tool_span.attributes["neatlogs.span.kind"] == "tool"
+
+
+def test_structured_tool_matches_base_tool_fidelity(in_memory_span_exporter, monkeypatch) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+    input_tail = "STRUCTURED_INPUT_TAIL_AFTER_10000"
+    output_tail = "STRUCTURED_OUTPUT_TAIL_AFTER_10000"
+    received = {}
+    result = {"content": f"{'r' * 12_000}{output_tail}"}
+
+    class FakeStructuredTool:
+        name = "structured_long_tool"
+        description = "Returns structured output"
+
+        def invoke(self, *args, **kwargs):
+            received["args"] = args
+            received["kwargs"] = kwargs
+            return result
+
+    crewai_module = types.ModuleType("crewai")
+    tools_module = types.ModuleType("crewai.tools")
+    structured_module = types.ModuleType("crewai.tools.structured_tool")
+    structured_module.CrewStructuredTool = FakeStructuredTool
+    tools_module.structured_tool = structured_module
+    crewai_module.tools = tools_module
+    monkeypatch.setitem(sys.modules, "crewai", crewai_module)
+    monkeypatch.setitem(sys.modules, "crewai.tools", tools_module)
+    monkeypatch.setitem(sys.modules, "crewai.tools.structured_tool", structured_module)
+
+    crewai_instrumentation._patch_structured_tool()
+    payload = {"query": f"{'q' * 12_000}{input_tail}"}
+    returned = FakeStructuredTool().invoke(payload)
+
+    assert returned is result
+    assert received == {"args": (payload,), "kwargs": {}}
+    tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.structured_long_tool")
+    assert input_tail in tool_span.attributes["input.value"]
+    assert output_tail in tool_span.attributes["output.value"]
+    assert json.loads(tool_span.attributes["input.value"]) == payload
+    assert json.loads(tool_span.attributes["output.value"]) == result
+    assert tool_span.attributes["neatlogs.framework"] == "crewai"
+
+
+@pytest.mark.parametrize("result", [[], {}, ""])
+def test_base_tool_captures_empty_non_none_results(in_memory_span_exporter, result) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+
+    class EmptyResultTool:
+        name = f"empty_{type(result).__name__}"
+
+        def run(self):
+            return result
+
+    crewai_instrumentation._patch_tool_run(EmptyResultTool)
+    returned = EmptyResultTool().run()
+
+    assert returned is result
+    tool_span = _finished_span(in_memory_span_exporter, f"crewai.tool.{EmptyResultTool.name}")
+    assert "output.value" in tool_span.attributes
+    assert tool_span.attributes["output.value"] == json.dumps(result, ensure_ascii=False)
+
+
+def test_base_tool_serializes_non_json_native_values_without_changing_return(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+    timestamp = datetime(2026, 8, 6, 12, 30, tzinfo=timezone.utc)
+    result = {"created_at": timestamp}
+
+    class DatetimeTool:
+        name = "datetime_tool"
+
+        def run(self):
+            return result
+
+    crewai_instrumentation._patch_tool_run(DatetimeTool)
+    returned = DatetimeTool().run()
+
+    assert returned is result
+    tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.datetime_tool")
+    assert json.loads(tool_span.attributes["output.value"]) == {"created_at": str(timestamp)}
+
+
+def test_base_tool_serialization_failure_does_not_replace_business_result(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+
+    class BrokenString:
+        def __str__(self):
+            raise RuntimeError("telemetry serialization failed")
+
+    result = BrokenString()
+
+    class UnserializableTool:
+        name = "unserializable_tool"
+
+        def run(self):
+            return result
+
+    crewai_instrumentation._patch_tool_run(UnserializableTool)
+    returned = UnserializableTool().run()
+
+    assert returned is result
+    tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.unserializable_tool")
+    assert tool_span.status.status_code == StatusCode.OK
+
+
+def test_base_tool_preserves_exception_and_records_error_span(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+
+    class FailingTool:
+        name = "failing_tool"
+
+        def run(self):
+            raise RuntimeError("tool failed")
+
+    crewai_instrumentation._patch_tool_run(FailingTool)
+
+    with pytest.raises(RuntimeError, match="tool failed"):
+        FailingTool().run()
+
+    tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.failing_tool")
+    assert tool_span.status.status_code == StatusCode.ERROR
+    assert tool_span.attributes["neatlogs.framework"] == "crewai"
+
+
+def test_representative_crewai_span_kinds_include_framework_identity(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+
+    class Result:
+        raw = "ok"
+
+    class FakeCrew:
+        tasks = []
+        agents = []
+
+        def kickoff(self):
+            return Result()
+
+    class FakeFlow:
+        state = {"ready": True}
+
+        def kickoff(self):
+            return {"done": True}
+
+    class FakeTask:
+        description = "task"
+
+        def _execute_core(self):
+            return Result()
+
+    class FakeAgent:
+        role = "researcher"
+        tools = []
+
+        def execute_task(self):
+            return "agent result"
+
+    class FakeTool:
+        name = "identity_tool"
+
+        def run(self):
+            return "tool result"
+
+    class FakeLlm:
+        model = "test-model"
+
+        def call(self, messages, *args, **kwargs):
+            return "llm result"
+
+    crewai_instrumentation._patch_crew_class(FakeCrew)
+    crewai_instrumentation._patch_flow_class(FakeFlow)
+    task = FakeTask()
+    crewai_instrumentation._patch_task_execute(task)
+    agent = FakeAgent()
+    crewai_instrumentation._patch_agent_execute(agent)
+    crewai_instrumentation._patch_tool_run(FakeTool)
+    crewai_instrumentation._patch_llm_call(FakeLlm)
+
+    FakeCrew().kickoff()
+    FakeFlow().kickoff()
+    task._execute_core()
+    agent.execute_task()
+    FakeTool().run()
+    FakeLlm().call([{"role": "user", "content": "hello"}])
+
+    expected_kinds = {
+        "crewai.crew.kickoff": "workflow",
+        "crewai.flow.kickoff": "workflow",
+        "crewai.task": "task",
+        "crewai.agent.researcher": "agent",
+        "crewai.tool.identity_tool": "tool",
+        "crewai.llm.call": "llm",
+    }
+    spans = {span.name: span for span in in_memory_span_exporter.get_finished_spans()}
+    for span_name, kind in expected_kinds.items():
+        span = spans[span_name]
+        assert span.attributes["neatlogs.framework"] == "crewai"
+        assert span.attributes["neatlogs.span.kind"] == kind


### PR DESCRIPTION
## Summary

Preserve complete CrewAI tool inputs and outputs for backend payload handling, and add explicit CrewAI framework identity to SDK-created spans.

## Problem

The BaseTool and CrewStructuredTool wrappers sliced tool input and output at 10,000 characters before export. Long structured values became incomplete fragments, so the backend never received enough data to apply its payload and S3 policy. CrewAI wrapper spans also omitted `neatlogs.framework=crewai`.

## Changes

- serialize CrewAI tool I/O as full JSON with `default=str` and no 10k or shared 100k cutoff;
- preserve original return values and exception behavior even when telemetry serialization fails;
- use the same capture policy for BaseTool and CrewStructuredTool;
- add `neatlogs.framework=crewai` to Crew, Flow, Task, Agent, Tool, and LLM wrapper spans;
- add regression coverage for input/output beyond 100k, structured-tool parity, empty results, datetime fallback, serialization failure, errors, and representative framework markers.

## Validation

- `pytest -q tests/unit`: 98 passed
- `pytest -q tests/unit/test_crewai_tool_fidelity.py`: 9 passed
- `black --check neatlogs tests`: passed
- `isort --check-only neatlogs tests`: passed
- `git diff --check`: passed
- CrewAI integration suite: 19 passed, 1 failed because locked CrewAI 1.5.0 does not expose `Crew.akickoff`; the failing test is unchanged by this PR.

## Cross-repository acceptance required before release

This PR is intentionally a draft. Adding the explicit CrewAI marker may activate the backend framework-specific finalizer path. Before merge/release, validate a representative WORKFLOW -> AGENT -> LLM -> TOOL trace against the backend finalizer and confirm both full tool output and the complete user task remain visible. The backend repository is not among the repositories visible to the authenticated `khushalkumar` GitHub account, so that acceptance could not be run here.

## Additional audit findings outside this PR

- 14 explicit 10k slices remain across Crew, Task, Agent, Flow, and LLM paths.
- Consolidated CrewAI LLM `input.value` still uses the shared 100k serializer; a 120k reproduction lost its tail and produced invalid JSON.
- Sync batch kickoff records `output.value`, while async batch kickoff does not.
- Crew/Flow input and Crew/Task output truthiness checks can omit or replace explicit empty values.
- The declared CrewAI and LiteLLM lower bounds resolve to an incompatible OpenAI dependency pair; the lockfile combination works, apart from the existing `akickoff` test mismatch.

## Release impact

- no schema migration;
- no version bump;
- no package publication;
- no change to tool business behavior;
- historical truncated traces cannot recover missing tails.
