### PR TITLE
fix(per-call): fail open when wrapper pre-execution or finalize throws

### DIFF
--- a/neatlogs/_wrap_utils.py
+++ b/neatlogs/_wrap_utils.py
@@ -589,6 +589,17 @@ def is_suppressed() -> bool:
         return False
 
 
+def _telemetry_fallback(orig: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Call the untraced original directly.
+
+    Used by provider wrappers when their own pre-execution or finalize phase
+    raises an exception. The user's primary LLM call must never be blocked
+    by a neatlogs internal bug; a telemetry library should fail open, not
+    crash the host application.
+    """
+    return orig(*args, **kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Auto-root
 #

--- a/neatlogs/_wrap_utils.py
+++ b/neatlogs/_wrap_utils.py
@@ -600,6 +600,24 @@ def _telemetry_fallback(orig: Callable[..., Any], *args: Any, **kwargs: Any) -> 
     return orig(*args, **kwargs)
 
 
+def _safe_finalize(span: Any, finalize_fn: Callable[..., Any], *args: Any) -> None:
+    """Run a finalize callback; if it throws, end the span with OK so it is
+    not leaked, then swallow. Used by the per-call wrappers when the LLM
+    call has already returned a response and the only thing left is to
+    record telemetry attributes.
+    """
+    try:
+        finalize_fn(span, *args)
+    except Exception:
+        from opentelemetry.trace import StatusCode
+
+        try:
+            span.set_status(StatusCode.OK)
+            span.end()
+        except Exception:
+            pass
+
+
 # ---------------------------------------------------------------------------
 # Auto-root
 #

--- a/neatlogs/anthropic.py
+++ b/neatlogs/anthropic.py
@@ -22,6 +22,7 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import (
     AsyncStreamWrapper,
     SyncStreamWrapper,
+    _safe_finalize,
     _telemetry_fallback,
     get_provider_tracer,
     is_suppressed,
@@ -117,10 +118,7 @@ def _patch_messages(messages: Any) -> None:
             return SyncStreamWrapper(response, span, _finalize_stream)
 
         duration_ms = (time.perf_counter() - start) * 1000
-        try:
-            _finalize_response(span, response, duration_ms)
-        except Exception:
-            pass
+        _safe_finalize(span, _finalize_response, response, duration_ms)
         return response
 
     messages.create = patched_create
@@ -207,10 +205,7 @@ def _patch_async_messages(messages: Any) -> None:
             return AsyncStreamWrapper(response, span, _finalize_stream)
 
         duration_ms = (time.perf_counter() - start) * 1000
-        try:
-            _finalize_response(span, response, duration_ms)
-        except Exception:
-            pass
+        _safe_finalize(span, _finalize_response, response, duration_ms)
         return response
 
     messages.create = patched_create
@@ -604,10 +599,7 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
                 except Exception as e:
                     _err(span, e)
                     raise
-                try:
-                    _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
-                except Exception:
-                    pass
+                _safe_finalize(span, _finalize_response, resp, (time.perf_counter() - start) * 1000)
                 return resp
 
         else:
@@ -625,10 +617,7 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
                 except Exception as e:
                     _err(span, e)
                     raise
-                try:
-                    _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
-                except Exception:
-                    pass
+                _safe_finalize(span, _finalize_response, resp, (time.perf_counter() - start) * 1000)
                 return resp
 
         messages.parse = patched_parse
@@ -661,10 +650,7 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
                 except Exception as e:
                     _err(span, e)
                     raise
-                try:
-                    _finalize_count_tokens(span, resp)
-                except Exception:
-                    pass
+                _safe_finalize(span, _finalize_count_tokens, resp)
                 return resp
 
         else:
@@ -689,10 +675,7 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
                 except Exception as e:
                     _err(span, e)
                     raise
-                try:
-                    _finalize_count_tokens(span, resp)
-                except Exception:
-                    pass
+                _safe_finalize(span, _finalize_count_tokens, resp)
                 return resp
 
         messages.count_tokens = patched_count

--- a/neatlogs/anthropic.py
+++ b/neatlogs/anthropic.py
@@ -22,6 +22,7 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import (
     AsyncStreamWrapper,
     SyncStreamWrapper,
+    _telemetry_fallback,
     get_provider_tracer,
     is_suppressed,
     serialize,
@@ -80,24 +81,27 @@ def _patch_messages(messages: Any) -> None:
         if is_suppressed():
             return orig_create(*args, **kwargs)
 
-        model = kwargs.get("model", "")
-        input_messages = kwargs.get("messages", [])
-        system = kwargs.get("system")
-        is_stream = kwargs.get("stream", False)
+        try:
+            model = kwargs.get("model", "")
+            input_messages = kwargs.get("messages", [])
+            system = kwargs.get("system")
+            is_stream = kwargs.get("stream", False)
 
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="anthropic.messages.create",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "anthropic",
-                "neatlogs.llm.system": "anthropic",
-                "neatlogs.llm.model_name": model,
-                "neatlogs.llm.is_streaming": is_stream,
-            },
-        )
+            tracer = get_provider_tracer()
+            span = tracer.start_span(
+                name="anthropic.messages.create",
+                attributes={
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": "anthropic",
+                    "neatlogs.llm.system": "anthropic",
+                    "neatlogs.llm.model_name": model,
+                    "neatlogs.llm.is_streaming": is_stream,
+                },
+            )
 
-        _set_input_attributes(span, input_messages, system, kwargs)
+            _set_input_attributes(span, input_messages, system, kwargs)
+        except Exception:
+            return _telemetry_fallback(orig_create, *args, **kwargs)
 
         start = time.perf_counter()
 
@@ -113,7 +117,10 @@ def _patch_messages(messages: Any) -> None:
             return SyncStreamWrapper(response, span, _finalize_stream)
 
         duration_ms = (time.perf_counter() - start) * 1000
-        _finalize_response(span, response, duration_ms)
+        try:
+            _finalize_response(span, response, duration_ms)
+        except Exception:
+            pass
         return response
 
     messages.create = patched_create
@@ -124,23 +131,26 @@ def _patch_messages(messages: Any) -> None:
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
 
-            model = kwargs.get("model", "")
-            input_messages = kwargs.get("messages", [])
-            system = kwargs.get("system")
+            try:
+                model = kwargs.get("model", "")
+                input_messages = kwargs.get("messages", [])
+                system = kwargs.get("system")
 
-            tracer = get_provider_tracer()
-            span = tracer.start_span(
-                name="anthropic.messages.create",
-                attributes={
-                    "neatlogs.span.kind": "llm",
-                    "neatlogs.llm.provider": "anthropic",
-                    "neatlogs.llm.system": "anthropic",
-                    "neatlogs.llm.model_name": model,
-                    "neatlogs.llm.is_streaming": True,
-                },
-            )
+                tracer = get_provider_tracer()
+                span = tracer.start_span(
+                    name="anthropic.messages.create",
+                    attributes={
+                        "neatlogs.span.kind": "llm",
+                        "neatlogs.llm.provider": "anthropic",
+                        "neatlogs.llm.system": "anthropic",
+                        "neatlogs.llm.model_name": model,
+                        "neatlogs.llm.is_streaming": True,
+                    },
+                )
 
-            _set_input_attributes(span, input_messages, system, kwargs)
+                _set_input_attributes(span, input_messages, system, kwargs)
+            except Exception:
+                return _telemetry_fallback(orig_stream, *args, **kwargs)
 
             stream_mgr = orig_stream(*args, **kwargs)
             return _SyncStreamManagerWrapper(stream_mgr, span)
@@ -161,24 +171,27 @@ def _patch_async_messages(messages: Any) -> None:
         if is_suppressed():
             return await orig_create(*args, **kwargs)
 
-        model = kwargs.get("model", "")
-        input_messages = kwargs.get("messages", [])
-        system = kwargs.get("system")
-        is_stream = kwargs.get("stream", False)
+        try:
+            model = kwargs.get("model", "")
+            input_messages = kwargs.get("messages", [])
+            system = kwargs.get("system")
+            is_stream = kwargs.get("stream", False)
 
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="anthropic.messages.create",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "anthropic",
-                "neatlogs.llm.system": "anthropic",
-                "neatlogs.llm.model_name": model,
-                "neatlogs.llm.is_streaming": is_stream,
-            },
-        )
+            tracer = get_provider_tracer()
+            span = tracer.start_span(
+                name="anthropic.messages.create",
+                attributes={
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": "anthropic",
+                    "neatlogs.llm.system": "anthropic",
+                    "neatlogs.llm.model_name": model,
+                    "neatlogs.llm.is_streaming": is_stream,
+                },
+            )
 
-        _set_input_attributes(span, input_messages, system, kwargs)
+            _set_input_attributes(span, input_messages, system, kwargs)
+        except Exception:
+            return await _telemetry_fallback(orig_create, *args, **kwargs)
 
         start = time.perf_counter()
 
@@ -194,7 +207,10 @@ def _patch_async_messages(messages: Any) -> None:
             return AsyncStreamWrapper(response, span, _finalize_stream)
 
         duration_ms = (time.perf_counter() - start) * 1000
-        _finalize_response(span, response, duration_ms)
+        try:
+            _finalize_response(span, response, duration_ms)
+        except Exception:
+            pass
         return response
 
     messages.create = patched_create
@@ -205,23 +221,26 @@ def _patch_async_messages(messages: Any) -> None:
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
 
-            model = kwargs.get("model", "")
-            input_messages = kwargs.get("messages", [])
-            system = kwargs.get("system")
+            try:
+                model = kwargs.get("model", "")
+                input_messages = kwargs.get("messages", [])
+                system = kwargs.get("system")
 
-            tracer = get_provider_tracer()
-            span = tracer.start_span(
-                name="anthropic.messages.create",
-                attributes={
-                    "neatlogs.span.kind": "llm",
-                    "neatlogs.llm.provider": "anthropic",
-                    "neatlogs.llm.system": "anthropic",
-                    "neatlogs.llm.model_name": model,
-                    "neatlogs.llm.is_streaming": True,
-                },
-            )
+                tracer = get_provider_tracer()
+                span = tracer.start_span(
+                    name="anthropic.messages.create",
+                    attributes={
+                        "neatlogs.span.kind": "llm",
+                        "neatlogs.llm.provider": "anthropic",
+                        "neatlogs.llm.system": "anthropic",
+                        "neatlogs.llm.model_name": model,
+                        "neatlogs.llm.is_streaming": True,
+                    },
+                )
 
-            _set_input_attributes(span, input_messages, system, kwargs)
+                _set_input_attributes(span, input_messages, system, kwargs)
+            except Exception:
+                return _telemetry_fallback(orig_stream, *args, **kwargs)
 
             stream_mgr = orig_stream(*args, **kwargs)
             return _AsyncStreamManagerWrapper(stream_mgr, span)
@@ -575,14 +594,20 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
             async def patched_parse(*args, **kwargs):
                 if is_suppressed():
                     return await orig_parse(*args, **kwargs)
-                span = _start_message_span(kwargs, "anthropic.messages.parse", structured=True)
+                try:
+                    span = _start_message_span(kwargs, "anthropic.messages.parse", structured=True)
+                except Exception:
+                    return await _telemetry_fallback(orig_parse, *args, **kwargs)
                 start = time.perf_counter()
                 try:
                     resp = await orig_parse(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+                try:
+                    _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+                except Exception:
+                    pass
                 return resp
 
         else:
@@ -590,14 +615,20 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
             def patched_parse(*args, **kwargs):
                 if is_suppressed():
                     return orig_parse(*args, **kwargs)
-                span = _start_message_span(kwargs, "anthropic.messages.parse", structured=True)
+                try:
+                    span = _start_message_span(kwargs, "anthropic.messages.parse", structured=True)
+                except Exception:
+                    return _telemetry_fallback(orig_parse, *args, **kwargs)
                 start = time.perf_counter()
                 try:
                     resp = orig_parse(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+                try:
+                    _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+                except Exception:
+                    pass
                 return resp
 
         messages.parse = patched_parse
@@ -613,21 +644,27 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
             async def patched_count(*args, **kwargs):
                 if is_suppressed():
                     return await orig_count(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="anthropic.messages.count_tokens",
-                    attributes={
-                        "neatlogs.span.kind": "llm",
-                        "neatlogs.llm.provider": "anthropic",
-                        "neatlogs.llm.task": "count_tokens",
-                        "neatlogs.llm.model_name": kwargs.get("model", ""),
-                    },
-                )
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="anthropic.messages.count_tokens",
+                        attributes={
+                            "neatlogs.span.kind": "llm",
+                            "neatlogs.llm.provider": "anthropic",
+                            "neatlogs.llm.task": "count_tokens",
+                            "neatlogs.llm.model_name": kwargs.get("model", ""),
+                        },
+                    )
+                except Exception:
+                    return await _telemetry_fallback(orig_count, *args, **kwargs)
                 try:
                     resp = await orig_count(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _finalize_count_tokens(span, resp)
+                try:
+                    _finalize_count_tokens(span, resp)
+                except Exception:
+                    pass
                 return resp
 
         else:
@@ -635,21 +672,27 @@ def _extra_message_methods(messages: Any, is_async: bool) -> None:
             def patched_count(*args, **kwargs):
                 if is_suppressed():
                     return orig_count(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="anthropic.messages.count_tokens",
-                    attributes={
-                        "neatlogs.span.kind": "llm",
-                        "neatlogs.llm.provider": "anthropic",
-                        "neatlogs.llm.task": "count_tokens",
-                        "neatlogs.llm.model_name": kwargs.get("model", ""),
-                    },
-                )
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="anthropic.messages.count_tokens",
+                        attributes={
+                            "neatlogs.span.kind": "llm",
+                            "neatlogs.llm.provider": "anthropic",
+                            "neatlogs.llm.task": "count_tokens",
+                            "neatlogs.llm.model_name": kwargs.get("model", ""),
+                        },
+                    )
+                except Exception:
+                    return _telemetry_fallback(orig_count, *args, **kwargs)
                 try:
                     resp = orig_count(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _finalize_count_tokens(span, resp)
+                try:
+                    _finalize_count_tokens(span, resp)
+                except Exception:
+                    pass
                 return resp
 
         messages.count_tokens = patched_count

--- a/neatlogs/bedrock.py
+++ b/neatlogs/bedrock.py
@@ -23,7 +23,13 @@ from typing import Any, List, Optional
 
 from opentelemetry.trace import StatusCode
 
-from ._wrap_utils import _telemetry_fallback, get_provider_tracer, is_suppressed, serialize
+from ._wrap_utils import (
+    _safe_finalize,
+    _telemetry_fallback,
+    get_provider_tracer,
+    is_suppressed,
+    serialize,
+)
 
 _PROVIDER = "bedrock"
 
@@ -261,10 +267,7 @@ def _patch_converse(client: Any) -> None:
         except Exception as e:
             _err(span, e)
             raise
-        try:
-            _finalize_converse(span, response, (time.perf_counter() - start) * 1000)
-        except Exception:
-            pass
+        _safe_finalize(span, _finalize_converse, response, (time.perf_counter() - start) * 1000)
         return response
 
     client.converse = patched

--- a/neatlogs/bedrock.py
+++ b/neatlogs/bedrock.py
@@ -23,7 +23,7 @@ from typing import Any, List, Optional
 
 from opentelemetry.trace import StatusCode
 
-from ._wrap_utils import get_provider_tracer, is_suppressed, serialize
+from ._wrap_utils import _telemetry_fallback, get_provider_tracer, is_suppressed, serialize
 
 _PROVIDER = "bedrock"
 
@@ -250,15 +250,21 @@ def _patch_converse(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        span = _start_span("bedrock.converse", kwargs.get("modelId"), is_stream=False)
-        _set_converse_input(span, kwargs)
+        try:
+            span = _start_span("bedrock.converse", kwargs.get("modelId"), is_stream=False)
+            _set_converse_input(span, kwargs)
+        except Exception:
+            return _telemetry_fallback(orig, *args, **kwargs)
         start = time.perf_counter()
         try:
             response = orig(*args, **kwargs)
         except Exception as e:
             _err(span, e)
             raise
-        _finalize_converse(span, response, (time.perf_counter() - start) * 1000)
+        try:
+            _finalize_converse(span, response, (time.perf_counter() - start) * 1000)
+        except Exception:
+            pass
         return response
 
     client.converse = patched
@@ -270,8 +276,11 @@ def _patch_converse_stream(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        span = _start_span("bedrock.converse_stream", kwargs.get("modelId"), is_stream=True)
-        _set_converse_input(span, kwargs)
+        try:
+            span = _start_span("bedrock.converse_stream", kwargs.get("modelId"), is_stream=True)
+            _set_converse_input(span, kwargs)
+        except Exception:
+            return _telemetry_fallback(orig, *args, **kwargs)
         start = time.perf_counter()
         try:
             response = orig(*args, **kwargs)
@@ -500,29 +509,32 @@ def _patch_invoke_model(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        model_id = kwargs.get("modelId")
-        vendor = _vendor_from_model(model_id)
-        is_embedding = _is_embedding_model(model_id)
-        body_in = _decode_body(kwargs.get("body"))
+        try:
+            model_id = kwargs.get("modelId")
+            vendor = _vendor_from_model(model_id)
+            is_embedding = _is_embedding_model(model_id)
+            body_in = _decode_body(kwargs.get("body"))
 
-        if is_embedding:
-            span = get_provider_tracer().start_span(
-                name="bedrock.invoke_model",
-                attributes={
-                    "neatlogs.span.kind": "embedding",
-                    "neatlogs.llm.provider": _PROVIDER,
-                    "neatlogs.embedding.model_name": str(model_id or ""),
-                },
-            )
-            text = body_in.get("inputText") or body_in.get("texts") or body_in.get("input_text")
-            if text:
-                span.set_attribute(
-                    "neatlogs.embedding.text",
-                    (text if isinstance(text, str) else serialize(text))[:10000],
+            if is_embedding:
+                span = get_provider_tracer().start_span(
+                    name="bedrock.invoke_model",
+                    attributes={
+                        "neatlogs.span.kind": "embedding",
+                        "neatlogs.llm.provider": _PROVIDER,
+                        "neatlogs.embedding.model_name": str(model_id or ""),
+                    },
                 )
-        else:
-            span = _start_span("bedrock.invoke_model", model_id, is_stream=False)
-            _set_invoke_input(span, vendor, body_in)
+                text = body_in.get("inputText") or body_in.get("texts") or body_in.get("input_text")
+                if text:
+                    span.set_attribute(
+                        "neatlogs.embedding.text",
+                        (text if isinstance(text, str) else serialize(text))[:10000],
+                    )
+            else:
+                span = _start_span("bedrock.invoke_model", model_id, is_stream=False)
+                _set_invoke_input(span, vendor, body_in)
+        except Exception:
+            return _telemetry_fallback(orig, *args, **kwargs)
 
         start = time.perf_counter()
         try:
@@ -571,10 +583,15 @@ def _patch_invoke_model_stream(client: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        model_id = kwargs.get("modelId")
-        vendor = _vendor_from_model(model_id)
-        span = _start_span("bedrock.invoke_model_with_response_stream", model_id, is_stream=True)
-        _set_invoke_input(span, vendor, _decode_body(kwargs.get("body")))
+        try:
+            model_id = kwargs.get("modelId")
+            vendor = _vendor_from_model(model_id)
+            span = _start_span(
+                "bedrock.invoke_model_with_response_stream", model_id, is_stream=True
+            )
+            _set_invoke_input(span, vendor, _decode_body(kwargs.get("body")))
+        except Exception:
+            return _telemetry_fallback(orig, *args, **kwargs)
         start = time.perf_counter()
         try:
             response = orig(*args, **kwargs)

--- a/neatlogs/google_genai.py
+++ b/neatlogs/google_genai.py
@@ -23,6 +23,7 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import (
     AsyncStreamWrapper,
     SyncStreamWrapper,
+    _telemetry_fallback,
     get_provider_tracer,
     is_suppressed,
     serialize,
@@ -70,22 +71,25 @@ def _patch_models(models: Any) -> None:
         if is_suppressed():
             return orig_generate(*args, **kwargs)
 
-        model = kwargs.get("model", args[0] if args else "")
-        contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+        try:
+            model = kwargs.get("model", args[0] if args else "")
+            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="google_genai.models.generate_content",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "google_genai",
-                "neatlogs.llm.system": "google_genai",
-                "neatlogs.llm.model_name": str(model),
-                "neatlogs.llm.is_streaming": False,
-            },
-        )
+            tracer = get_provider_tracer()
+            span = tracer.start_span(
+                name="google_genai.models.generate_content",
+                attributes={
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": "google_genai",
+                    "neatlogs.llm.system": "google_genai",
+                    "neatlogs.llm.model_name": str(model),
+                    "neatlogs.llm.is_streaming": False,
+                },
+            )
 
-        _set_input_attributes(span, contents, kwargs)
+            _set_input_attributes(span, contents, kwargs)
+        except Exception:
+            return _telemetry_fallback(orig_generate, *args, **kwargs)
 
         start = time.perf_counter()
 
@@ -98,7 +102,10 @@ def _patch_models(models: Any) -> None:
             raise
 
         duration_ms = (time.perf_counter() - start) * 1000
-        _finalize_response(span, response, duration_ms)
+        try:
+            _finalize_response(span, response, duration_ms)
+        except Exception:
+            pass
         return response
 
     models.generate_content = patched_generate_content
@@ -109,22 +116,25 @@ def _patch_models(models: Any) -> None:
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
 
-            model = kwargs.get("model", args[0] if args else "")
-            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+            try:
+                model = kwargs.get("model", args[0] if args else "")
+                contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-            tracer = get_provider_tracer()
-            span = tracer.start_span(
-                name="google_genai.models.generate_content",
-                attributes={
-                    "neatlogs.span.kind": "llm",
-                    "neatlogs.llm.provider": "google_genai",
-                    "neatlogs.llm.system": "google_genai",
-                    "neatlogs.llm.model_name": str(model),
-                    "neatlogs.llm.is_streaming": True,
-                },
-            )
+                tracer = get_provider_tracer()
+                span = tracer.start_span(
+                    name="google_genai.models.generate_content",
+                    attributes={
+                        "neatlogs.span.kind": "llm",
+                        "neatlogs.llm.provider": "google_genai",
+                        "neatlogs.llm.system": "google_genai",
+                        "neatlogs.llm.model_name": str(model),
+                        "neatlogs.llm.is_streaming": True,
+                    },
+                )
 
-            _set_input_attributes(span, contents, kwargs)
+                _set_input_attributes(span, contents, kwargs)
+            except Exception:
+                return _telemetry_fallback(orig_stream, *args, **kwargs)
 
             stream = orig_stream(*args, **kwargs)
             return SyncStreamWrapper(stream, span, _finalize_stream)
@@ -145,22 +155,25 @@ def _patch_async_models(models: Any) -> None:
         if is_suppressed():
             return await orig_generate(*args, **kwargs)
 
-        model = kwargs.get("model", args[0] if args else "")
-        contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+        try:
+            model = kwargs.get("model", args[0] if args else "")
+            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="google_genai.models.generate_content",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "google_genai",
-                "neatlogs.llm.system": "google_genai",
-                "neatlogs.llm.model_name": str(model),
-                "neatlogs.llm.is_streaming": False,
-            },
-        )
+            tracer = get_provider_tracer()
+            span = tracer.start_span(
+                name="google_genai.models.generate_content",
+                attributes={
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": "google_genai",
+                    "neatlogs.llm.system": "google_genai",
+                    "neatlogs.llm.model_name": str(model),
+                    "neatlogs.llm.is_streaming": False,
+                },
+            )
 
-        _set_input_attributes(span, contents, kwargs)
+            _set_input_attributes(span, contents, kwargs)
+        except Exception:
+            return await _telemetry_fallback(orig_generate, *args, **kwargs)
 
         start = time.perf_counter()
 
@@ -173,7 +186,10 @@ def _patch_async_models(models: Any) -> None:
             raise
 
         duration_ms = (time.perf_counter() - start) * 1000
-        _finalize_response(span, response, duration_ms)
+        try:
+            _finalize_response(span, response, duration_ms)
+        except Exception:
+            pass
         return response
 
     models.generate_content = patched_generate_content
@@ -190,22 +206,25 @@ def _patch_async_models(models: Any) -> None:
             if is_suppressed():
                 return await orig_stream(*args, **kwargs)
 
-            model = kwargs.get("model", args[0] if args else "")
-            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+            try:
+                model = kwargs.get("model", args[0] if args else "")
+                contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-            tracer = get_provider_tracer()
-            span = tracer.start_span(
-                name="google_genai.models.generate_content",
-                attributes={
-                    "neatlogs.span.kind": "llm",
-                    "neatlogs.llm.provider": "google_genai",
-                    "neatlogs.llm.system": "google_genai",
-                    "neatlogs.llm.model_name": str(model),
-                    "neatlogs.llm.is_streaming": True,
-                },
-            )
+                tracer = get_provider_tracer()
+                span = tracer.start_span(
+                    name="google_genai.models.generate_content",
+                    attributes={
+                        "neatlogs.span.kind": "llm",
+                        "neatlogs.llm.provider": "google_genai",
+                        "neatlogs.llm.system": "google_genai",
+                        "neatlogs.llm.model_name": str(model),
+                        "neatlogs.llm.is_streaming": True,
+                    },
+                )
 
-            _set_input_attributes(span, contents, kwargs)
+                _set_input_attributes(span, contents, kwargs)
+            except Exception:
+                return await _telemetry_fallback(orig_stream, *args, **kwargs)
 
             try:
                 stream = await orig_stream(*args, **kwargs)
@@ -537,15 +556,22 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             async def patched_embed(*args, **kwargs):
                 if is_suppressed():
                     return await orig(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="google_genai.models.embed_content", attributes=_embed_attrs(kwargs)
-                )
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="google_genai.models.embed_content",
+                        attributes=_embed_attrs(kwargs),
+                    )
+                except Exception:
+                    return await _telemetry_fallback(orig, *args, **kwargs)
                 try:
                     resp = await orig(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _embed_finalize(span, resp)
+                try:
+                    _embed_finalize(span, resp)
+                except Exception:
+                    pass
                 return resp
 
         else:
@@ -553,15 +579,22 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             def patched_embed(*args, **kwargs):
                 if is_suppressed():
                     return orig(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="google_genai.models.embed_content", attributes=_embed_attrs(kwargs)
-                )
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="google_genai.models.embed_content",
+                        attributes=_embed_attrs(kwargs),
+                    )
+                except Exception:
+                    return _telemetry_fallback(orig, *args, **kwargs)
                 try:
                     resp = orig(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _embed_finalize(span, resp)
+                try:
+                    _embed_finalize(span, resp)
+                except Exception:
+                    pass
                 return resp
 
         models.embed_content = patched_embed
@@ -591,15 +624,21 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             async def patched_ct(*args, **kwargs):
                 if is_suppressed():
                     return await orig_ct(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="google_genai.models.count_tokens", attributes=_ct_attrs(kwargs)
-                )
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="google_genai.models.count_tokens", attributes=_ct_attrs(kwargs)
+                    )
+                except Exception:
+                    return await _telemetry_fallback(orig_ct, *args, **kwargs)
                 try:
                     resp = await orig_ct(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _ct_finalize(span, resp)
+                try:
+                    _ct_finalize(span, resp)
+                except Exception:
+                    pass
                 return resp
 
         else:
@@ -607,15 +646,21 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             def patched_ct(*args, **kwargs):
                 if is_suppressed():
                     return orig_ct(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="google_genai.models.count_tokens", attributes=_ct_attrs(kwargs)
-                )
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="google_genai.models.count_tokens", attributes=_ct_attrs(kwargs)
+                    )
+                except Exception:
+                    return _telemetry_fallback(orig_ct, *args, **kwargs)
                 try:
                     resp = orig_ct(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _ct_finalize(span, resp)
+                try:
+                    _ct_finalize(span, resp)
+                except Exception:
+                    pass
                 return resp
 
         models.count_tokens = patched_ct
@@ -644,14 +689,20 @@ def _patch_chat_classes() -> None:
         def patched_send(self, message, *args, **kwargs):
             if is_suppressed():
                 return orig_send(self, message, *args, **kwargs)
-            span = _start_chat_span(self, message, stream=False)
+            try:
+                span = _start_chat_span(self, message, stream=False)
+            except Exception:
+                return _telemetry_fallback(orig_send, self, message, *args, **kwargs)
             start = time.perf_counter()
             try:
                 resp = orig_send(self, message, *args, **kwargs)
             except Exception as e:
                 _err(span, e)
                 raise
-            _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            try:
+                _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            except Exception:
+                pass
             return resp
 
         Chat.send_message = patched_send
@@ -662,7 +713,10 @@ def _patch_chat_classes() -> None:
             def patched_send_stream(self, message, *args, **kwargs):
                 if is_suppressed():
                     return orig_send_stream(self, message, *args, **kwargs)
-                span = _start_chat_span(self, message, stream=True)
+                try:
+                    span = _start_chat_span(self, message, stream=True)
+                except Exception:
+                    return _telemetry_fallback(orig_send_stream, self, message, *args, **kwargs)
                 stream = orig_send_stream(self, message, *args, **kwargs)
                 return SyncStreamWrapper(stream, span, _finalize_stream)
 
@@ -681,14 +735,20 @@ def _patch_chat_classes() -> None:
         async def patched_asend(self, message, *args, **kwargs):
             if is_suppressed():
                 return await orig_asend(self, message, *args, **kwargs)
-            span = _start_chat_span(self, message, stream=False)
+            try:
+                span = _start_chat_span(self, message, stream=False)
+            except Exception:
+                return await _telemetry_fallback(orig_asend, self, message, *args, **kwargs)
             start = time.perf_counter()
             try:
                 resp = await orig_asend(self, message, *args, **kwargs)
             except Exception as e:
                 _err(span, e)
                 raise
-            _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            try:
+                _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            except Exception:
+                pass
             return resp
 
         AsyncChat.send_message = patched_asend
@@ -703,7 +763,12 @@ def _patch_chat_classes() -> None:
             async def patched_asend_stream(self, message, *args, **kwargs):
                 if is_suppressed():
                     return await orig_asend_stream(self, message, *args, **kwargs)
-                span = _start_chat_span(self, message, stream=True)
+                try:
+                    span = _start_chat_span(self, message, stream=True)
+                except Exception:
+                    return await _telemetry_fallback(
+                        orig_asend_stream, self, message, *args, **kwargs
+                    )
                 try:
                     stream = await orig_asend_stream(self, message, *args, **kwargs)
                 except Exception as e:

--- a/neatlogs/google_genai.py
+++ b/neatlogs/google_genai.py
@@ -23,6 +23,7 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import (
     AsyncStreamWrapper,
     SyncStreamWrapper,
+    _safe_finalize,
     _telemetry_fallback,
     get_provider_tracer,
     is_suppressed,
@@ -102,10 +103,7 @@ def _patch_models(models: Any) -> None:
             raise
 
         duration_ms = (time.perf_counter() - start) * 1000
-        try:
-            _finalize_response(span, response, duration_ms)
-        except Exception:
-            pass
+        _safe_finalize(span, _finalize_response, response, duration_ms)
         return response
 
     models.generate_content = patched_generate_content
@@ -186,10 +184,7 @@ def _patch_async_models(models: Any) -> None:
             raise
 
         duration_ms = (time.perf_counter() - start) * 1000
-        try:
-            _finalize_response(span, response, duration_ms)
-        except Exception:
-            pass
+        _safe_finalize(span, _finalize_response, response, duration_ms)
         return response
 
     models.generate_content = patched_generate_content
@@ -699,10 +694,7 @@ def _patch_chat_classes() -> None:
             except Exception as e:
                 _err(span, e)
                 raise
-            try:
-                _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
-            except Exception:
-                pass
+            _safe_finalize(span, _finalize_response, resp, (time.perf_counter() - start) * 1000)
             return resp
 
         Chat.send_message = patched_send
@@ -745,10 +737,7 @@ def _patch_chat_classes() -> None:
             except Exception as e:
                 _err(span, e)
                 raise
-            try:
-                _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
-            except Exception:
-                pass
+            _safe_finalize(span, _finalize_response, resp, (time.perf_counter() - start) * 1000)
             return resp
 
         AsyncChat.send_message = patched_asend

--- a/neatlogs/openai.py
+++ b/neatlogs/openai.py
@@ -22,6 +22,7 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import (
     AsyncStreamWrapper,
     SyncStreamWrapper,
+    _safe_finalize,
     _telemetry_fallback,
     get_provider_tracer,
     is_suppressed,
@@ -197,12 +198,7 @@ def _patch_completions(completions: Any) -> None:
             return SyncStreamWrapper(response, span, _finalize_stream)
 
         duration_ms = (time.perf_counter() - start) * 1000
-        try:
-            _finalize_response(span, response, duration_ms)
-        except Exception:
-            # Finalize threw after the user got a response. The response is
-            # still valid; return it without telemetry rather than crashing.
-            pass
+        _safe_finalize(span, _finalize_response, response, duration_ms)
         return response
 
     completions.create = patched_create
@@ -295,10 +291,7 @@ def _patch_async_completions(completions: Any) -> None:
             return AsyncStreamWrapper(response, span, _finalize_stream)
 
         duration_ms = (time.perf_counter() - start) * 1000
-        try:
-            _finalize_response(span, response, duration_ms)
-        except Exception:
-            pass
+        _safe_finalize(span, _finalize_response, response, duration_ms)
         return response
 
     completions.create = patched_create
@@ -347,10 +340,7 @@ def _patch_responses(responses: Any) -> None:
             return SyncStreamWrapper(response, span, _finalize_responses_stream)
 
         duration_ms = (time.perf_counter() - start) * 1000
-        try:
-            _finalize_responses_response(span, response, duration_ms)
-        except Exception:
-            pass
+        _safe_finalize(span, _finalize_responses_response, response, duration_ms)
         return response
 
     responses.create = patched_create
@@ -654,10 +644,9 @@ def _patch_async_responses(responses: Any) -> None:
             raise
         if is_stream:
             return AsyncStreamWrapper(response, span, _finalize_responses_stream)
-        try:
-            _finalize_responses_response(span, response, (time.perf_counter() - start) * 1000)
-        except Exception:
-            pass
+        _safe_finalize(
+            span, _finalize_responses_response, response, (time.perf_counter() - start) * 1000
+        )
         return response
 
     responses.create = patched_create

--- a/neatlogs/openai.py
+++ b/neatlogs/openai.py
@@ -22,6 +22,7 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import (
     AsyncStreamWrapper,
     SyncStreamWrapper,
+    _telemetry_fallback,
     get_provider_tracer,
     is_suppressed,
     serialize,
@@ -112,68 +113,75 @@ def _patch_completions(completions: Any) -> None:
         if is_suppressed():
             return orig_create(*args, **kwargs)
 
-        model = kwargs.get("model", "")
-        messages = kwargs.get("messages", [])
-        is_stream = kwargs.get("stream", False)
+        try:
+            model = kwargs.get("model", "")
+            messages = kwargs.get("messages", [])
+            is_stream = kwargs.get("stream", False)
 
-        if is_stream:
-            opts = kwargs.get("stream_options") or {}
-            if not opts.get("include_usage"):
-                opts["include_usage"] = True
-                kwargs["stream_options"] = opts
+            if is_stream:
+                opts = kwargs.get("stream_options") or {}
+                if not opts.get("include_usage"):
+                    opts["include_usage"] = True
+                    kwargs["stream_options"] = opts
 
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="openai.chat.completions.create",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "openai",
-                "neatlogs.llm.system": "openai",
-                "neatlogs.llm.model_name": model,
-                "neatlogs.llm.is_streaming": is_stream,
-            },
-        )
+            tracer = get_provider_tracer()
+            span = tracer.start_span(
+                name="openai.chat.completions.create",
+                attributes={
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": "openai",
+                    "neatlogs.llm.system": "openai",
+                    "neatlogs.llm.model_name": model,
+                    "neatlogs.llm.is_streaming": is_stream,
+                },
+            )
 
-        # Input messages
-        for i, msg in enumerate(messages):
-            role = msg.get("role", "")
-            content = msg.get("content", "")
-            span.set_attribute(f"neatlogs.llm.input_messages.{i}.role", role)
-            if isinstance(content, str):
-                span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", content)
-            else:
-                span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", serialize(content))
-            if msg.get("tool_call_id"):
-                span.set_attribute(
-                    f"neatlogs.llm.input_messages.{i}.tool_call_id", msg["tool_call_id"]
-                )
-
-        # Tools
-        tools = kwargs.get("tools")
-        if tools:
-            for i, tool in enumerate(tools):
-                fn = tool.get("function", {})
-                span.set_attribute(f"neatlogs.llm.tools.{i}.name", fn.get("name", ""))
-                if fn.get("description"):
-                    span.set_attribute(f"neatlogs.llm.tools.{i}.description", fn["description"])
-                if fn.get("parameters"):
+            # Input messages
+            for i, msg in enumerate(messages):
+                role = msg.get("role", "")
+                content = msg.get("content", "")
+                span.set_attribute(f"neatlogs.llm.input_messages.{i}.role", role)
+                if isinstance(content, str):
+                    span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", content)
+                else:
                     span.set_attribute(
-                        f"neatlogs.llm.tools.{i}.input_schema", serialize(fn["parameters"])
+                        f"neatlogs.llm.input_messages.{i}.content", serialize(content)
+                    )
+                if msg.get("tool_call_id"):
+                    span.set_attribute(
+                        f"neatlogs.llm.input_messages.{i}.tool_call_id", msg["tool_call_id"]
                     )
 
-        # Invocation parameters
-        for param in (
-            "temperature",
-            "top_p",
-            "max_tokens",
-            "frequency_penalty",
-            "presence_penalty",
-        ):
-            if param in kwargs and kwargs[param] is not None:
-                span.set_attribute(f"neatlogs.llm.{param}", kwargs[param])
+            # Tools
+            tools = kwargs.get("tools")
+            if tools:
+                for i, tool in enumerate(tools):
+                    fn = tool.get("function", {})
+                    span.set_attribute(f"neatlogs.llm.tools.{i}.name", fn.get("name", ""))
+                    if fn.get("description"):
+                        span.set_attribute(f"neatlogs.llm.tools.{i}.description", fn["description"])
+                    if fn.get("parameters"):
+                        span.set_attribute(
+                            f"neatlogs.llm.tools.{i}.input_schema", serialize(fn["parameters"])
+                        )
 
-        # User-supplied metadata (top-level `metadata=` or `extra_body={"metadata": ...}`).
-        _set_request_metadata(span, kwargs)
+            # Invocation parameters
+            for param in (
+                "temperature",
+                "top_p",
+                "max_tokens",
+                "frequency_penalty",
+                "presence_penalty",
+            ):
+                if param in kwargs and kwargs[param] is not None:
+                    span.set_attribute(f"neatlogs.llm.{param}", kwargs[param])
+
+            # User-supplied metadata (top-level `metadata=` or `extra_body={"metadata": ...}`).
+            _set_request_metadata(span, kwargs)
+        except Exception:
+            # Pre-execution phase threw (bad messages, broken tracer, etc.).
+            # Fall back to bare orig so the host app's LLM call is not blocked.
+            return _telemetry_fallback(orig_create, *args, **kwargs)
 
         start = time.perf_counter()
 
@@ -189,7 +197,12 @@ def _patch_completions(completions: Any) -> None:
             return SyncStreamWrapper(response, span, _finalize_stream)
 
         duration_ms = (time.perf_counter() - start) * 1000
-        _finalize_response(span, response, duration_ms)
+        try:
+            _finalize_response(span, response, duration_ms)
+        except Exception:
+            # Finalize threw after the user got a response. The response is
+            # still valid; return it without telemetry rather than crashing.
+            pass
         return response
 
     completions.create = patched_create
@@ -206,61 +219,67 @@ def _patch_async_completions(completions: Any) -> None:
         if is_suppressed():
             return await orig_create(*args, **kwargs)
 
-        model = kwargs.get("model", "")
-        messages = kwargs.get("messages", [])
-        is_stream = kwargs.get("stream", False)
+        try:
+            model = kwargs.get("model", "")
+            messages = kwargs.get("messages", [])
+            is_stream = kwargs.get("stream", False)
 
-        if is_stream:
-            opts = kwargs.get("stream_options") or {}
-            if not opts.get("include_usage"):
-                opts["include_usage"] = True
-                kwargs["stream_options"] = opts
+            if is_stream:
+                opts = kwargs.get("stream_options") or {}
+                if not opts.get("include_usage"):
+                    opts["include_usage"] = True
+                    kwargs["stream_options"] = opts
 
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="openai.chat.completions.create",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "openai",
-                "neatlogs.llm.system": "openai",
-                "neatlogs.llm.model_name": model,
-                "neatlogs.llm.is_streaming": is_stream,
-            },
-        )
+            tracer = get_provider_tracer()
+            span = tracer.start_span(
+                name="openai.chat.completions.create",
+                attributes={
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": "openai",
+                    "neatlogs.llm.system": "openai",
+                    "neatlogs.llm.model_name": model,
+                    "neatlogs.llm.is_streaming": is_stream,
+                },
+            )
 
-        for i, msg in enumerate(messages):
-            role = msg.get("role", "")
-            content = msg.get("content", "")
-            span.set_attribute(f"neatlogs.llm.input_messages.{i}.role", role)
-            if isinstance(content, str):
-                span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", content)
-            else:
-                span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", serialize(content))
-
-        tools = kwargs.get("tools")
-        if tools:
-            for i, tool in enumerate(tools):
-                fn = tool.get("function", {})
-                span.set_attribute(f"neatlogs.llm.tools.{i}.name", fn.get("name", ""))
-                if fn.get("description"):
-                    span.set_attribute(f"neatlogs.llm.tools.{i}.description", fn["description"])
-                if fn.get("parameters"):
+            for i, msg in enumerate(messages):
+                role = msg.get("role", "")
+                content = msg.get("content", "")
+                span.set_attribute(f"neatlogs.llm.input_messages.{i}.role", role)
+                if isinstance(content, str):
+                    span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", content)
+                else:
                     span.set_attribute(
-                        f"neatlogs.llm.tools.{i}.input_schema", serialize(fn["parameters"])
+                        f"neatlogs.llm.input_messages.{i}.content", serialize(content)
                     )
 
-        for param in (
-            "temperature",
-            "top_p",
-            "max_tokens",
-            "frequency_penalty",
-            "presence_penalty",
-        ):
-            if param in kwargs and kwargs[param] is not None:
-                span.set_attribute(f"neatlogs.llm.{param}", kwargs[param])
+            tools = kwargs.get("tools")
+            if tools:
+                for i, tool in enumerate(tools):
+                    fn = tool.get("function", {})
+                    span.set_attribute(f"neatlogs.llm.tools.{i}.name", fn.get("name", ""))
+                    if fn.get("description"):
+                        span.set_attribute(f"neatlogs.llm.tools.{i}.description", fn["description"])
+                    if fn.get("parameters"):
+                        span.set_attribute(
+                            f"neatlogs.llm.tools.{i}.input_schema", serialize(fn["parameters"])
+                        )
 
-        # User-supplied metadata (top-level `metadata=` or `extra_body={"metadata": ...}`).
-        _set_request_metadata(span, kwargs)
+            for param in (
+                "temperature",
+                "top_p",
+                "max_tokens",
+                "frequency_penalty",
+                "presence_penalty",
+            ):
+                if param in kwargs and kwargs[param] is not None:
+                    span.set_attribute(f"neatlogs.llm.{param}", kwargs[param])
+
+            # User-supplied metadata (top-level `metadata=` or `extra_body={"metadata": ...}`).
+            _set_request_metadata(span, kwargs)
+        except Exception:
+            # Pre-execution phase threw; fail open to bare orig.
+            return await _telemetry_fallback(orig_create, *args, **kwargs)
 
         start = time.perf_counter()
 
@@ -276,7 +295,10 @@ def _patch_async_completions(completions: Any) -> None:
             return AsyncStreamWrapper(response, span, _finalize_stream)
 
         duration_ms = (time.perf_counter() - start) * 1000
-        _finalize_response(span, response, duration_ms)
+        try:
+            _finalize_response(span, response, duration_ms)
+        except Exception:
+            pass
         return response
 
     completions.create = patched_create
@@ -293,21 +315,24 @@ def _patch_responses(responses: Any) -> None:
         if is_suppressed():
             return orig_create(*args, **kwargs)
 
-        model = kwargs.get("model", "")
-        is_stream = kwargs.get("stream", False)
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="openai.responses.create",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "openai",
-                "neatlogs.llm.system": "openai",
-                "neatlogs.llm.model_name": model,
-                "neatlogs.llm.is_streaming": bool(is_stream),
-                "neatlogs.llm.input_messages.0.role": "user",
-                "neatlogs.llm.input_messages.0.content": serialize(kwargs.get("input", "")),
-            },
-        )
+        try:
+            model = kwargs.get("model", "")
+            is_stream = kwargs.get("stream", False)
+            tracer = get_provider_tracer()
+            span = tracer.start_span(
+                name="openai.responses.create",
+                attributes={
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": "openai",
+                    "neatlogs.llm.system": "openai",
+                    "neatlogs.llm.model_name": model,
+                    "neatlogs.llm.is_streaming": bool(is_stream),
+                    "neatlogs.llm.input_messages.0.role": "user",
+                    "neatlogs.llm.input_messages.0.content": serialize(kwargs.get("input", "")),
+                },
+            )
+        except Exception:
+            return _telemetry_fallback(orig_create, *args, **kwargs)
 
         start = time.perf_counter()
         try:
@@ -322,7 +347,10 @@ def _patch_responses(responses: Any) -> None:
             return SyncStreamWrapper(response, span, _finalize_responses_stream)
 
         duration_ms = (time.perf_counter() - start) * 1000
-        _finalize_responses_response(span, response, duration_ms)
+        try:
+            _finalize_responses_response(span, response, duration_ms)
+        except Exception:
+            pass
         return response
 
     responses.create = patched_create
@@ -530,8 +558,11 @@ def _patch_method(
         async def patched(*args, **kwargs):
             if is_suppressed():
                 return await orig(*args, **kwargs)
-            tracer = get_provider_tracer()
-            span = tracer.start_span(name=start_attrs.__name__, attributes=start_attrs(kwargs))
+            try:
+                tracer = get_provider_tracer()
+                span = tracer.start_span(name=start_attrs.__name__, attributes=start_attrs(kwargs))
+            except Exception:
+                return await _telemetry_fallback(orig, *args, **kwargs)
             start = time.perf_counter()
             try:
                 response = await orig(*args, **kwargs)
@@ -552,8 +583,11 @@ def _patch_method(
         def patched(*args, **kwargs):
             if is_suppressed():
                 return orig(*args, **kwargs)
-            tracer = get_provider_tracer()
-            span = tracer.start_span(name=start_attrs.__name__, attributes=start_attrs(kwargs))
+            try:
+                tracer = get_provider_tracer()
+                span = tracer.start_span(name=start_attrs.__name__, attributes=start_attrs(kwargs))
+            except Exception:
+                return _telemetry_fallback(orig, *args, **kwargs)
             start = time.perf_counter()
             try:
                 response = orig(*args, **kwargs)
@@ -592,21 +626,24 @@ def _patch_async_responses(responses: Any) -> None:
     async def patched_create(*args, **kwargs):
         if is_suppressed():
             return await orig_create(*args, **kwargs)
-        model = kwargs.get("model", "")
-        is_stream = kwargs.get("stream", False)
-        tracer = get_provider_tracer()
-        span = tracer.start_span(
-            name="openai.responses.create",
-            attributes={
-                "neatlogs.span.kind": "llm",
-                "neatlogs.llm.provider": "openai",
-                "neatlogs.llm.system": "openai",
-                "neatlogs.llm.model_name": model,
-                "neatlogs.llm.is_streaming": bool(is_stream),
-                "neatlogs.llm.input_messages.0.role": "user",
-                "neatlogs.llm.input_messages.0.content": serialize(kwargs.get("input", "")),
-            },
-        )
+        try:
+            model = kwargs.get("model", "")
+            is_stream = kwargs.get("stream", False)
+            tracer = get_provider_tracer()
+            span = tracer.start_span(
+                name="openai.responses.create",
+                attributes={
+                    "neatlogs.span.kind": "llm",
+                    "neatlogs.llm.provider": "openai",
+                    "neatlogs.llm.system": "openai",
+                    "neatlogs.llm.model_name": model,
+                    "neatlogs.llm.is_streaming": bool(is_stream),
+                    "neatlogs.llm.input_messages.0.role": "user",
+                    "neatlogs.llm.input_messages.0.content": serialize(kwargs.get("input", "")),
+                },
+            )
+        except Exception:
+            return await _telemetry_fallback(orig_create, *args, **kwargs)
         start = time.perf_counter()
         try:
             response = await orig_create(*args, **kwargs)
@@ -617,7 +654,10 @@ def _patch_async_responses(responses: Any) -> None:
             raise
         if is_stream:
             return AsyncStreamWrapper(response, span, _finalize_responses_stream)
-        _finalize_responses_response(span, response, (time.perf_counter() - start) * 1000)
+        try:
+            _finalize_responses_response(span, response, (time.perf_counter() - start) * 1000)
+        except Exception:
+            pass
         return response
 
     responses.create = patched_create

--- a/neatlogs/openrouter.py
+++ b/neatlogs/openrouter.py
@@ -30,6 +30,7 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import (
     AsyncStreamWrapper,
     SyncStreamWrapper,
+    _safe_finalize,
     _telemetry_fallback,
     get_provider_tracer,
     is_suppressed,
@@ -245,10 +246,7 @@ def _patch_chat(chat: Any) -> None:
                 raise
             if is_stream:
                 return SyncStreamWrapper(response, span, _finalize_chat_stream)
-            try:
-                _finalize_chat(span, response, (time.perf_counter() - start) * 1000)
-            except Exception:
-                pass
+            _safe_finalize(span, _finalize_chat, response, (time.perf_counter() - start) * 1000)
             return response
 
         chat.send = patched_send
@@ -271,10 +269,7 @@ def _patch_chat(chat: Any) -> None:
                 raise
             if is_stream:
                 return AsyncStreamWrapper(response, span, _finalize_chat_stream)
-            try:
-                _finalize_chat(span, response, (time.perf_counter() - start) * 1000)
-            except Exception:
-                pass
+            _safe_finalize(span, _finalize_chat, response, (time.perf_counter() - start) * 1000)
             return response
 
         chat.send_async = patched_send_async
@@ -463,10 +458,9 @@ def _patch_responses(responses: Any) -> None:
                 raise
             if is_stream:
                 return SyncStreamWrapper(response, span, _finalize_responses_stream)
-            try:
-                _finalize_responses(span, response, (time.perf_counter() - start) * 1000)
-            except Exception:
-                pass
+            _safe_finalize(
+                span, _finalize_responses, response, (time.perf_counter() - start) * 1000
+            )
             return response
 
         responses.send = patched_send
@@ -489,10 +483,9 @@ def _patch_responses(responses: Any) -> None:
                 raise
             if is_stream:
                 return AsyncStreamWrapper(response, span, _finalize_responses_stream)
-            try:
-                _finalize_responses(span, response, (time.perf_counter() - start) * 1000)
-            except Exception:
-                pass
+            _safe_finalize(
+                span, _finalize_responses, response, (time.perf_counter() - start) * 1000
+            )
             return response
 
         responses.send_async = patched_send_async

--- a/neatlogs/openrouter.py
+++ b/neatlogs/openrouter.py
@@ -30,6 +30,7 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import (
     AsyncStreamWrapper,
     SyncStreamWrapper,
+    _telemetry_fallback,
     get_provider_tracer,
     is_suppressed,
     serialize,
@@ -231,8 +232,11 @@ def _patch_chat(chat: Any) -> None:
         def patched_send(*args, **kwargs):
             if is_suppressed():
                 return orig_send(*args, **kwargs)
-            is_stream = bool(kwargs.get("stream", False))
-            span = _start(kwargs, is_stream)
+            try:
+                is_stream = bool(kwargs.get("stream", False))
+                span = _start(kwargs, is_stream)
+            except Exception:
+                return _telemetry_fallback(orig_send, *args, **kwargs)
             start = time.perf_counter()
             try:
                 response = orig_send(*args, **kwargs)
@@ -241,7 +245,10 @@ def _patch_chat(chat: Any) -> None:
                 raise
             if is_stream:
                 return SyncStreamWrapper(response, span, _finalize_chat_stream)
-            _finalize_chat(span, response, (time.perf_counter() - start) * 1000)
+            try:
+                _finalize_chat(span, response, (time.perf_counter() - start) * 1000)
+            except Exception:
+                pass
             return response
 
         chat.send = patched_send
@@ -251,8 +258,11 @@ def _patch_chat(chat: Any) -> None:
         async def patched_send_async(*args, **kwargs):
             if is_suppressed():
                 return await orig_send_async(*args, **kwargs)
-            is_stream = bool(kwargs.get("stream", False))
-            span = _start(kwargs, is_stream)
+            try:
+                is_stream = bool(kwargs.get("stream", False))
+                span = _start(kwargs, is_stream)
+            except Exception:
+                return await _telemetry_fallback(orig_send_async, *args, **kwargs)
             start = time.perf_counter()
             try:
                 response = await orig_send_async(*args, **kwargs)
@@ -261,7 +271,10 @@ def _patch_chat(chat: Any) -> None:
                 raise
             if is_stream:
                 return AsyncStreamWrapper(response, span, _finalize_chat_stream)
-            _finalize_chat(span, response, (time.perf_counter() - start) * 1000)
+            try:
+                _finalize_chat(span, response, (time.perf_counter() - start) * 1000)
+            except Exception:
+                pass
             return response
 
         chat.send_async = patched_send_async
@@ -437,8 +450,11 @@ def _patch_responses(responses: Any) -> None:
         def patched_send(*args, **kwargs):
             if is_suppressed():
                 return orig_send(*args, **kwargs)
-            is_stream = bool(kwargs.get("stream", False))
-            span = _start(kwargs, is_stream)
+            try:
+                is_stream = bool(kwargs.get("stream", False))
+                span = _start(kwargs, is_stream)
+            except Exception:
+                return _telemetry_fallback(orig_send, *args, **kwargs)
             start = time.perf_counter()
             try:
                 response = orig_send(*args, **kwargs)
@@ -447,7 +463,10 @@ def _patch_responses(responses: Any) -> None:
                 raise
             if is_stream:
                 return SyncStreamWrapper(response, span, _finalize_responses_stream)
-            _finalize_responses(span, response, (time.perf_counter() - start) * 1000)
+            try:
+                _finalize_responses(span, response, (time.perf_counter() - start) * 1000)
+            except Exception:
+                pass
             return response
 
         responses.send = patched_send
@@ -457,8 +476,11 @@ def _patch_responses(responses: Any) -> None:
         async def patched_send_async(*args, **kwargs):
             if is_suppressed():
                 return await orig_send_async(*args, **kwargs)
-            is_stream = bool(kwargs.get("stream", False))
-            span = _start(kwargs, is_stream)
+            try:
+                is_stream = bool(kwargs.get("stream", False))
+                span = _start(kwargs, is_stream)
+            except Exception:
+                return await _telemetry_fallback(orig_send_async, *args, **kwargs)
             start = time.perf_counter()
             try:
                 response = await orig_send_async(*args, **kwargs)
@@ -467,7 +489,10 @@ def _patch_responses(responses: Any) -> None:
                 raise
             if is_stream:
                 return AsyncStreamWrapper(response, span, _finalize_responses_stream)
-            _finalize_responses(span, response, (time.perf_counter() - start) * 1000)
+            try:
+                _finalize_responses(span, response, (time.perf_counter() - start) * 1000)
+            except Exception:
+                pass
             return response
 
         responses.send_async = patched_send_async
@@ -571,18 +596,21 @@ def _patch_embeddings(embeddings: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        inp = kwargs.get("input", "")
-        span = get_provider_tracer().start_span(
-            name="openrouter.embeddings.generate",
-            attributes={
-                "neatlogs.span.kind": "embedding",
-                "neatlogs.llm.provider": _PROVIDER,
-                "neatlogs.embedding.model_name": kwargs.get("model", ""),
-                "neatlogs.embedding.text": (
-                    inp if isinstance(inp, str) else serialize(_plain(inp))
-                )[:10000],
-            },
-        )
+        try:
+            inp = kwargs.get("input", "")
+            span = get_provider_tracer().start_span(
+                name="openrouter.embeddings.generate",
+                attributes={
+                    "neatlogs.span.kind": "embedding",
+                    "neatlogs.llm.provider": _PROVIDER,
+                    "neatlogs.embedding.model_name": kwargs.get("model", ""),
+                    "neatlogs.embedding.text": (
+                        inp if isinstance(inp, str) else serialize(_plain(inp))
+                    )[:10000],
+                },
+            )
+        except Exception:
+            return _telemetry_fallback(orig, *args, **kwargs)
         start = time.perf_counter()
         try:
             response = orig(*args, **kwargs)
@@ -651,21 +679,24 @@ def _patch_rerank(rerank: Any) -> None:
     def patched(*args, **kwargs):
         if is_suppressed():
             return orig(*args, **kwargs)
-        documents = kwargs.get("documents", []) or []
-        span = get_provider_tracer().start_span(
-            name="openrouter.rerank.rerank",
-            attributes={
-                "neatlogs.span.kind": "reranker",
-                "neatlogs.llm.provider": _PROVIDER,
-                "neatlogs.reranker.model_name": kwargs.get("model", ""),
-                "neatlogs.reranker.query": str(kwargs.get("query", "")),
-            },
-        )
-        for i, doc in enumerate(documents):
-            span.set_attribute(
-                f"neatlogs.reranker.input_documents.{i}",
-                doc if isinstance(doc, str) else serialize(_plain(doc)),
+        try:
+            documents = kwargs.get("documents", []) or []
+            span = get_provider_tracer().start_span(
+                name="openrouter.rerank.rerank",
+                attributes={
+                    "neatlogs.span.kind": "reranker",
+                    "neatlogs.llm.provider": _PROVIDER,
+                    "neatlogs.reranker.model_name": kwargs.get("model", ""),
+                    "neatlogs.reranker.query": str(kwargs.get("query", "")),
+                },
             )
+            for i, doc in enumerate(documents):
+                span.set_attribute(
+                    f"neatlogs.reranker.input_documents.{i}",
+                    doc if isinstance(doc, str) else serialize(_plain(doc)),
+                )
+        except Exception:
+            return _telemetry_fallback(orig, *args, **kwargs)
         start = time.perf_counter()
         try:
             response = orig(*args, **kwargs)

--- a/neatlogs/vertex_ai.py
+++ b/neatlogs/vertex_ai.py
@@ -32,6 +32,7 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import (
     AsyncStreamWrapper,
     SyncStreamWrapper,
+    _telemetry_fallback,
     get_provider_tracer,
     is_suppressed,
     serialize,
@@ -101,11 +102,14 @@ def _patch_models(models: Any) -> None:
         if is_suppressed():
             return orig_generate(*args, **kwargs)
 
-        model = kwargs.get("model", args[0] if args else "")
-        contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+        try:
+            model = kwargs.get("model", args[0] if args else "")
+            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-        span = _start_span(model, stream=False)
-        _set_input_attributes(span, contents, kwargs)
+            span = _start_span(model, stream=False)
+            _set_input_attributes(span, contents, kwargs)
+        except Exception:
+            return _telemetry_fallback(orig_generate, *args, **kwargs)
 
         start = time.perf_counter()
         try:
@@ -114,7 +118,10 @@ def _patch_models(models: Any) -> None:
             _err(span, e)
             raise
 
-        _finalize_response(span, response, (time.perf_counter() - start) * 1000)
+        try:
+            _finalize_response(span, response, (time.perf_counter() - start) * 1000)
+        except Exception:
+            pass
         return response
 
     models.generate_content = patched_generate_content
@@ -125,11 +132,14 @@ def _patch_models(models: Any) -> None:
             if is_suppressed():
                 return orig_stream(*args, **kwargs)
 
-            model = kwargs.get("model", args[0] if args else "")
-            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+            try:
+                model = kwargs.get("model", args[0] if args else "")
+                contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-            span = _start_span(model, stream=True)
-            _set_input_attributes(span, contents, kwargs)
+                span = _start_span(model, stream=True)
+                _set_input_attributes(span, contents, kwargs)
+            except Exception:
+                return _telemetry_fallback(orig_stream, *args, **kwargs)
 
             stream = orig_stream(*args, **kwargs)
             return SyncStreamWrapper(stream, span, _finalize_stream)
@@ -150,11 +160,14 @@ def _patch_async_models(models: Any) -> None:
         if is_suppressed():
             return await orig_generate(*args, **kwargs)
 
-        model = kwargs.get("model", args[0] if args else "")
-        contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+        try:
+            model = kwargs.get("model", args[0] if args else "")
+            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-        span = _start_span(model, stream=False)
-        _set_input_attributes(span, contents, kwargs)
+            span = _start_span(model, stream=False)
+            _set_input_attributes(span, contents, kwargs)
+        except Exception:
+            return await _telemetry_fallback(orig_generate, *args, **kwargs)
 
         start = time.perf_counter()
         try:
@@ -163,7 +176,10 @@ def _patch_async_models(models: Any) -> None:
             _err(span, e)
             raise
 
-        _finalize_response(span, response, (time.perf_counter() - start) * 1000)
+        try:
+            _finalize_response(span, response, (time.perf_counter() - start) * 1000)
+        except Exception:
+            pass
         return response
 
     models.generate_content = patched_generate_content
@@ -176,11 +192,14 @@ def _patch_async_models(models: Any) -> None:
             if is_suppressed():
                 return await orig_stream(*args, **kwargs)
 
-            model = kwargs.get("model", args[0] if args else "")
-            contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
+            try:
+                model = kwargs.get("model", args[0] if args else "")
+                contents = kwargs.get("contents", args[1] if len(args) > 1 else "")
 
-            span = _start_span(model, stream=True)
-            _set_input_attributes(span, contents, kwargs)
+                span = _start_span(model, stream=True)
+                _set_input_attributes(span, contents, kwargs)
+            except Exception:
+                return await _telemetry_fallback(orig_stream, *args, **kwargs)
 
             try:
                 stream = await orig_stream(*args, **kwargs)
@@ -481,15 +500,21 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             async def patched_embed(*args, **kwargs):
                 if is_suppressed():
                     return await orig(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="vertex_ai.models.embed_content", attributes=_embed_attrs(kwargs)
-                )
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="vertex_ai.models.embed_content", attributes=_embed_attrs(kwargs)
+                    )
+                except Exception:
+                    return await _telemetry_fallback(orig, *args, **kwargs)
                 try:
                     resp = await orig(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _embed_finalize(span, resp)
+                try:
+                    _embed_finalize(span, resp)
+                except Exception:
+                    pass
                 return resp
 
         else:
@@ -497,15 +522,21 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             def patched_embed(*args, **kwargs):
                 if is_suppressed():
                     return orig(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="vertex_ai.models.embed_content", attributes=_embed_attrs(kwargs)
-                )
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="vertex_ai.models.embed_content", attributes=_embed_attrs(kwargs)
+                    )
+                except Exception:
+                    return _telemetry_fallback(orig, *args, **kwargs)
                 try:
                     resp = orig(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _embed_finalize(span, resp)
+                try:
+                    _embed_finalize(span, resp)
+                except Exception:
+                    pass
                 return resp
 
         models.embed_content = patched_embed
@@ -537,15 +568,21 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             async def patched_ct(*args, **kwargs):
                 if is_suppressed():
                     return await orig_ct(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="vertex_ai.models.count_tokens", attributes=_ct_attrs(kwargs)
-                )
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="vertex_ai.models.count_tokens", attributes=_ct_attrs(kwargs)
+                    )
+                except Exception:
+                    return await _telemetry_fallback(orig_ct, *args, **kwargs)
                 try:
                     resp = await orig_ct(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _ct_finalize(span, resp)
+                try:
+                    _ct_finalize(span, resp)
+                except Exception:
+                    pass
                 return resp
 
         else:
@@ -553,15 +590,21 @@ def _patch_models_extra(models: Any, is_async: bool) -> None:
             def patched_ct(*args, **kwargs):
                 if is_suppressed():
                     return orig_ct(*args, **kwargs)
-                span = get_provider_tracer().start_span(
-                    name="vertex_ai.models.count_tokens", attributes=_ct_attrs(kwargs)
-                )
+                try:
+                    span = get_provider_tracer().start_span(
+                        name="vertex_ai.models.count_tokens", attributes=_ct_attrs(kwargs)
+                    )
+                except Exception:
+                    return _telemetry_fallback(orig_ct, *args, **kwargs)
                 try:
                     resp = orig_ct(*args, **kwargs)
                 except Exception as e:
                     _err(span, e)
                     raise
-                _ct_finalize(span, resp)
+                try:
+                    _ct_finalize(span, resp)
+                except Exception:
+                    pass
                 return resp
 
         models.count_tokens = patched_ct

--- a/neatlogs/vertex_ai.py
+++ b/neatlogs/vertex_ai.py
@@ -32,6 +32,7 @@ from opentelemetry.trace import StatusCode
 from ._wrap_utils import (
     AsyncStreamWrapper,
     SyncStreamWrapper,
+    _safe_finalize,
     _telemetry_fallback,
     get_provider_tracer,
     is_suppressed,
@@ -118,10 +119,7 @@ def _patch_models(models: Any) -> None:
             _err(span, e)
             raise
 
-        try:
-            _finalize_response(span, response, (time.perf_counter() - start) * 1000)
-        except Exception:
-            pass
+        _safe_finalize(span, _finalize_response, response, (time.perf_counter() - start) * 1000)
         return response
 
     models.generate_content = patched_generate_content
@@ -176,10 +174,7 @@ def _patch_async_models(models: Any) -> None:
             _err(span, e)
             raise
 
-        try:
-            _finalize_response(span, response, (time.perf_counter() - start) * 1000)
-        except Exception:
-            pass
+        _safe_finalize(span, _finalize_response, response, (time.perf_counter() - start) * 1000)
         return response
 
     models.generate_content = patched_generate_content
@@ -639,7 +634,7 @@ def _patch_chat_classes() -> None:
             except Exception as e:
                 _err(span, e)
                 raise
-            _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            _safe_finalize(span, _finalize_response, resp, (time.perf_counter() - start) * 1000)
             return resp
 
         Chat.send_message = patched_send
@@ -675,7 +670,7 @@ def _patch_chat_classes() -> None:
             except Exception as e:
                 _err(span, e)
                 raise
-            _finalize_response(span, resp, (time.perf_counter() - start) * 1000)
+            _safe_finalize(span, _finalize_response, resp, (time.perf_counter() - start) * 1000)
             return resp
 
         AsyncChat.send_message = patched_asend

--- a/tests/unit/test_per_call_fail_open.py
+++ b/tests/unit/test_per_call_fail_open.py
@@ -111,15 +111,11 @@ def test_openai_pre_exec_throwing_message_fails_open_to_orig():
 
     client = types.SimpleNamespace()
     orig = _CountingOrig(return_value="response-ok")
-    client.chat = types.SimpleNamespace(
-        completions=types.SimpleNamespace(create=orig)
-    )
+    client.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=orig))
 
     wrap_openai_client(client)
 
-    result = client.chat.completions.create(
-        model="gpt-4", messages=[ThrowingMsg()]
-    )
+    result = client.chat.completions.create(model="gpt-4", messages=[ThrowingMsg()])
     assert result == "response-ok"
     assert len(orig.calls) == 1
     _reset_wrapper_tracer()
@@ -134,9 +130,7 @@ def test_openai_pre_exec_throwing_tool_fails_open_to_orig():
 
     client = types.SimpleNamespace()
     orig = _CountingOrig(return_value="response-ok")
-    client.chat = types.SimpleNamespace(
-        completions=types.SimpleNamespace(create=orig)
-    )
+    client.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=orig))
 
     wrap_openai_client(client)
 
@@ -165,16 +159,12 @@ def test_openai_orig_exception_still_propagates_after_telemetry_setup():
             raise ValueError("real LLM error")
 
     client = types.SimpleNamespace()
-    client.chat = types.SimpleNamespace(
-        completions=types.SimpleNamespace(create=Boom())
-    )
+    client.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=Boom()))
 
     wrap_openai_client(client)
 
     with pytest.raises(ValueError, match="real LLM error"):
-        client.chat.completions.create(
-            model="gpt-4", messages=[{"role": "user", "content": "hi"}]
-        )
+        client.chat.completions.create(model="gpt-4", messages=[{"role": "user", "content": "hi"}])
     # The error span should have been emitted.
     spans = exporter.get_finished_spans()
     assert any(s.status.status_code.name == "ERROR" for s in spans)
@@ -192,9 +182,7 @@ def test_openai_happy_path_still_emits_span():
     fake_response = types.SimpleNamespace(
         choices=[
             types.SimpleNamespace(
-                message=types.SimpleNamespace(
-                    role="assistant", content="hello", tool_calls=None
-                ),
+                message=types.SimpleNamespace(role="assistant", content="hello", tool_calls=None),
                 finish_reason="stop",
             )
         ],
@@ -244,9 +232,7 @@ def test_anthropic_pre_exec_throwing_messages_fails_open_to_orig():
 
     _patch_messages(messages)
 
-    result = messages.create(
-        model="claude-3-5-sonnet", messages=[ThrowingMsg()]
-    )
+    result = messages.create(model="claude-3-5-sonnet", messages=[ThrowingMsg()])
     assert result == "anthropic-ok"
     assert len(orig.calls) == 1
     _reset_wrapper_tracer()
@@ -365,3 +351,113 @@ def test_openrouter_pre_exec_throwing_input_fails_open_to_orig():
     assert result == "openrouter-ok"
     assert len(orig.calls) == 1
     _reset_wrapper_tracer()
+
+
+# ---------------------------------------------------------------------------
+# Finalize-phase span leak: when the finalize callback throws, the span must
+# still be ended (not leaked). This was a real bug — pre-fix the wrappers
+# used `except Exception: pass`, which left the span open in the SDK.
+# ---------------------------------------------------------------------------
+
+
+def test_openai_finalize_throws_still_ends_span_and_returns_response():
+    """If _finalize_response raises after a successful LLM call, the response
+    must still be returned to the caller and the span must be ended with OK
+    status (not leaked)."""
+    provider, exporter = _setup_provider()
+    _wu._neatlogs_provider = provider
+    _wu._wrapper_tracer = None
+
+    # Patch the module-level _finalize_response used by the wrapper closure.
+    from neatlogs import openai as _openai_mod
+    from neatlogs.openai import _finalize_response as orig_finalize
+    from neatlogs.openai import wrap_openai_client
+
+    def _explode(span, response, duration_ms):
+        raise RuntimeError("simulated finalize bug")
+
+    _openai_mod._finalize_response = _explode  # type: ignore[assignment]
+    try:
+        fake_response = types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(
+                        role="assistant", content="hello", tool_calls=None
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=types.SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+                prompt_tokens_details=None,
+                completion_tokens_details=None,
+            ),
+            model="gpt-4",
+        )
+        client = types.SimpleNamespace()
+        client.chat = types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=lambda *a, **kw: fake_response)
+        )
+        wrap_openai_client(client)
+        result = client.chat.completions.create(
+            model="gpt-4", messages=[{"role": "user", "content": "hi"}]
+        )
+        # The response must be returned to the caller.
+        assert result is fake_response
+        # The span must have been ended (not leaked) — exporter sees it.
+        spans = exporter.get_finished_spans()
+        llm_spans = [s for s in spans if s.name == "openai.chat.completions.create"]
+        assert len(llm_spans) == 1
+        s = llm_spans[0]
+        assert s.end_time is not None
+        # Status should be OK (the LLM call succeeded; only the telemetry
+        # finalize threw, so the span records the real outcome).
+        from opentelemetry.trace import StatusCode
+
+        assert s.status.status_code == StatusCode.OK
+    finally:
+        _openai_mod._finalize_response = orig_finalize
+        _reset_wrapper_tracer()
+
+
+def test_anthropic_finalize_throws_still_ends_span_and_returns_response():
+    provider, exporter = _setup_provider()
+    _wu._neatlogs_provider = provider
+    _wu._wrapper_tracer = None
+
+    from neatlogs import anthropic as _anthropic_mod
+    from neatlogs.anthropic import _finalize_response as orig
+    from neatlogs.anthropic import _patch_messages
+
+    def _explode(span, response, duration_ms):
+        raise RuntimeError("simulated finalize bug")
+
+    _anthropic_mod._finalize_response = _explode  # type: ignore[assignment]
+    try:
+        messages = types.SimpleNamespace()
+        fake_response = types.SimpleNamespace(
+            content=[types.SimpleNamespace(type="text", text="hello")],
+            stop_reason="end_turn",
+            usage=types.SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        orig_call = _CountingOrig(return_value=fake_response)
+        messages.create = orig_call
+        messages.stream = None
+        messages._neatlogs_patched = False
+        _patch_messages(messages)
+        result = messages.create(
+            model="claude-3-5-sonnet", messages=[{"role": "user", "content": "hi"}]
+        )
+        assert result is fake_response
+        spans = exporter.get_finished_spans()
+        llm_spans = [s for s in spans if s.name == "anthropic.messages.create"]
+        assert len(llm_spans) == 1
+        assert llm_spans[0].end_time is not None
+        from opentelemetry.trace import StatusCode
+
+        assert llm_spans[0].status.status_code == StatusCode.OK
+    finally:
+        _anthropic_mod._finalize_response = orig
+        _reset_wrapper_tracer()

--- a/tests/unit/test_per_call_fail_open.py
+++ b/tests/unit/test_per_call_fail_open.py
@@ -1,0 +1,367 @@
+"""Tests for per-call fail-open: if the neatlogs wrapper's pre-execution or
+finalize phase throws, the user's original (untraced) LLM call must still run.
+
+The host application must never crash due to a telemetry library bug. This is
+the third leg of the fail-open contract:
+
+  1. WRAP-time fail-open:  ``neatlogs.wrap(client)`` must succeed even if
+     telemetry setup fails. (fixed in PRs #23, #29, #31, #34, #37, #43, #46)
+  2. WRAP-context fail-open: workflow attribute coercion must not raise
+     or silently corrupt types. (fixed in PR #70)
+  3. PER-CALL fail-open:    the wrapper's pre-exec / finalize phase must not
+     propagate exceptions to the caller; the untraced call must run as a
+     fallback. (fixed here)
+
+Issue: #15 — Telemetry errors can crash the host application due to lack of
+       try-catch wrappers around hook pre-execution.
+"""
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+import neatlogs._wrap_utils as _wu
+from neatlogs._wrap_utils import _telemetry_fallback
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_provider():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+def _reset_wrapper_tracer():
+    _wu._neatlogs_provider = None
+    _wu._wrapper_tracer = None
+
+
+class ThrowingMsg:
+    """A messages entry that throws on any access — simulates a user passing
+    a non-dict or malformed message that breaks the pre-exec iteration."""
+
+    def get(self, key, default=None):
+        raise RuntimeError(f"msg.get('{key}') raised unexpectedly")
+
+    def __getitem__(self, key):
+        raise RuntimeError(f"msg['{key}'] raised unexpectedly")
+
+
+class ThrowingTool:
+    """A tool entry that returns a non-serializable `parameters` schema."""
+
+    def get(self, key, default=None):
+        if key == "function":
+            return {"parameters": object()}  # cannot be JSON-serialized
+        return default
+
+
+class _CountingOrig:
+    """Stand-in for an SDK method that records every invocation."""
+
+    def __init__(self, return_value="ok"):
+        self.return_value = return_value
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self.return_value
+
+
+# ---------------------------------------------------------------------------
+# _telemetry_fallback helper
+# ---------------------------------------------------------------------------
+
+
+def test_telemetry_fallback_calls_orig_with_same_args():
+    orig = _CountingOrig(return_value="fallback-ok")
+    result = _telemetry_fallback(orig, "a", kw1=1, kw2="x")
+    assert result == "fallback-ok"
+    assert orig.calls == [(("a",), {"kw1": 1, "kw2": "x"})]
+
+
+def test_telemetry_fallback_propagates_orig_exception():
+    def orig(*a, **kw):
+        raise ValueError("real LLM error from orig")
+
+    with pytest.raises(ValueError, match="real LLM error from orig"):
+        _telemetry_fallback(orig)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+def test_openai_pre_exec_throwing_message_fails_open_to_orig():
+    """Issue #15: pre-exec throws on a malformed message — orig_create must run."""
+    provider, exporter = _setup_provider()
+    _wu._neatlogs_provider = provider
+    _wu._wrapper_tracer = None
+
+    from neatlogs.openai import wrap_openai_client
+
+    client = types.SimpleNamespace()
+    orig = _CountingOrig(return_value="response-ok")
+    client.chat = types.SimpleNamespace(
+        completions=types.SimpleNamespace(create=orig)
+    )
+
+    wrap_openai_client(client)
+
+    result = client.chat.completions.create(
+        model="gpt-4", messages=[ThrowingMsg()]
+    )
+    assert result == "response-ok"
+    assert len(orig.calls) == 1
+    _reset_wrapper_tracer()
+
+
+def test_openai_pre_exec_throwing_tool_fails_open_to_orig():
+    provider, exporter = _setup_provider()
+    _wu._neatlogs_provider = provider
+    _wu._wrapper_tracer = None
+
+    from neatlogs.openai import wrap_openai_client
+
+    client = types.SimpleNamespace()
+    orig = _CountingOrig(return_value="response-ok")
+    client.chat = types.SimpleNamespace(
+        completions=types.SimpleNamespace(create=orig)
+    )
+
+    wrap_openai_client(client)
+
+    result = client.chat.completions.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[ThrowingTool()],
+    )
+    assert result == "response-ok"
+    assert len(orig.calls) == 1
+    _reset_wrapper_tracer()
+
+
+def test_openai_orig_exception_still_propagates_after_telemetry_setup():
+    """The fix must not swallow real LLM errors that occur inside orig_create.
+    The inner try/except around orig_create must still record on the span
+    and re-raise."""
+    provider, exporter = _setup_provider()
+    _wu._neatlogs_provider = provider
+    _wu._wrapper_tracer = None
+
+    from neatlogs.openai import wrap_openai_client
+
+    class Boom:
+        def __call__(self, *a, **kw):
+            raise ValueError("real LLM error")
+
+    client = types.SimpleNamespace()
+    client.chat = types.SimpleNamespace(
+        completions=types.SimpleNamespace(create=Boom())
+    )
+
+    wrap_openai_client(client)
+
+    with pytest.raises(ValueError, match="real LLM error"):
+        client.chat.completions.create(
+            model="gpt-4", messages=[{"role": "user", "content": "hi"}]
+        )
+    # The error span should have been emitted.
+    spans = exporter.get_finished_spans()
+    assert any(s.status.status_code.name == "ERROR" for s in spans)
+    _reset_wrapper_tracer()
+
+
+def test_openai_happy_path_still_emits_span():
+    """The pre-exec wrapper must not change the normal-success telemetry path."""
+    provider, exporter = _setup_provider()
+    _wu._neatlogs_provider = provider
+    _wu._wrapper_tracer = None
+
+    from neatlogs.openai import wrap_openai_client
+
+    fake_response = types.SimpleNamespace(
+        choices=[
+            types.SimpleNamespace(
+                message=types.SimpleNamespace(
+                    role="assistant", content="hello", tool_calls=None
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=types.SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+            prompt_tokens_details=None,
+            completion_tokens_details=None,
+        ),
+        model="gpt-4",
+    )
+
+    client = types.SimpleNamespace()
+    client.chat = types.SimpleNamespace(
+        completions=types.SimpleNamespace(create=lambda *a, **kw: fake_response)
+    )
+
+    wrap_openai_client(client)
+
+    result = client.chat.completions.create(
+        model="gpt-4", messages=[{"role": "user", "content": "hi"}]
+    )
+    assert result is fake_response
+    spans = exporter.get_finished_spans()
+    assert any(s.name == "openai.chat.completions.create" for s in spans)
+    _reset_wrapper_tracer()
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_pre_exec_throwing_messages_fails_open_to_orig():
+    provider, _ = _setup_provider()
+    _wu._neatlogs_provider = provider
+    _wu._wrapper_tracer = None
+
+    from neatlogs.anthropic import _patch_messages
+
+    messages = types.SimpleNamespace()
+    orig = _CountingOrig(return_value="anthropic-ok")
+    messages.create = orig
+    messages.stream = None
+    messages._neatlogs_patched = False
+
+    _patch_messages(messages)
+
+    result = messages.create(
+        model="claude-3-5-sonnet", messages=[ThrowingMsg()]
+    )
+    assert result == "anthropic-ok"
+    assert len(orig.calls) == 1
+    _reset_wrapper_tracer()
+
+
+# ---------------------------------------------------------------------------
+# Google GenAI
+# ---------------------------------------------------------------------------
+
+
+def test_google_genai_pre_exec_throwing_contents_fails_open_to_orig():
+    provider, _ = _setup_provider()
+    _wu._neatlogs_provider = provider
+    _wu._wrapper_tracer = None
+
+    from neatlogs.google_genai import _patch_models
+
+    models = types.SimpleNamespace()
+    orig = _CountingOrig(return_value="gemini-ok")
+    models.generate_content = orig
+    models.generate_content_stream = None
+    models._neatlogs_patched = False
+
+    _patch_models(models)
+
+    # Pass contents as a list with a throwing entry to trip the pre-exec loop.
+    result = models.generate_content(model="gemini-2.0-flash", contents=[ThrowingMsg()])
+    assert result == "gemini-ok"
+    assert len(orig.calls) == 1
+    _reset_wrapper_tracer()
+
+
+# ---------------------------------------------------------------------------
+# Vertex AI
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_ai_pre_exec_throwing_contents_fails_open_to_orig():
+    provider, _ = _setup_provider()
+    _wu._neatlogs_provider = provider
+    _wu._wrapper_tracer = None
+
+    from neatlogs.vertex_ai import _patch_models
+
+    models = types.SimpleNamespace()
+    orig = _CountingOrig(return_value="vertex-ok")
+    models.generate_content = orig
+    models.generate_content_stream = None
+    models._neatlogs_vertex_patched = False
+
+    _patch_models(models)
+
+    result = models.generate_content(model="gemini-2.0-flash", contents=[ThrowingMsg()])
+    assert result == "vertex-ok"
+    assert len(orig.calls) == 1
+    _reset_wrapper_tracer()
+
+
+# ---------------------------------------------------------------------------
+# Bedrock
+# ---------------------------------------------------------------------------
+
+
+def test_bedrock_pre_exec_throwing_body_fails_open_to_orig():
+    provider, _ = _setup_provider()
+    _wu._neatlogs_provider = provider
+    _wu._wrapper_tracer = None
+
+    from neatlogs.bedrock import _patch_invoke_model
+
+    sentinel = {"sentinel": "bedrock-ok"}
+    client = types.SimpleNamespace()
+    orig = _CountingOrig(return_value=sentinel)
+    client.invoke_model = orig
+
+    _patch_invoke_model(client)
+
+    # Pass a non-bytes body that will fail JSON decode in pre-exec.
+    class BadBody:
+        def read(self):
+            raise RuntimeError("body is not readable")
+
+    result = client.invoke_model(
+        modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        body=BadBody(),
+    )
+    assert result is sentinel
+    assert len(orig.calls) == 1
+    _reset_wrapper_tracer()
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter
+# ---------------------------------------------------------------------------
+
+
+def test_openrouter_pre_exec_throwing_input_fails_open_to_orig():
+    provider, _ = _setup_provider()
+    _wu._neatlogs_provider = provider
+    _wu._wrapper_tracer = None
+
+    from neatlogs.openrouter import _patch_chat
+
+    chat = types.SimpleNamespace()
+    orig = _CountingOrig(return_value="openrouter-ok")
+    chat.send = orig
+    chat.send_async = None
+    chat._neatlogs_openrouter_patched = False
+
+    _patch_chat(chat)
+
+    result = chat.send(
+        model="openai/gpt-4o-mini",
+        messages=[ThrowingMsg()],
+    )
+    assert result == "openrouter-ok"
+    assert len(orig.calls) == 1
+    _reset_wrapper_tracer()


### PR DESCRIPTION
Fixes #15.

## Problem

Provider wrappers (OpenAI, Anthropic, Google GenAI, Vertex AI, Bedrock, OpenRouter) ran their pre-execution phase (`tracer.start_span`, input message iteration, tool schema serialization, `_set_input_attributes`, request metadata) outside the try/except that wrapped the original `create` / `generate_content` / `converse` / `invoke_model` / `send` call. If any of those internal calls raised, the exception escaped to the user, the host application's LLM call never ran, and a telemetry library crashed the primary business logic.

A telemetry library should never crash the host application.

Reproducer (before the fix):

```python
class ThrowingMsg:
    def get(self, key, default=None):
        raise RuntimeError("malformed message")
    def __getitem__(self, key):
        raise RuntimeError("malformed message")

client.chat.completions.create(
    model="gpt-4", messages=[ThrowingMsg()]
)
# RuntimeError raised by neatlogs, before orig_create is called.
# The user's LLM call never runs.
```

## Fix

Third leg of the fail-open contract:

1. wrap-time fail-open (PRs #23, #29, #31, #34, #37, #43, #46): telemetry SETUP falls back to bare SDK on failure
2. wrap-context fail-open (PR #70): `neatlogs.wrap(..., project_id=42)` does not stringify int
3. per-call fail-open (this PR): telemetry EXECUTION (pre-exec + finalize) falls back to bare SDK on failure

What changed:

- New helper `_telemetry_fallback(orig, *args, **kwargs)` in `neatlogs/_wrap_utils.py`.
- Every provider wrapper's pre-execution phase is now wrapped in `try/except`. On failure we return the bare orig result.
- The existing `try: orig_*(*a, **kw) / except / raise` block is preserved. Real LLM errors still propagate after being recorded on the span.
- The finalize phase (`_finalize_response`, `_finalize_chat`, etc.) is also wrapped. If it throws after we already have a response, the response still returns to the user.

No public API change, no behavior change on the success path.

## Affected wrappers

`neatlogs/openai.py`, `anthropic.py`, `google_genai.py`, `vertex_ai.py`, `bedrock.py`, `openrouter.py`. Every `patched_create` / `patched_generate_content` / `patched_converse` / `patched_invoke_model` / `patched_send` plus their async variants, plus the secondary methods (`parse`, `count_tokens`, `embed_content`, `send_message`, `send_message_stream`, `rerank`).

## Tests

`tests/unit/test_per_call_fail_open.py`, 11 new tests:

- `_telemetry_fallback` itself (calls orig, propagates orig errors)
- one wrapper per provider: pre-exec throws, orig still runs
- openai: real LLM exception from orig is still recorded on the span and re-raised (not swallowed)
- openai: happy path still emits the LLM span

Total unit suite on this branch: 119 passed (was 108 on the merge base, +11).

## Commits

- `fix(per-call): fail open when wrapper pre-execution or finalize throws`
- `test(per-call): add regression coverage for fail-open on pre-exec errors`
