### PR TITLE
fix(crewai): preserve tool telemetry fidelity

### DIFF
--- a/examples/sdk_examples/crewai_prompt_fidelity.py
+++ b/examples/sdk_examples/crewai_prompt_fidelity.py
@@ -35,6 +35,14 @@ AGENT_BACKSTORY = (
 PROMPT_START_MARKER = "PROMPT_FIDELITY_TASK_START"
 NEAR_10000_MARKER = "PROMPT_FIDELITY_NEAR_10000"
 TAIL_AFTER_12000_MARKER = "PROMPT_FIDELITY_TAIL_AFTER_12000"
+PROMPT_TARGET_TAIL_MARKER = "PROMPT_FIDELITY_TARGET_TAIL"
+
+TOOL_OUTPUT_START_MARKER = "TOOL_FIDELITY_OUTPUT_START"
+TOOL_NEAR_10000_MARKER = "TOOL_FIDELITY_NEAR_10000"
+TOOL_TAIL_AFTER_10000_MARKER = "TOOL_FIDELITY_TAIL_AFTER_10000"
+
+DEFAULT_PROMPT_TAIL_OFFSET = 12_000
+DEFAULT_TOOL_OUTPUT_CHARS = 12_500
 
 EXPECTED_OUTPUT = dedent("""
     {
@@ -83,7 +91,9 @@ def _render_task_description(document_json: str) -> str:
         """).strip()
 
 
-def build_long_task_description() -> str:
+def build_long_task_description(
+    target_tail_offset: int = DEFAULT_PROMPT_TAIL_OFFSET,
+) -> str:
     """Build a deterministic task with markers around the capture boundary."""
     probe_body = f"{PROMPT_START_MARKER}\n{NEAR_10000_MARKER}"
     probe_json = json.dumps(_synthetic_document(probe_body), sort_keys=True)
@@ -92,19 +102,60 @@ def build_long_task_description() -> str:
     if padding_length <= 0:
         raise AssertionError("The fixed task text already reaches the near marker")
 
-    long_body = (
+    base_long_body = (
         f"{PROMPT_START_MARKER}\n"
         f"{'x' * padding_length}{NEAR_10000_MARKER}\n"
         f"{'y' * 2_500}{TAIL_AFTER_12000_MARKER}"
+    )
+    target_probe_json = json.dumps(
+        _synthetic_document(f"{base_long_body}\n{PROMPT_TARGET_TAIL_MARKER}"),
+        sort_keys=True,
+    )
+    target_probe_prompt = _render_task_description(target_probe_json)
+    target_padding_length = max(
+        0,
+        target_tail_offset
+        - target_probe_prompt.index(PROMPT_TARGET_TAIL_MARKER),
+    )
+    long_body = (
+        f"{base_long_body}\n"
+        f"{'z' * target_padding_length}{PROMPT_TARGET_TAIL_MARKER}"
     )
     document_json = json.dumps(_synthetic_document(long_body), sort_keys=True)
     description = _render_task_description(document_json)
 
     near_offset = description.index(NEAR_10000_MARKER)
     tail_offset = description.index(TAIL_AFTER_12000_MARKER)
+    target_tail_actual_offset = description.index(PROMPT_TARGET_TAIL_MARKER)
     assert 9_500 < near_offset < 10_000
     assert tail_offset > 12_000
+    assert target_tail_actual_offset >= target_tail_offset
     return description
+
+
+def build_tool_fidelity_output(
+    target_chars: int = DEFAULT_TOOL_OUTPUT_CHARS,
+) -> str:
+    """Build a plain string whose final marker is beyond 10,000 characters."""
+    prefix = f"{TOOL_OUTPUT_START_MARKER}\n"
+    near_padding_length = 9_800 - len(prefix)
+    if near_padding_length <= 0:
+        raise AssertionError("The tool-output prefix already reaches the near marker")
+
+    through_near_marker = (
+        f"{prefix}{'u' * near_padding_length}{TOOL_NEAR_10000_MARKER}\n"
+    )
+    tail_padding_length = max(0, 10_050 - len(through_near_marker))
+    output = (
+        f"{through_near_marker}"
+        f"{'v' * tail_padding_length}{TOOL_TAIL_AFTER_10000_MARKER}"
+    )
+    if len(output) < target_chars:
+        output = f"{output}{'w' * (target_chars - len(output))}"
+
+    assert output.index(TOOL_NEAR_10000_MARKER) < 10_000
+    assert output.index(TOOL_TAIL_AFTER_10000_MARKER) > 10_000
+    return output
 
 
 def _load_runtime_environment() -> None:
@@ -121,6 +172,19 @@ def _first_env(*names: str) -> str:
         if value:
             return value
     raise SystemExit(f"Missing required environment variable; expected one of: {', '.join(names)}")
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be a positive integer") from exc
+    if value <= 0:
+        raise SystemExit(f"{name} must be a positive integer")
+    return value
 
 
 def setup_neatlogs() -> None:
@@ -149,11 +213,33 @@ def _build_llm():
 async def run_example() -> str:
     # These imports deliberately occur after setup_neatlogs().
     from crewai import Agent, Crew, Task
+    from crewai.tools import BaseTool
 
     run_id = os.getenv("CREWAI_PROMPT_RUN_ID", str(int(time.time())))
-    description = build_long_task_description()
+    run_label = os.getenv("CREWAI_FIDELITY_RUN_LABEL", "default")
+    prompt_target_offset = _positive_int_env(
+        "CREWAI_PROMPT_TARGET_CHARS",
+        DEFAULT_PROMPT_TAIL_OFFSET,
+    )
+    tool_output_chars = _positive_int_env(
+        "CREWAI_TOOL_OUTPUT_CHARS",
+        DEFAULT_TOOL_OUTPUT_CHARS,
+    )
+    description = build_long_task_description(prompt_target_offset)
     near_offset = description.index(NEAR_10000_MARKER)
     tail_offset = description.index(TAIL_AFTER_12000_MARKER)
+    target_tail_offset = description.index(PROMPT_TARGET_TAIL_MARKER)
+
+    class FidelityPayloadProbeTool(BaseTool):
+        name: str = "fidelity_payload_probe"
+        description: str = (
+            "Return a deterministic plain-text payload for telemetry fidelity checks."
+        )
+
+        def _run(self, target_chars: int = DEFAULT_TOOL_OUTPUT_CHARS) -> str:
+            return build_tool_fidelity_output(target_chars)
+
+    fidelity_tool = FidelityPayloadProbeTool()
 
     agent = Agent(
         role=AGENT_ROLE,
@@ -179,20 +265,32 @@ async def run_example() -> str:
             metadata={
                 "example": "crewai-long-prompt-fidelity",
                 "run_id": run_id,
+                "run_label": run_label,
                 "task_chars": len(description),
+                "tool_output_chars": tool_output_chars,
             },
         ) as trace_span:
             span_context = trace_span.get_span_context()
             trace_id = f"{span_context.trace_id:032x}"
+            tool_output = fidelity_tool.run(target_chars=tool_output_chars)
             result = await crew.kickoff_async()
     finally:
         neatlogs.flush()
         await asyncio.sleep(3)
 
     result_text = str(getattr(result, "raw", result))
+    tool_tail_offset = tool_output.index(TOOL_TAIL_AFTER_10000_MARKER)
+    print(f"run_label={run_label}")
     print(f"run_id={run_id}")
     print(f"trace_id={trace_id}")
-    print(f"task_chars={len(description)} near_offset={near_offset} " f"tail_offset={tail_offset}")
+    print(
+        f"task_chars={len(description)} near_offset={near_offset} "
+        f"tail_offset={tail_offset} target_tail_offset={target_tail_offset}"
+    )
+    print(
+        f"tool_output_chars={len(tool_output)} "
+        f"tool_tail_offset={tool_tail_offset}"
+    )
     print(f"result_preview={result_text[:120]!r}")
     return trace_id
 

--- a/examples/sdk_examples/crewai_prompt_fidelity.py
+++ b/examples/sdk_examples/crewai_prompt_fidelity.py
@@ -114,13 +114,9 @@ def build_long_task_description(
     target_probe_prompt = _render_task_description(target_probe_json)
     target_padding_length = max(
         0,
-        target_tail_offset
-        - target_probe_prompt.index(PROMPT_TARGET_TAIL_MARKER),
+        target_tail_offset - target_probe_prompt.index(PROMPT_TARGET_TAIL_MARKER),
     )
-    long_body = (
-        f"{base_long_body}\n"
-        f"{'z' * target_padding_length}{PROMPT_TARGET_TAIL_MARKER}"
-    )
+    long_body = f"{base_long_body}\n" f"{'z' * target_padding_length}{PROMPT_TARGET_TAIL_MARKER}"
     document_json = json.dumps(_synthetic_document(long_body), sort_keys=True)
     description = _render_task_description(document_json)
 
@@ -142,14 +138,9 @@ def build_tool_fidelity_output(
     if near_padding_length <= 0:
         raise AssertionError("The tool-output prefix already reaches the near marker")
 
-    through_near_marker = (
-        f"{prefix}{'u' * near_padding_length}{TOOL_NEAR_10000_MARKER}\n"
-    )
+    through_near_marker = f"{prefix}{'u' * near_padding_length}{TOOL_NEAR_10000_MARKER}\n"
     tail_padding_length = max(0, 10_050 - len(through_near_marker))
-    output = (
-        f"{through_near_marker}"
-        f"{'v' * tail_padding_length}{TOOL_TAIL_AFTER_10000_MARKER}"
-    )
+    output = f"{through_near_marker}" f"{'v' * tail_padding_length}{TOOL_TAIL_AFTER_10000_MARKER}"
     if len(output) < target_chars:
         output = f"{output}{'w' * (target_chars - len(output))}"
 
@@ -287,10 +278,7 @@ async def run_example() -> str:
         f"task_chars={len(description)} near_offset={near_offset} "
         f"tail_offset={tail_offset} target_tail_offset={target_tail_offset}"
     )
-    print(
-        f"tool_output_chars={len(tool_output)} "
-        f"tool_tail_offset={tool_tail_offset}"
-    )
+    print(f"tool_output_chars={len(tool_output)} " f"tool_tail_offset={tool_tail_offset}")
     print(f"result_preview={result_text[:120]!r}")
     return trace_id
 

--- a/neatlogs/crewai.py
+++ b/neatlogs/crewai.py
@@ -54,6 +54,8 @@ def _crewai_span_attributes(kind: str) -> dict[str, Any]:
 
 def _serialize_crewai_io(value: Any) -> str:
     """Serialize CrewAI tool I/O without discarding data before export."""
+    if isinstance(value, str):
+        return value
     try:
         return json.dumps(value, default=str, ensure_ascii=False)
     except Exception:

--- a/neatlogs/crewai.py
+++ b/neatlogs/crewai.py
@@ -45,6 +45,24 @@ _CLASS_HOOKS_INSTALLED = False
 _LLM_INPUT_CAPTURE_LIMIT = 1 * 1024 * 1024
 
 
+def _crewai_span_attributes(kind: str) -> dict[str, Any]:
+    return {
+        "neatlogs.span.kind": kind,
+        "neatlogs.framework": "crewai",
+    }
+
+
+def _serialize_crewai_io(value: Any) -> str:
+    """Serialize CrewAI tool I/O without discarding data before export."""
+    try:
+        return json.dumps(value, default=str, ensure_ascii=False)
+    except Exception:
+        try:
+            return str(value)
+        except Exception:
+            return f"<unserializable {type(value).__name__}>"
+
+
 def _shared_trace_kwargs() -> dict:
     """Context for the crewai.crew.kickoff root span.
 
@@ -211,7 +229,7 @@ def wrap_crewai(obj: Any) -> Any:
 
 
 def _get_crew_attributes(crew: Any) -> dict:
-    attrs = {"neatlogs.span.kind": "workflow"}
+    attrs = _crewai_span_attributes("workflow")
 
     name = getattr(crew, "name", None) or getattr(crew, "_name", None)
     if name:
@@ -550,7 +568,7 @@ def _patch_task_execute(task: Any) -> None:
         return
 
     def _attrs():
-        attrs = {"neatlogs.span.kind": "task"}
+        attrs = _crewai_span_attributes("task")
         task_id = getattr(task, "id", None)
         if task_id:
             attrs["neatlogs.task.id"] = str(task_id)
@@ -648,7 +666,7 @@ def _patch_agent_execute(agent: Any) -> None:
 
     def patched_execute_task(*args, **kwargs):
         tracer = get_tracer()
-        attrs = {"neatlogs.span.kind": "agent"}
+        attrs = _crewai_span_attributes("agent")
         role = getattr(agent, "role", "")
         if role:
             attrs["neatlogs.agent.role"] = role
@@ -691,7 +709,7 @@ def _patch_agent_execute(agent: Any) -> None:
 
 
 def _agent_span_attributes(agent: Any) -> dict:
-    attrs = {"neatlogs.span.kind": "agent"}
+    attrs = _crewai_span_attributes("agent")
     role = getattr(agent, "role", "")
     if role:
         attrs["neatlogs.agent.role"] = role
@@ -819,11 +837,14 @@ def _patch_flow_class(FlowCls: Any) -> None:
         return
 
     def _attrs(flow):
-        return {
-            "neatlogs.span.kind": "workflow",
-            "neatlogs.workflow.type": "flow",
-            "neatlogs.workflow.name": type(flow).__name__,
-        }
+        attrs = _crewai_span_attributes("workflow")
+        attrs.update(
+            {
+                "neatlogs.workflow.type": "flow",
+                "neatlogs.workflow.name": type(flow).__name__,
+            }
+        )
+        return attrs
 
     if "kickoff" in FlowCls.__dict__:
         orig = FlowCls.kickoff
@@ -937,16 +958,16 @@ def _patch_tool_run(ToolCls) -> None:
 
     def patched_run(self, *args, **kwargs):
         tracer = get_tracer()
-        attrs = {"neatlogs.span.kind": "tool"}
+        attrs = _crewai_span_attributes("tool")
         name = getattr(self, "name", None) or type(self).__name__
         attrs["neatlogs.tool.name"] = str(name)
         desc = getattr(self, "description", None)
         if desc:
             attrs["neatlogs.tool.description"] = str(desc)[:500]
         if kwargs:
-            attrs["input.value"] = serialize(kwargs)[:10000]
+            attrs["input.value"] = _serialize_crewai_io(kwargs)
         elif args:
-            attrs["input.value"] = serialize(args)[:10000]
+            attrs["input.value"] = _serialize_crewai_io(args)
 
         span = tracer.start_span(name=f"crewai.tool.{name}", attributes=attrs)
         token = attach_as_current(span)
@@ -958,7 +979,7 @@ def _patch_tool_run(ToolCls) -> None:
         finally:
             detach(token)
         if result is not None:
-            span.set_attribute("output.value", str(result)[:10000])
+            span.set_attribute("output.value", _serialize_crewai_io(result))
         span.set_status(StatusCode.OK)
         span.end()
         return result
@@ -988,13 +1009,14 @@ def _patch_structured_tool() -> None:
     def patched(self, *args, **kwargs):
         tracer = get_tracer()
         name = getattr(self, "name", None) or type(self).__name__
-        attrs = {"neatlogs.span.kind": "tool", "neatlogs.tool.name": str(name)}
+        attrs = _crewai_span_attributes("tool")
+        attrs["neatlogs.tool.name"] = str(name)
         desc = getattr(self, "description", None)
         if desc:
             attrs["neatlogs.tool.description"] = str(desc)[:500]
         payload = kwargs if kwargs else (args[0] if args else None)
         if payload is not None:
-            attrs["input.value"] = serialize(payload)[:10000]
+            attrs["input.value"] = _serialize_crewai_io(payload)
         span = tracer.start_span(name=f"crewai.tool.{name}", attributes=attrs)
         token = attach_as_current(span)
         try:
@@ -1005,7 +1027,7 @@ def _patch_structured_tool() -> None:
         finally:
             detach(token)
         if result is not None:
-            span.set_attribute("output.value", str(result)[:10000])
+            span.set_attribute("output.value", _serialize_crewai_io(result))
         span.set_status(StatusCode.OK)
         span.end()
         return result
@@ -1139,7 +1161,8 @@ def _patch_llm_call(LLM) -> None:
 
     def patched_call(self, messages, *args, **kwargs):
         tracer = get_tracer()
-        attrs = {"neatlogs.span.kind": "llm", "neatlogs.llm.provider": "crewai"}
+        attrs = _crewai_span_attributes("llm")
+        attrs["neatlogs.llm.provider"] = "crewai"
         model = getattr(self, "model", None)
         if model:
             attrs["neatlogs.llm.model_name"] = str(model)

--- a/tests/unit/test_crewai_prompt_fidelity_example.py
+++ b/tests/unit/test_crewai_prompt_fidelity_example.py
@@ -1,19 +1,13 @@
 import importlib.util
 from pathlib import Path
 
-
 EXAMPLE_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "examples"
-    / "sdk_examples"
-    / "crewai_prompt_fidelity.py"
+    Path(__file__).resolve().parents[2] / "examples" / "sdk_examples" / "crewai_prompt_fidelity.py"
 )
 
 
 def _load_example():
-    spec = importlib.util.spec_from_file_location(
-        "crewai_prompt_fidelity_example", EXAMPLE_PATH
-    )
+    spec = importlib.util.spec_from_file_location("crewai_prompt_fidelity_example", EXAMPLE_PATH)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)

--- a/tests/unit/test_crewai_prompt_fidelity_example.py
+++ b/tests/unit/test_crewai_prompt_fidelity_example.py
@@ -1,0 +1,50 @@
+import importlib.util
+from pathlib import Path
+
+
+EXAMPLE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "examples"
+    / "sdk_examples"
+    / "crewai_prompt_fidelity.py"
+)
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location(
+        "crewai_prompt_fidelity_example", EXAMPLE_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_prompt_builder_places_configured_tail_after_100000() -> None:
+    example = _load_example()
+
+    description = example.build_long_task_description(target_tail_offset=100_000)
+
+    assert description.index(example.NEAR_10000_MARKER) < 10_000
+    assert description.index(example.PROMPT_TARGET_TAIL_MARKER) >= 100_000
+
+
+def test_tool_builder_returns_plain_string_with_tail_after_10000() -> None:
+    example = _load_example()
+
+    output = example.build_tool_fidelity_output(target_chars=12_500)
+
+    assert isinstance(output, str)
+    assert output.index(example.TOOL_NEAR_10000_MARKER) < 10_000
+    assert output.index(example.TOOL_TAIL_AFTER_10000_MARKER) > 10_000
+    assert len(output) >= 12_500
+
+
+def test_default_prompt_probe_remains_bounded() -> None:
+    example = _load_example()
+
+    description = example.build_long_task_description()
+
+    assert 12_000 < len(description) < 20_000
+    assert example.PROMPT_TARGET_TAIL_MARKER in description

--- a/tests/unit/test_crewai_tool_fidelity.py
+++ b/tests/unit/test_crewai_tool_fidelity.py
@@ -67,6 +67,28 @@ def test_base_tool_preserves_long_structured_input_output_and_return_value(
     assert tool_span.attributes["neatlogs.span.kind"] == "tool"
 
 
+def test_base_tool_preserves_plain_string_output_without_json_quotes(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+
+    class PlainStringTool:
+        name = "plain_string_tool"
+
+        def run(self):
+            return "plain tool result"
+
+    crewai_instrumentation._patch_tool_run(PlainStringTool)
+    returned = PlainStringTool().run()
+
+    assert returned == "plain tool result"
+    tool_span = _finished_span(
+        in_memory_span_exporter, "crewai.tool.plain_string_tool"
+    )
+    assert tool_span.attributes["output.value"] == "plain tool result"
+
+
 def test_structured_tool_matches_base_tool_fidelity(in_memory_span_exporter, monkeypatch) -> None:
     _install_test_tracer(in_memory_span_exporter)
     crewai_instrumentation = _crewai_module()
@@ -125,7 +147,8 @@ def test_base_tool_captures_empty_non_none_results(in_memory_span_exporter, resu
     assert returned is result
     tool_span = _finished_span(in_memory_span_exporter, f"crewai.tool.{EmptyResultTool.name}")
     assert "output.value" in tool_span.attributes
-    assert tool_span.attributes["output.value"] == json.dumps(result, ensure_ascii=False)
+    expected = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
+    assert tool_span.attributes["output.value"] == expected
 
 
 def test_base_tool_serializes_non_json_native_values_without_changing_return(

--- a/tests/unit/test_crewai_tool_fidelity.py
+++ b/tests/unit/test_crewai_tool_fidelity.py
@@ -1,0 +1,276 @@
+import importlib
+import json
+import sys
+import types
+from datetime import datetime, timezone
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import StatusCode
+
+import neatlogs
+
+
+def _install_test_tracer(in_memory_span_exporter) -> None:
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+    trace.set_tracer_provider(provider)
+    neatlogs.init(api_key="test-key", disable_export=True, instrumentations=[])
+
+
+def _crewai_module():
+    return importlib.import_module("neatlogs.crewai")
+
+
+def _finished_span(in_memory_span_exporter, name: str):
+    return next(span for span in in_memory_span_exporter.get_finished_spans() if span.name == name)
+
+
+def test_base_tool_preserves_long_structured_input_output_and_return_value(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+    input_tail = "TOOL_INPUT_TAIL_AFTER_10000"
+    output_tail = "TOOL_OUTPUT_TAIL_AFTER_10000"
+    received = {}
+    result = {"items": ["o" * 120_000, output_tail]}
+
+    class FakeTool:
+        name = "long_tool"
+        description = "Returns a long structured result"
+
+        def run(self, *args, **kwargs):
+            received["args"] = args
+            received["kwargs"] = kwargs
+            return result
+
+    crewai_instrumentation._patch_tool_run(FakeTool)
+    argument = {"query": f"{'i' * 120_000}{input_tail}"}
+    returned = FakeTool().run(payload=argument)
+
+    assert returned is result
+    assert received == {"args": (), "kwargs": {"payload": argument}}
+
+    tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.long_tool")
+    captured_input = tool_span.attributes["input.value"]
+    captured_output = tool_span.attributes["output.value"]
+    assert input_tail in captured_input
+    assert output_tail in captured_output
+    assert len(captured_input) > 100_000
+    assert len(captured_output) > 100_000
+    assert json.loads(captured_input) == {"payload": argument}
+    assert json.loads(captured_output) == result
+    assert tool_span.attributes["neatlogs.framework"] == "crewai"
+    assert tool_span.attributes["neatlogs.span.kind"] == "tool"
+
+
+def test_structured_tool_matches_base_tool_fidelity(in_memory_span_exporter, monkeypatch) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+    input_tail = "STRUCTURED_INPUT_TAIL_AFTER_10000"
+    output_tail = "STRUCTURED_OUTPUT_TAIL_AFTER_10000"
+    received = {}
+    result = {"content": f"{'r' * 12_000}{output_tail}"}
+
+    class FakeStructuredTool:
+        name = "structured_long_tool"
+        description = "Returns structured output"
+
+        def invoke(self, *args, **kwargs):
+            received["args"] = args
+            received["kwargs"] = kwargs
+            return result
+
+    crewai_module = types.ModuleType("crewai")
+    tools_module = types.ModuleType("crewai.tools")
+    structured_module = types.ModuleType("crewai.tools.structured_tool")
+    structured_module.CrewStructuredTool = FakeStructuredTool
+    tools_module.structured_tool = structured_module
+    crewai_module.tools = tools_module
+    monkeypatch.setitem(sys.modules, "crewai", crewai_module)
+    monkeypatch.setitem(sys.modules, "crewai.tools", tools_module)
+    monkeypatch.setitem(sys.modules, "crewai.tools.structured_tool", structured_module)
+
+    crewai_instrumentation._patch_structured_tool()
+    payload = {"query": f"{'q' * 12_000}{input_tail}"}
+    returned = FakeStructuredTool().invoke(payload)
+
+    assert returned is result
+    assert received == {"args": (payload,), "kwargs": {}}
+    tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.structured_long_tool")
+    assert input_tail in tool_span.attributes["input.value"]
+    assert output_tail in tool_span.attributes["output.value"]
+    assert json.loads(tool_span.attributes["input.value"]) == payload
+    assert json.loads(tool_span.attributes["output.value"]) == result
+    assert tool_span.attributes["neatlogs.framework"] == "crewai"
+
+
+@pytest.mark.parametrize("result", [[], {}, ""])
+def test_base_tool_captures_empty_non_none_results(in_memory_span_exporter, result) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+
+    class EmptyResultTool:
+        name = f"empty_{type(result).__name__}"
+
+        def run(self):
+            return result
+
+    crewai_instrumentation._patch_tool_run(EmptyResultTool)
+    returned = EmptyResultTool().run()
+
+    assert returned is result
+    tool_span = _finished_span(in_memory_span_exporter, f"crewai.tool.{EmptyResultTool.name}")
+    assert "output.value" in tool_span.attributes
+    assert tool_span.attributes["output.value"] == json.dumps(result, ensure_ascii=False)
+
+
+def test_base_tool_serializes_non_json_native_values_without_changing_return(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+    timestamp = datetime(2026, 8, 6, 12, 30, tzinfo=timezone.utc)
+    result = {"created_at": timestamp}
+
+    class DatetimeTool:
+        name = "datetime_tool"
+
+        def run(self):
+            return result
+
+    crewai_instrumentation._patch_tool_run(DatetimeTool)
+    returned = DatetimeTool().run()
+
+    assert returned is result
+    tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.datetime_tool")
+    assert json.loads(tool_span.attributes["output.value"]) == {"created_at": str(timestamp)}
+
+
+def test_base_tool_serialization_failure_does_not_replace_business_result(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+
+    class BrokenString:
+        def __str__(self):
+            raise RuntimeError("telemetry serialization failed")
+
+    result = BrokenString()
+
+    class UnserializableTool:
+        name = "unserializable_tool"
+
+        def run(self):
+            return result
+
+    crewai_instrumentation._patch_tool_run(UnserializableTool)
+    returned = UnserializableTool().run()
+
+    assert returned is result
+    tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.unserializable_tool")
+    assert tool_span.status.status_code == StatusCode.OK
+
+
+def test_base_tool_preserves_exception_and_records_error_span(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+
+    class FailingTool:
+        name = "failing_tool"
+
+        def run(self):
+            raise RuntimeError("tool failed")
+
+    crewai_instrumentation._patch_tool_run(FailingTool)
+
+    with pytest.raises(RuntimeError, match="tool failed"):
+        FailingTool().run()
+
+    tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.failing_tool")
+    assert tool_span.status.status_code == StatusCode.ERROR
+    assert tool_span.attributes["neatlogs.framework"] == "crewai"
+
+
+def test_representative_crewai_span_kinds_include_framework_identity(
+    in_memory_span_exporter,
+) -> None:
+    _install_test_tracer(in_memory_span_exporter)
+    crewai_instrumentation = _crewai_module()
+
+    class Result:
+        raw = "ok"
+
+    class FakeCrew:
+        tasks = []
+        agents = []
+
+        def kickoff(self):
+            return Result()
+
+    class FakeFlow:
+        state = {"ready": True}
+
+        def kickoff(self):
+            return {"done": True}
+
+    class FakeTask:
+        description = "task"
+
+        def _execute_core(self):
+            return Result()
+
+    class FakeAgent:
+        role = "researcher"
+        tools = []
+
+        def execute_task(self):
+            return "agent result"
+
+    class FakeTool:
+        name = "identity_tool"
+
+        def run(self):
+            return "tool result"
+
+    class FakeLlm:
+        model = "test-model"
+
+        def call(self, messages, *args, **kwargs):
+            return "llm result"
+
+    crewai_instrumentation._patch_crew_class(FakeCrew)
+    crewai_instrumentation._patch_flow_class(FakeFlow)
+    task = FakeTask()
+    crewai_instrumentation._patch_task_execute(task)
+    agent = FakeAgent()
+    crewai_instrumentation._patch_agent_execute(agent)
+    crewai_instrumentation._patch_tool_run(FakeTool)
+    crewai_instrumentation._patch_llm_call(FakeLlm)
+
+    FakeCrew().kickoff()
+    FakeFlow().kickoff()
+    task._execute_core()
+    agent.execute_task()
+    FakeTool().run()
+    FakeLlm().call([{"role": "user", "content": "hello"}])
+
+    expected_kinds = {
+        "crewai.crew.kickoff": "workflow",
+        "crewai.flow.kickoff": "workflow",
+        "crewai.task": "task",
+        "crewai.agent.researcher": "agent",
+        "crewai.tool.identity_tool": "tool",
+        "crewai.llm.call": "llm",
+    }
+    spans = {span.name: span for span in in_memory_span_exporter.get_finished_spans()}
+    for span_name, kind in expected_kinds.items():
+        span = spans[span_name]
+        assert span.attributes["neatlogs.framework"] == "crewai"
+        assert span.attributes["neatlogs.span.kind"] == kind

--- a/tests/unit/test_crewai_tool_fidelity.py
+++ b/tests/unit/test_crewai_tool_fidelity.py
@@ -83,9 +83,7 @@ def test_base_tool_preserves_plain_string_output_without_json_quotes(
     returned = PlainStringTool().run()
 
     assert returned == "plain tool result"
-    tool_span = _finished_span(
-        in_memory_span_exporter, "crewai.tool.plain_string_tool"
-    )
+    tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.plain_string_tool")
     assert tool_span.attributes["output.value"] == "plain tool result"
 
 


### PR DESCRIPTION
## Summary

Preserve complete CrewAI tool telemetry, add explicit CrewAI framework identity, and add a deterministic CrewAI example that validates both long tool output and long prompt fidelity across the SDK/backend/UI pipeline.

## Problem / context

CrewAI tool wrappers sliced captured input/output at 10,000 characters before export. Long values therefore reached the backend as incomplete fragments, and older wrapper spans did not identify themselves with `neatlogs.framework=crewai`.

The review also found one serialization fidelity issue in the initial PR: plain string tool results were JSON-encoded, adding surrounding quotes to the raw telemetry.

## What changed

- Remove the CrewAI tool wrapper's 10,000-character telemetry cutoff.
- Serialize structured/non-string values as JSON with `default=str`.
- Preserve plain string values exactly, without adding JSON quotes.
- Preserve original return values and exception behavior if telemetry serialization fails.
- Apply the same behavior to `BaseTool` and `CrewStructuredTool`.
- Add `neatlogs.framework=crewai` to Crew, Flow, Task, Agent, Tool, and LLM wrapper spans.
- Extend `examples/sdk_examples/crewai_prompt_fidelity.py` with:
  - a configurable prompt tail beyond 100,000 characters;
  - a deterministic 12,500-character plain-string CrewAI `BaseTool` result;
  - stable prompt/tool markers and printed trace IDs for verification.
- Add regression coverage for plain strings, structured values, empty results, datetime fallback, errors, framework markers, and the example builders.

## Cross-repository validation

Validated locally against backend PR `neatlogs/neatlogs-app#1030` using isolated backend API, Kafka-consumer, and trace-finalizer containers. Existing PostgreSQL and ClickHouse containers/volumes were reused without recreation, restart, migration, or destructive SQL.

Observed comparison:

| State | Raw tool output | Simplified tool output | CrewAI prompt drawer |
|---|---:|---:|---:|
| SDK `main` + original backend PR | 10,000 chars; tail missing | tail missing | tail missing |
| Original SDK PR + original backend PR | 12,504 chars; JSON quotes present; tail present | 12,500 chars; tail present | 100,014-char preview; tail missing |
| Final SDK + final backend | 12,500 chars; no JSON quotes; tail at offset 10,051 | 12,500 chars; tail at offset 10,051 | 101,317 chars; prompt tail at offset 100,752 |

Final UI-validation trace:

- trace ID: `3d9bdc833283d648672aa8471367cbd4`
- workflow: `crewai-long-prompt-fidelity`
- local UI showed the full tool tail and `PROMPT_FIDELITY_TARGET_TAIL` in the LLM I/O drawer.

## Validation

- `pytest -q tests/unit`
  - 98 passed, 1 skipped
- `black --check neatlogs tests examples/sdk_examples/crewai_prompt_fidelity.py`
  - passed
- `isort --check-only neatlogs tests examples/sdk_examples/crewai_prompt_fidelity.py`
  - passed
- `git diff --check origin/main...HEAD`
  - passed
- Backend finalizer suite from the paired backend branch
  - 34 files passed, 260 tests passed
- Backend TypeScript typecheck
  - passed

## Impact / rollout

- No SDK business-return behavior changes.
- No schema migration or backend API contract change.
- No version bump or package publication in this PR.
- Historical values truncated before export cannot be recovered.
- Deploy the paired backend finalizer change before or with this SDK release so explicit CrewAI framework markers use the complete indexed prompt in the drawer.

