### PR TITLE
Launch readiness: harden Python telemetry and consume contract v2

### DIFF
--- a/neatlogs/__init__.py
+++ b/neatlogs/__init__.py
@@ -34,7 +34,8 @@ from .core.llm_binder import bind_templates
 from .core.log import log
 from .core.propagation import extract_trace_context, inject_trace_context
 from .decorators import span
-from .init import flush, init, shutdown
+from .errors import NeatlogsConfigurationError, NeatlogsError
+from .init import flush, flush_all, init, shutdown
 from .prompt.client import (
     AsyncPromptClient,
     CachedPrompt,
@@ -278,6 +279,9 @@ __all__ = [
     "init",
     "flush",
     "shutdown",
+    "flush_all",
+    "NeatlogsError",
+    "NeatlogsConfigurationError",
     "span",
     "trace",
     "identify",

--- a/neatlogs/__init__.py
+++ b/neatlogs/__init__.py
@@ -55,6 +55,14 @@ from .prompt.client import (
     update_prompt,
 )
 from .prompt.template import PromptTemplate, SystemPromptTemplate, UserPromptTemplate
+from .schema_v2 import (
+    TELEMETRY_CONTRACT_VERSION,
+    TELEMETRY_SCHEMA_SHA256,
+    TELEMETRY_SCHEMA_VERSION,
+    telemetry_schema,
+    telemetry_schema_bytes,
+    verify_telemetry_schema,
+)
 from .version import __version__
 
 

--- a/neatlogs/_wrap_utils.py
+++ b/neatlogs/_wrap_utils.py
@@ -2,7 +2,7 @@
 Shared infrastructure for Neatlogs provider wrappers.
 
 Only contains truly shared concerns:
-  - TracerProvider bootstrap (auto from env or reuse from init())
+  - private TracerProvider bootstrap (auto from env or reuse from init())
   - configure() for wrapper-only mode
   - Sync/async stream wrapper classes
   - Safe JSON serialization
@@ -28,24 +28,16 @@ _wrapper_tracer: Optional[otel_trace.Tracer] = None
 _wrapper_bootstrapped = False
 _bootstrap_warned = False
 
-# Single source of truth for the provider neatlogs emits into. Set by init()
-# (to the owned/shared/private provider). When non-None, EVERY neatlogs tracer
-# resolves from it instead of the global provider — this is what keeps neatlogs
-# spans off a co-tenant's pipeline (e.g. a user's Langfuse provider) when a
-# private provider is passed to init(tracer_provider=...).
+# Single source of truth for the private provider Neatlogs emits into. Every
+# Neatlogs tracer resolves from it; the process-global provider is never adopted.
 _neatlogs_provider: Optional[TracerProvider] = None
 
 # Optional secondary Client selected only for the current async/thread context.
 # The process-wide provider configured by neatlogs.init() remains the default.
 _active_client: ContextVar[Optional[Any]] = ContextVar("neatlogs.active_client", default=None)
 
-# True when neatlogs emits into a PRIVATE provider distinct from the OTel global
-# (init(tracer_provider=<private>) → isolated mode). This is the auto-detect gate:
-# only in this mode does neatlogs thread its parent via a private context key
-# instead of the global current-span, so a co-tenant instrumentor (openlit /
-# langfuse) keeps nesting under the HOST — never under a neatlogs span, and no
-# neatlogs span ever borrows a foreign parent. In the default single-provider
-# mode this is False and behaviour is byte-for-byte unchanged.
+# True when Neatlogs has its required private provider. Neatlogs threads parents
+# through a private context key so co-tenant instrumentors never inherit them.
 _isolated: bool = False
 
 
@@ -83,7 +75,7 @@ def reset_active_client(token: Any) -> None:
 
 
 def _isolation_active() -> bool:
-    """Auto-detect gate: True in isolated mode (private provider != OTel global)."""
+    """True when a private default or context-scoped Client pipeline is active."""
     return _active_client.get() is not None or _isolated
 
 
@@ -270,7 +262,7 @@ def apply_wrap_context_attributes(span: Any, is_root: bool = True) -> None:
 
 def reset_tracer() -> None:
     """Drop the cached wrapper tracer so the next get_tracer() rebinds to the
-    current global provider. Called by neatlogs.shutdown() — without it, a re-init
+    next private provider. Called by neatlogs.shutdown() — without it, a re-init
     (or a test that swaps the TracerProvider) keeps emitting wrapper spans through
     the previous, now-dead provider."""
     global _wrapper_tracer, _wrapper_bootstrapped
@@ -341,10 +333,9 @@ def get_tracer() -> otel_trace.Tracer:
     if _wrapper_tracer is not None:
         return _wrapper_tracer
 
-    # Prefer the provider init() registered (may be a PRIVATE provider never
-    # installed globally). Only when none is set do we fall back to the global
-    # provider — preserving behaviour for the default single-provider mode.
-    provider = _neatlogs_provider or otel_trace.get_tracer_provider()
+    # Neatlogs never adopts the process-global provider. Wrapper-only mode either
+    # uses the private provider registered by init/configuration or bootstraps one.
+    provider = _neatlogs_provider
     if isinstance(provider, TracerProvider):
         _wrapper_tracer = _ForeignParentGuardTracer(provider.get_tracer("neatlogs.wrapper"))
         return _wrapper_tracer
@@ -364,7 +355,11 @@ def get_tracer() -> otel_trace.Tracer:
         _wrapper_bootstrapped = True
         _bootstrap_from_env(api_key)
 
-    _wrapper_tracer = _ForeignParentGuardTracer(otel_trace.get_tracer("neatlogs.wrapper"))
+    provider = get_neatlogs_provider()
+    if provider is None:
+        _wrapper_tracer = _ForeignParentGuardTracer(otel_trace.get_tracer("neatlogs.wrapper.noop"))
+    else:
+        _wrapper_tracer = _ForeignParentGuardTracer(provider.get_tracer("neatlogs.wrapper"))
     return _wrapper_tracer
 
 
@@ -379,10 +374,17 @@ def get_internal_tracer(scope: str) -> otel_trace.Tracer:
     client = _active_client.get()
     if client is not None:
         return client.get_tracer(scope)
-    provider = _neatlogs_provider or otel_trace.get_tracer_provider()
+    provider = _neatlogs_provider
     if isinstance(provider, TracerProvider):
         return _ForeignParentGuardTracer(provider.get_tracer(scope))
-    return _ForeignParentGuardTracer(otel_trace.get_tracer(scope))
+    # Give wrapper-only configuration one chance to bootstrap a private provider.
+    get_tracer()
+    provider = _neatlogs_provider
+    if isinstance(provider, TracerProvider):
+        return _ForeignParentGuardTracer(provider.get_tracer(scope))
+    return _ForeignParentGuardTracer(
+        otel_trace.NoOpTracerProvider().get_tracer("neatlogs.unconfigured")
+    )
 
 
 class _NeatlogsSpanCM:
@@ -456,8 +458,8 @@ def _bootstrap_from_env(api_key: str) -> None:
         headers={"x-api-key": api_key},
     )
     provider.add_span_processor(BatchSpanProcessor(exporter))
-    otel_trace.set_tracer_provider(provider)
-    logger.debug(f"neatlogs wrapper: auto-bootstrapped TracerProvider → {endpoint}")
+    set_neatlogs_provider(provider)
+    logger.debug(f"neatlogs wrapper: auto-bootstrapped private TracerProvider → {endpoint}")
 
 
 def set_neatlogs_span_in_context(

--- a/neatlogs/client.py
+++ b/neatlogs/client.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import math
 import threading
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 from opentelemetry import trace as otel_trace
@@ -21,6 +22,7 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import SpanLimits, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
 
 from ._wrap_utils import (
     _ForeignParentGuardTracer,
@@ -28,8 +30,11 @@ from ._wrap_utils import (
     activate_client,
     reset_active_client,
 )
+from .core.client_registry import register_client, unregister_client
 from .core.log_exporter import NeatlogsLogFilter
+from .core.masking_exporter import MaskingLogExporter, MaskingSpanExporter
 from .core.span_processor import CompletionMarkerSpanProcessor, NeatlogsSpanProcessor
+from .errors import NeatlogsConfigurationError
 from .version import __version__
 
 
@@ -67,6 +72,8 @@ class Client:
         capture_logs: bool = False,
         batch_size: int = 100,
         flush_interval: float = 5.0,
+        sample_rate: float = 1.0,
+        mask: Callable[[dict[str, Any]], Any] | None = None,
         disable_export: bool = False,
         tracer_provider: TracerProvider | None = None,
     ) -> None:
@@ -78,6 +85,20 @@ class Client:
             raise ValueError("workflow_name is required")
         if tags is not None and not all(isinstance(tag, str) for tag in tags):
             raise ValueError("All tags must be strings")
+        if isinstance(sample_rate, bool) or not isinstance(sample_rate, (int, float)):
+            raise NeatlogsConfigurationError("sample_rate must be a finite number from 0.0 to 1.0")
+        rate = float(sample_rate)
+        if not math.isfinite(rate) or rate < 0.0 or rate > 1.0:
+            raise NeatlogsConfigurationError("sample_rate must be a finite number from 0.0 to 1.0")
+        if tracer_provider is not None and rate != 1.0:
+            raise NeatlogsConfigurationError(
+                "sample_rate cannot configure a caller-owned tracer_provider; "
+                "configure its sampler directly or omit tracer_provider"
+            )
+        if tracer_provider is not None and tracer_provider is otel_trace.get_tracer_provider():
+            raise NeatlogsConfigurationError(
+                "tracer_provider must be private and must not be the process-global provider"
+            )
 
         self.workflow_name = name
         self._state = "running"
@@ -98,6 +119,7 @@ class Client:
 
         self.tracer_provider = tracer_provider or TracerProvider(
             resource=resource,
+            sampler=ParentBased(root=TraceIdRatioBased(rate)),
             span_limits=SpanLimits(max_span_attributes=10_000),
         )
         if tracer_provider is not None:
@@ -107,6 +129,7 @@ class Client:
                 pass
 
         self._span_processor = NeatlogsSpanProcessor(
+            mask=mask,
             emit_completion_markers=False,
             # A private provider is an isolated project pipeline. A caller-owned
             # provider may be shared with host telemetry, so ownership is marked
@@ -126,7 +149,7 @@ class Client:
                 headers={"x-api-key": key},
             )
             batch_processor = BatchSpanProcessor(
-                exporter,
+                MaskingSpanExporter(exporter, mask),
                 max_export_batch_size=batch_size,
                 schedule_delay_millis=int(flush_interval * 1000),
             )
@@ -150,10 +173,13 @@ class Client:
                     headers={"x-api-key": key},
                 )
                 self.log_provider.add_log_record_processor(
-                    NeatlogsLogFilter(BatchLogRecordProcessor(log_exporter))
+                    NeatlogsLogFilter(
+                        BatchLogRecordProcessor(MaskingLogExporter(log_exporter, mask))
+                    )
                 )
 
         atexit.register(self.shutdown)
+        register_client(self)
 
     def get_tracer(self, scope: str):
         tracer = self._tracers.get(scope)
@@ -195,11 +221,12 @@ class Client:
                 self.log_provider.force_flush(timeout_millis=timeout_millis)
             except Exception:
                 success = False
-        try:
-            result = self.tracer_provider.force_flush(timeout_millis=timeout_millis)
-            success = bool(result) and success
-        except Exception:
-            success = False
+        for processor in self._transport_processors:
+            try:
+                result = processor.force_flush(timeout_millis=timeout_millis)
+                success = (result is None or bool(result)) and success
+            except Exception:
+                success = False
         return success
 
     def shutdown(
@@ -235,6 +262,7 @@ class Client:
                 atexit.unregister(self.shutdown)
             except Exception:
                 pass
+            unregister_client(self)
 
     def _perform_shutdown(self, timeout_millis: int, termination_reason: str) -> bool:
         success = True

--- a/neatlogs/contracts/v2/manifest.json
+++ b/neatlogs/contracts/v2/manifest.json
@@ -1,0 +1,8 @@
+{
+  "contract_version": "2.0.0",
+  "schema_version": 2,
+  "schema_file": "neatlogs-telemetry.schema.json",
+  "schema_id": "https://schemas.neatlogs.com/telemetry/v2/neatlogs-telemetry.schema.json",
+  "schema_sha256": "9aec0e1b4e2fba718a1bad060798a881543c56ec8b887c6b0fb8ab147bbaee75",
+  "authority": "https://github.com/neatlogs/skills/tree/main/contracts/v2"
+}

--- a/neatlogs/contracts/v2/neatlogs-telemetry.schema.json
+++ b/neatlogs/contracts/v2/neatlogs-telemetry.schema.json
@@ -1,0 +1,1987 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.neatlogs.com/telemetry/v2/neatlogs-telemetry.schema.json",
+  "title": "NeatLogs Canonical Telemetry Span Envelope v2",
+  "description": "The language-neutral canonical span representation used after capture normalization and before masking/export.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trace_id",
+    "span_id",
+    "parent_span_id",
+    "name",
+    "kind",
+    "ownership",
+    "wrapper",
+    "input",
+    "output",
+    "status",
+    "error",
+    "code",
+    "provenance",
+    "conflicts",
+    "semantic",
+    "attributes"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 2
+    },
+    "trace_id": {
+      "$ref": "#/$defs/traceId"
+    },
+    "span_id": {
+      "$ref": "#/$defs/spanId"
+    },
+    "parent_span_id": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/spanId"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "kind": {
+      "$ref": "#/$defs/spanKind"
+    },
+    "start_time_unix_nano": {
+      "$ref": "#/$defs/uint64String"
+    },
+    "end_time_unix_nano": {
+      "$ref": "#/$defs/uint64String"
+    },
+    "ownership": {
+      "$ref": "#/$defs/ownership"
+    },
+    "wrapper": {
+      "$ref": "#/$defs/wrapper"
+    },
+    "input": {
+      "$ref": "#/$defs/typedValue"
+    },
+    "output": {
+      "$ref": "#/$defs/typedValue"
+    },
+    "status": {
+      "$ref": "#/$defs/status"
+    },
+    "error": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/error"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "code": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/codeLocation"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "provenance": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/provenance"
+      }
+    },
+    "conflicts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/conflict"
+      }
+    },
+    "semantic": {
+      "$ref": "#/$defs/semantic"
+    },
+    "attributes": {
+      "type": "object",
+      "description": "Non-canonical source attributes retained for compatibility and debugging. They never override canonical fields.",
+      "additionalProperties": {
+        "$ref": "#/$defs/jsonValue"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "LLM"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/llmSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "enum": [
+              "TOOL",
+              "MCP_TOOL"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/toolSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "RETRIEVER"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/retrieverSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "RERANKER"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/rerankerSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "EMBEDDING"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/embeddingSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "VECTOR_STORE"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/vectorStoreSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "MEMORY"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/memorySemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "GUARDRAIL"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/guardrailSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "LOG"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/logSemantic"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "traceId": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{32}$"
+    },
+    "spanId": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{16}$"
+    },
+    "uint64String": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)$"
+    },
+    "jsonValue": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        }
+      ]
+    },
+    "spanKind": {
+      "type": "string",
+      "enum": [
+        "WORKFLOW",
+        "AGENT",
+        "CHAIN",
+        "TASK",
+        "LLM",
+        "TOOL",
+        "MCP_TOOL",
+        "RETRIEVER",
+        "RERANKER",
+        "EMBEDDING",
+        "VECTOR_STORE",
+        "MEMORY",
+        "GUARDRAIL",
+        "LOG",
+        "HTTP",
+        "UNKNOWN"
+      ]
+    },
+    "ownership": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner",
+        "provider_generation",
+        "project_key_id",
+        "propagation"
+      ],
+      "properties": {
+        "owner": {
+          "type": "string",
+          "enum": [
+            "neatlogs-sdk",
+            "neatlogs-ingest-adapter",
+            "neatlogs-backend-recovery",
+            "external-otel"
+          ]
+        },
+        "provider_generation": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "project_key_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "propagation": {
+          "type": "string",
+          "enum": [
+            "local-private-context",
+            "explicit-neatlogs-remote",
+            "backend-projection",
+            "external-ingest"
+          ]
+        }
+      }
+    },
+    "wrapper": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "captured",
+        "integration",
+        "integration_version",
+        "capture_fidelity"
+      ],
+      "properties": {
+        "captured": {
+          "type": "boolean"
+        },
+        "integration": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "integration_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "capture_fidelity": {
+          "type": "string",
+          "enum": [
+            "native",
+            "normalized",
+            "flattened",
+            "synthetic-recovery",
+            "unknown"
+          ]
+        }
+      }
+    },
+    "typedValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "value",
+        "media"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "none",
+            "text",
+            "json",
+            "messages",
+            "documents",
+            "media",
+            "binary-reference"
+          ]
+        },
+        "value": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "media": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/mediaReference"
+          }
+        }
+      }
+    },
+    "mediaReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "sha256",
+        "mime_type",
+        "byte_length",
+        "source",
+        "purpose",
+        "state",
+        "safe_preview"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mime_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "byte_length": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "inline",
+            "url",
+            "file",
+            "provider",
+            "uploaded",
+            "generated"
+          ]
+        },
+        "purpose": {
+          "type": "string",
+          "enum": [
+            "input",
+            "output",
+            "tool-argument",
+            "tool-result",
+            "document",
+            "raw-stream",
+            "overflow"
+          ]
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "inline",
+            "pending-upload",
+            "available",
+            "failed",
+            "expired"
+          ]
+        },
+        "safe_preview": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 4096
+        }
+      }
+    },
+    "status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "source"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "UNSET",
+            "OK",
+            "ERROR"
+          ]
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "application",
+            "provider",
+            "sdk",
+            "backend-recovery",
+            "unknown"
+          ]
+        }
+      }
+    },
+    "error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "message",
+        "stack",
+        "escaped"
+      ],
+      "properties": {
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "stack": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "escaped": {
+          "type": "boolean"
+        }
+      }
+    },
+    "codeLocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "file",
+        "function",
+        "line",
+        "column",
+        "namespace"
+      ],
+      "properties": {
+        "file": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "function": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "line": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "column": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "namespace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "sourceDialect": {
+      "type": "string",
+      "enum": [
+        "native-v2",
+        "neatlogs-direct",
+        "otel-genai",
+        "openinference",
+        "provider-specific",
+        "external-legacy",
+        "unknown-raw"
+      ]
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "source_dialect",
+        "source_key",
+        "precedence",
+        "action"
+      ],
+      "properties": {
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_dialect": {
+          "$ref": "#/$defs/sourceDialect"
+        },
+        "source_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "precedence": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 7
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "accepted",
+            "synthesized",
+            "missing",
+            "ignored-lower-precedence",
+            "retained-raw",
+            "rejected-invalid"
+          ]
+        }
+      }
+    },
+    "conflict": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "winner_source_key",
+        "loser_source_key",
+        "reason_code"
+      ],
+      "properties": {
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "winner_source_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "loser_source_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason_code": {
+          "type": "string",
+          "enum": [
+            "LOWER_PRECEDENCE",
+            "INVALID_TYPE",
+            "INVALID_JSON",
+            "EMPTY_VALUE",
+            "DUPLICATE_SEMANTIC_VALUE",
+            "UNSUPPORTED_SOURCE"
+          ]
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role",
+        "name",
+        "content",
+        "tool_calls",
+        "tool_call_id"
+      ],
+      "properties": {
+        "role": {
+          "type": "string",
+          "enum": [
+            "system",
+            "developer",
+            "user",
+            "assistant",
+            "tool"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/contentPart"
+          }
+        },
+        "tool_calls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolCall"
+          }
+        },
+        "tool_call_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "contentPart": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "text"
+          ],
+          "properties": {
+            "type": {
+              "const": "text"
+            },
+            "text": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "reference"
+          ],
+          "properties": {
+            "type": {
+              "enum": [
+                "image",
+                "audio",
+                "document",
+                "video"
+              ]
+            },
+            "reference": {
+              "$ref": "#/$defs/mediaReference"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "call_id",
+            "value",
+            "is_error"
+          ],
+          "properties": {
+            "type": {
+              "const": "tool_result"
+            },
+            "call_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "value": {
+              "$ref": "#/$defs/jsonValue"
+            },
+            "is_error": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "toolDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name",
+        "description",
+        "schema",
+        "configuration"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "configuration": {
+          "$ref": "#/$defs/jsonValue"
+        }
+      }
+    },
+    "toolCall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "id_origin",
+        "type",
+        "name",
+        "arguments",
+        "choice_index",
+        "tool_index"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id_origin": {
+          "type": "string",
+          "enum": [
+            "neatlogs-direct",
+            "provider",
+            "deterministic-synthetic"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "arguments": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "choice_index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tool_index": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "toolResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "call_id",
+        "value",
+        "is_error",
+        "media"
+      ],
+      "properties": {
+        "call_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "value": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "is_error": {
+          "type": "boolean"
+        },
+        "media": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/mediaReference"
+          }
+        }
+      }
+    },
+    "llmParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "temperature",
+        "top_p",
+        "top_k",
+        "max_output_tokens",
+        "stop",
+        "seed",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "reasoning",
+        "service_tier",
+        "provider_options"
+      ],
+      "properties": {
+        "temperature": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "top_p": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "top_k": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "max_output_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "stop": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "seed": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "frequency_penalty": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "presence_penalty": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "response_format": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "reasoning": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "service_tier": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "provider_options": {
+          "$ref": "#/$defs/jsonValue"
+        }
+      }
+    },
+    "llmRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "model",
+        "operation",
+        "messages",
+        "tools",
+        "parameters"
+      ],
+      "properties": {
+        "provider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation": {
+          "type": "string",
+          "enum": [
+            "chat",
+            "completion",
+            "responses",
+            "generate",
+            "unknown"
+          ]
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/message"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolDefinition"
+          }
+        },
+        "parameters": {
+          "$ref": "#/$defs/llmParameters"
+        }
+      }
+    },
+    "llmChoice": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "choice_index",
+        "message",
+        "finish_reason"
+      ],
+      "properties": {
+        "choice_index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "message": {
+          "$ref": "#/$defs/message"
+        },
+        "finish_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "llmResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "model",
+        "choices",
+        "finish_reasons"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "choices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/llmChoice"
+          }
+        },
+        "finish_reasons": {
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "llmUsage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "reasoning_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "cost_usd"
+      ],
+      "properties": {
+        "input_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "output_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "total_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "reasoning_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "cache_read_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "cache_write_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "cost_usd": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    },
+    "streamEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sequence",
+        "time_unix_nano",
+        "type",
+        "choice_index",
+        "tool_index",
+        "value"
+      ],
+      "properties": {
+        "sequence": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "time_unix_nano": {
+          "$ref": "#/$defs/uint64String"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "output_text.delta",
+            "reasoning.delta",
+            "tool_call.delta",
+            "choice.finish",
+            "usage",
+            "error"
+          ]
+        },
+        "choice_index": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "tool_index": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "value": {
+          "$ref": "#/$defs/jsonValue"
+        }
+      }
+    },
+    "llmStream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "time_to_first_token_ms",
+        "chunk_count",
+        "choice_count",
+        "events",
+        "raw_chunks"
+      ],
+      "properties": {
+        "time_to_first_token_ms": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "chunk_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "choice_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/streamEvent"
+          }
+        },
+        "raw_chunks": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/mediaReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "llmSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "request",
+        "response",
+        "usage",
+        "stream"
+      ],
+      "properties": {
+        "kind": {
+          "const": "LLM"
+        },
+        "request": {
+          "$ref": "#/$defs/llmRequest"
+        },
+        "response": {
+          "$ref": "#/$defs/llmResponse"
+        },
+        "usage": {
+          "$ref": "#/$defs/llmUsage"
+        },
+        "stream": {
+          "$ref": "#/$defs/llmStream"
+        }
+      }
+    },
+    "toolSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "definition",
+        "call",
+        "result",
+        "requesting_span_id",
+        "transport"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "TOOL",
+            "MCP_TOOL"
+          ]
+        },
+        "definition": {
+          "$ref": "#/$defs/toolDefinition"
+        },
+        "call": {
+          "$ref": "#/$defs/toolCall"
+        },
+        "result": {
+          "$ref": "#/$defs/toolResult"
+        },
+        "requesting_span_id": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/spanId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "transport": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/mcpTransport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "content",
+        "score",
+        "metadata",
+        "media"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "content": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "score": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "media": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/mediaReference"
+          }
+        }
+      }
+    },
+    "retrieverSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "query",
+        "documents",
+        "top_k",
+        "filters"
+      ],
+      "properties": {
+        "kind": {
+          "const": "RETRIEVER"
+        },
+        "query": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/document"
+          }
+        },
+        "top_k": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "filters": {
+          "$ref": "#/$defs/jsonValue"
+        }
+      }
+    },
+    "rerankerSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "model",
+        "query",
+        "input_documents",
+        "output_documents",
+        "top_n"
+      ],
+      "properties": {
+        "kind": {
+          "const": "RERANKER"
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "query": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "input_documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/document"
+          }
+        },
+        "output_documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/document"
+          }
+        },
+        "top_n": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    },
+    "embeddingSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "provider",
+        "model",
+        "inputs",
+        "vectors",
+        "dimensions",
+        "usage"
+      ],
+      "properties": {
+        "kind": {
+          "const": "EMBEDDING"
+        },
+        "provider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        },
+        "vectors": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "dimensions": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "usage": {
+          "$ref": "#/$defs/llmUsage"
+        }
+      }
+    },
+    "vectorStoreSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "provider",
+        "operation",
+        "collection",
+        "query",
+        "documents"
+      ],
+      "properties": {
+        "kind": {
+          "const": "VECTOR_STORE"
+        },
+        "provider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "collection": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "query": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/document"
+          }
+        }
+      }
+    },
+    "memorySemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "operation",
+        "memory_id",
+        "scope",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "const": "MEMORY"
+        },
+        "operation": {
+          "type": "string",
+          "enum": [
+            "read",
+            "write",
+            "update",
+            "delete",
+            "search",
+            "unknown"
+          ]
+        },
+        "memory_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scope": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "value": {
+          "$ref": "#/$defs/jsonValue"
+        }
+      }
+    },
+    "guardrailSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "name",
+        "action",
+        "triggered",
+        "score",
+        "reason"
+      ],
+      "properties": {
+        "kind": {
+          "const": "GUARDRAIL"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggered": {
+          "type": "boolean"
+        },
+        "score": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "mcpTransport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "transport",
+        "server",
+        "method",
+        "request_id"
+      ],
+      "properties": {
+        "transport": {
+          "type": "string",
+          "enum": [
+            "stdio",
+            "sse",
+            "streamable-http",
+            "websocket",
+            "unknown"
+          ]
+        },
+        "server": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "request_id": {
+          "type": [
+            "string",
+            "number",
+            "null"
+          ]
+        }
+      }
+    },
+    "logSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "severity_text",
+        "severity_number",
+        "body",
+        "logger_name"
+      ],
+      "properties": {
+        "kind": {
+          "const": "LOG"
+        },
+        "severity_text": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "severity_number": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "body": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "logger_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "operationSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "operation",
+        "role",
+        "metadata",
+        "recovery"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "WORKFLOW",
+            "AGENT",
+            "CHAIN",
+            "TASK",
+            "HTTP",
+            "UNKNOWN"
+          ]
+        },
+        "operation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "role": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "recovery": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/recovery"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "recovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "synthetic",
+        "reason",
+        "recovery_span_id",
+        "genuine_root_span_id",
+        "reconciled"
+      ],
+      "properties": {
+        "synthetic": {
+          "const": true
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recovery_span_id": {
+          "$ref": "#/$defs/spanId"
+        },
+        "genuine_root_span_id": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/spanId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "reconciled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "semantic": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/llmSemantic"
+        },
+        {
+          "$ref": "#/$defs/toolSemantic"
+        },
+        {
+          "$ref": "#/$defs/retrieverSemantic"
+        },
+        {
+          "$ref": "#/$defs/rerankerSemantic"
+        },
+        {
+          "$ref": "#/$defs/embeddingSemantic"
+        },
+        {
+          "$ref": "#/$defs/vectorStoreSemantic"
+        },
+        {
+          "$ref": "#/$defs/memorySemantic"
+        },
+        {
+          "$ref": "#/$defs/guardrailSemantic"
+        },
+        {
+          "$ref": "#/$defs/logSemantic"
+        },
+        {
+          "$ref": "#/$defs/operationSemantic"
+        }
+      ]
+    }
+  },
+  "x-neatlogs-policy": {
+    "contract_version": "2.0.0",
+    "attribute_prefix": "neatlogs.v2",
+    "conflict_precedence": [
+      "native-v2",
+      "neatlogs-direct",
+      "otel-genai",
+      "openinference",
+      "provider-specific",
+      "external-legacy",
+      "unknown-raw"
+    ],
+    "tool_calls": {
+      "assistant_requests_live_in_assistant_message": true,
+      "execution_is_separate_tool_span": true,
+      "id_precedence": [
+        "neatlogs-direct",
+        "provider",
+        "deterministic-synthetic"
+      ],
+      "retain_unlinked_execution": true,
+      "forbid_name_timing_merge": true
+    },
+    "root_finalization": {
+      "launch_sdk_auto_workflow_roots": true,
+      "launch_completion_markers": true,
+      "stale_root_recovery_is_safety_net": true,
+      "recovered_root_status_must_not_be_fabricated_ok": true,
+      "preserve_late_genuine_root_identity": true,
+      "logical_root_only_finalization": "deferred-post-launch"
+    },
+    "launch_scope": {
+      "sdk_transport": "otlp-http-protobuf",
+      "python_openinference_compatibility": "retain-where-active",
+      "sdk_product_apis_excluded": [
+        "datasets",
+        "evaluations",
+        "scoring",
+        "experiments",
+        "new-prompt-apis"
+      ],
+      "new_go_integrations": false,
+      "typescript_edge_entrypoint": false
+    },
+    "compatibility": [
+      {
+        "dialect": "neatlogs-direct",
+        "patterns": [
+          "neatlogs.span.kind",
+          "neatlogs.workflow.*",
+          "neatlogs.agent.*",
+          "neatlogs.llm.*",
+          "neatlogs.tool.*",
+          "neatlogs.retriever.*",
+          "neatlogs.reranker.*",
+          "neatlogs.embedding.*",
+          "neatlogs.vector_store.*",
+          "neatlogs.memory.*",
+          "neatlogs.guardrail.*",
+          "neatlogs.mcp.*",
+          "neatlogs.code.*"
+        ],
+        "launch_state": "accepted"
+      },
+      {
+        "dialect": "otel-genai",
+        "patterns": [
+          "gen_ai.*"
+        ],
+        "launch_state": "accepted-at-normalization-boundary"
+      },
+      {
+        "dialect": "openinference",
+        "patterns": [
+          "openinference.span.kind",
+          "input.value",
+          "input.mime_type",
+          "output.value",
+          "output.mime_type",
+          "llm.*",
+          "tool.*",
+          "retrieval.*",
+          "embedding.*"
+        ],
+        "launch_state": "accepted-for-active-python-integrations"
+      },
+      {
+        "dialect": "provider-specific",
+        "patterns": [
+          "ai.*",
+          "openai.*",
+          "anthropic.*",
+          "aws.bedrock.*",
+          "google_genai.*",
+          "vertex_ai.*"
+        ],
+        "launch_state": "accepted-at-source-adapter"
+      },
+      {
+        "dialect": "external-legacy",
+        "patterns": [
+          "traceloop.*",
+          "openlit.*"
+        ],
+        "launch_state": "accepted-with-provenance"
+      },
+      {
+        "dialect": "unknown-raw",
+        "patterns": [
+          "*"
+        ],
+        "launch_state": "retain-raw-never-overwrite-canonical"
+      }
+    ],
+    "compatibility_removal_gate": {
+      "minimum_releases": 2,
+      "minimum_observation_days": 30,
+      "requires_zero_mapping_hits": true,
+      "requires_source_adapter_migration": true,
+      "requires_golden_fixture_removal_review": true
+    },
+    "deferred_post_launch": [
+      "logical-root-only-finalization",
+      "automatic-root-removal",
+      "completion-marker-removal",
+      "user-defined-export-filter",
+      "runtime-tracing-toggle",
+      "new-go-integrations",
+      "typescript-edge-entrypoint",
+      "sdk-datasets-evaluations-scoring-experiments"
+    ]
+  }
+}

--- a/neatlogs/core/client_registry.py
+++ b/neatlogs/core/client_registry.py
@@ -1,0 +1,25 @@
+"""Thread-safe registry of live Neatlogs client pipelines."""
+
+from __future__ import annotations
+
+import threading
+import weakref
+from typing import Any
+
+_lock = threading.RLock()
+_clients: weakref.WeakSet[Any] = weakref.WeakSet()
+
+
+def register_client(client: Any) -> None:
+    with _lock:
+        _clients.add(client)
+
+
+def unregister_client(client: Any) -> None:
+    with _lock:
+        _clients.discard(client)
+
+
+def snapshot_clients() -> tuple[Any, ...]:
+    with _lock:
+        return tuple(_clients)

--- a/neatlogs/core/log.py
+++ b/neatlogs/core/log.py
@@ -124,12 +124,6 @@ def log(msg_template: str, /, level: str = "info", **data: Any) -> None:
     for key, value in data.items():
         attributes[f"log.{key}"] = _safe_json_dumps(value)
 
-    # Emit via OTel Logs API — trace_id + span_id are auto-populated from active context
-    try:
-        from opentelemetry import logs as otel_logs
-    except ImportError:
-        from opentelemetry import _logs as otel_logs  # type: ignore[no-redef]
-
     from .._wrap_utils import active_neatlogs_context, get_active_client
 
     client = get_active_client()
@@ -141,8 +135,13 @@ def log(msg_template: str, /, level: str = "info", **data: Any) -> None:
         otel_logger = client.log_provider.get_logger(__name__)
         log_context = active_neatlogs_context()
     else:
-        otel_logger = otel_logs.get_logger(__name__)
-        log_context = None
+        from ..init import get_log_provider
+
+        provider = get_log_provider()
+        if provider is None:
+            return
+        otel_logger = provider.get_logger(__name__)
+        log_context = active_neatlogs_context()
     record_kwargs: dict[str, Any] = {
         "timestamp": time.time_ns(),
         "severity_number": _SEVERITY_MAP.get(level.lower(), SeverityNumber.INFO),

--- a/neatlogs/core/mask.py
+++ b/neatlogs/core/mask.py
@@ -17,10 +17,7 @@ Example::
     neatlogs.init(mask=redact)
 """
 
-import logging
 from typing import Any, Callable, Dict, Optional
-
-logger = logging.getLogger(__name__)
 
 # Module-level registry: str(id(fn)) -> callable
 # Entries are permanent for the lifetime of the callable object; no cleanup needed.
@@ -55,14 +52,15 @@ def apply_mask(
     if mask_fn is None:
         return span_data
 
-    try:
-        result = mask_fn(span_data)
-        return result if result is not None else span_data
-    except Exception as exc:
-        logger.warning(
-            "[neatlogs] mask callable raised an exception for span '%s': %s — "
-            "original span data will be exported unchanged.",
-            span_data.get("name"),
-            exc,
-        )
-        return span_data
+    result = mask_fn(span_data)
+    return result if result is not None else span_data
+
+
+def effective_mask(span_data: Dict[str, Any], global_mask: Optional[Callable]):
+    """Return the per-span mask when registered, otherwise the global mask."""
+    mask_id = (span_data.get("attributes") or {}).get("neatlogs.mask_id")
+    if mask_id:
+        mask_fn = _MASK_REGISTRY.get(str(mask_id))
+        if mask_fn is not None:
+            return mask_fn
+    return global_mask

--- a/neatlogs/core/masking_exporter.py
+++ b/neatlogs/core/masking_exporter.py
@@ -1,0 +1,234 @@
+"""Fail-closed masking at Neatlogs' final telemetry export boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import copy
+import inspect
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any, Callable
+
+from opentelemetry.sdk._logs import ReadableLogRecord
+from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import Event, ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.trace import Link, Status, StatusCode
+
+from .mask import effective_mask
+
+logger = logging.getLogger(__name__)
+
+
+def _mask_call(mask: Callable, snapshot: dict[str, Any], timeout_seconds: float):
+    result = mask(snapshot)
+    if inspect.isawaitable(result):
+        return asyncio.run(asyncio.wait_for(result, timeout=timeout_seconds))
+    return result
+
+
+class _MaskRunner:
+    def __init__(self, timeout_seconds: float = 5.0) -> None:
+        self._timeout_seconds = timeout_seconds
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=4, thread_name_prefix="neatlogs-mask"
+        )
+
+    def apply(self, mask: Callable, snapshot: dict[str, Any]) -> dict[str, Any] | None:
+        candidate = copy.deepcopy(snapshot)
+        future = self._executor.submit(_mask_call, mask, candidate, self._timeout_seconds)
+        try:
+            result = future.result(timeout=self._timeout_seconds)
+        except Exception as exc:
+            future.cancel()
+            logger.error(
+                "[neatlogs] mask failed; telemetry item dropped (%s)",
+                type(exc).__name__,
+            )
+            return None
+        if result is None:
+            return candidate
+        if not isinstance(result, Mapping):
+            logger.error("[neatlogs] mask returned a non-mapping; telemetry item dropped")
+            return None
+        return dict(result)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+
+def _attrs(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in value.items() if item is not None}
+
+
+def _span_snapshot(span: ReadableSpan) -> dict[str, Any]:
+    return {
+        "signal": "span",
+        "name": span.name,
+        "attributes": dict(span.attributes or {}),
+        "events": [
+            {
+                "name": event.name,
+                "timestamp": event.timestamp,
+                "attributes": dict(event.attributes or {}),
+            }
+            for event in span.events
+        ],
+        "links": [
+            {
+                "trace_id": f"{link.context.trace_id:032x}",
+                "span_id": f"{link.context.span_id:016x}",
+                "attributes": dict(link.attributes or {}),
+            }
+            for link in span.links
+        ],
+        "resource": {"attributes": dict(span.resource.attributes or {})},
+        "status": {
+            "code": span.status.status_code.name,
+            "description": span.status.description,
+        },
+    }
+
+
+def _masked_span(span: ReadableSpan, snapshot: Mapping[str, Any]) -> ReadableSpan:
+    events = []
+    for item in snapshot.get("events", ()):
+        if not isinstance(item, Mapping):
+            continue
+        events.append(
+            Event(
+                str(item.get("name") or "event"),
+                attributes=_attrs(item.get("attributes")),
+                timestamp=item.get("timestamp"),
+            )
+        )
+
+    links = []
+    for index, item in enumerate(snapshot.get("links", ())):
+        if index >= len(span.links) or not isinstance(item, Mapping):
+            continue
+        links.append(Link(span.links[index].context, attributes=_attrs(item.get("attributes"))))
+
+    resource_data = snapshot.get("resource")
+    resource_attrs = (
+        _attrs(resource_data.get("attributes")) if isinstance(resource_data, Mapping) else {}
+    )
+    status_data = snapshot.get("status")
+    status = span.status
+    if isinstance(status_data, Mapping):
+        code_name = str(status_data.get("code") or span.status.status_code.name)
+        try:
+            code = StatusCode[code_name]
+        except KeyError:
+            code = span.status.status_code
+        status = Status(code, status_data.get("description"))
+
+    attributes = _attrs(snapshot.get("attributes"))
+    attributes.pop("neatlogs.mask_id", None)
+    return ReadableSpan(
+        name=str(snapshot.get("name") or span.name),
+        context=span.context,
+        parent=span.parent,
+        resource=Resource(resource_attrs, schema_url=span.resource.schema_url),
+        attributes=attributes,
+        events=events,
+        links=links,
+        kind=span.kind,
+        status=status,
+        start_time=span.start_time,
+        end_time=span.end_time,
+        instrumentation_scope=span.instrumentation_scope,
+    )
+
+
+class MaskingSpanExporter(SpanExporter):
+    """Clone, mask and export spans; callback failures drop only the affected span."""
+
+    def __init__(self, inner: SpanExporter, mask: Callable | None) -> None:
+        self._inner = inner
+        self._global_mask = mask
+        self._runner = _MaskRunner()
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        kept = []
+        for span in spans:
+            snapshot = _span_snapshot(span)
+            mask = effective_mask(snapshot, self._global_mask)
+            if mask is None:
+                kept.append(span)
+                continue
+            masked = self._runner.apply(mask, snapshot)
+            if masked is not None:
+                kept.append(_masked_span(span, masked))
+        if not kept:
+            return SpanExportResult.SUCCESS
+        return self._inner.export(kept)
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        result = self._inner.force_flush(timeout_millis)
+        return True if result is None else bool(result)
+
+    def shutdown(self) -> None:
+        self._runner.shutdown()
+        self._inner.shutdown()
+
+
+def _log_snapshot(item: ReadableLogRecord) -> dict[str, Any]:
+    record = item.log_record
+    return {
+        "signal": "log",
+        "name": item.instrumentation_scope.name if item.instrumentation_scope else "log",
+        "body": record.body,
+        "attributes": dict(record.attributes or {}),
+        "resource": {"attributes": dict(item.resource.attributes or {})},
+        "severity_text": record.severity_text,
+        "event_name": record.event_name,
+    }
+
+
+class MaskingLogExporter(LogRecordExporter):
+    """Apply the same global fail-closed mask contract to correlated logs."""
+
+    def __init__(self, inner: LogRecordExporter, mask: Callable | None) -> None:
+        self._inner = inner
+        self._mask = mask
+        self._runner = _MaskRunner()
+
+    def export(self, batch: Sequence[ReadableLogRecord]) -> LogRecordExportResult:
+        if self._mask is None:
+            return self._inner.export(batch)
+        kept = []
+        for item in batch:
+            masked = self._runner.apply(self._mask, _log_snapshot(item))
+            if masked is None:
+                continue
+            clone = copy.copy(item)
+            clone_record = copy.copy(item.log_record)
+            clone_record.body = masked.get("body")
+            clone_record.attributes = _attrs(masked.get("attributes"))
+            clone_record.severity_text = masked.get("severity_text")
+            clone_record.event_name = masked.get("event_name")
+            object.__setattr__(clone, "log_record", clone_record)
+            resource_data = masked.get("resource")
+            resource_attrs = (
+                _attrs(resource_data.get("attributes"))
+                if isinstance(resource_data, Mapping)
+                else {}
+            )
+            object.__setattr__(
+                clone,
+                "resource",
+                Resource(resource_attrs, schema_url=item.resource.schema_url),
+            )
+            kept.append(clone)
+        if not kept:
+            return LogRecordExportResult.SUCCESS
+        return self._inner.export(kept)
+
+    def shutdown(self) -> None:
+        self._runner.shutdown()
+        self._inner.shutdown()

--- a/neatlogs/core/masking_exporter.py
+++ b/neatlogs/core/masking_exporter.py
@@ -10,8 +10,15 @@ import logging
 from collections.abc import Mapping, Sequence
 from typing import Any, Callable
 
-from opentelemetry.sdk._logs import ReadableLogRecord
-from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
+try:
+    from opentelemetry.sdk._logs import ReadableLogRecord
+    from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
+except ImportError:  # OpenTelemetry 1.35-1.38 compatibility
+    from opentelemetry.sdk._logs import LogData as ReadableLogRecord
+    from opentelemetry.sdk._logs.export import (
+        LogExporter as LogRecordExporter,
+        LogExportResult as LogRecordExportResult,
+    )
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Event, ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
@@ -179,12 +186,13 @@ class MaskingSpanExporter(SpanExporter):
 
 def _log_snapshot(item: ReadableLogRecord) -> dict[str, Any]:
     record = item.log_record
+    resource = getattr(item, "resource", None) or getattr(record, "resource", None)
     return {
         "signal": "log",
         "name": item.instrumentation_scope.name if item.instrumentation_scope else "log",
         "body": record.body,
         "attributes": dict(record.attributes or {}),
-        "resource": {"attributes": dict(item.resource.attributes or {})},
+        "resource": {"attributes": dict(resource.attributes or {}) if resource else {}},
         "severity_text": record.severity_text,
         "event_name": record.event_name,
     }
@@ -219,15 +227,31 @@ class MaskingLogExporter(LogRecordExporter):
                 if isinstance(resource_data, Mapping)
                 else {}
             )
-            object.__setattr__(
-                clone,
-                "resource",
-                Resource(resource_attrs, schema_url=item.resource.schema_url),
+            original_resource = getattr(item, "resource", None) or getattr(
+                item.log_record, "resource", None
             )
+            masked_resource = Resource(
+                resource_attrs,
+                schema_url=original_resource.schema_url if original_resource else None,
+            )
+            if hasattr(clone, "resource"):
+                object.__setattr__(clone, "resource", masked_resource)
+            elif hasattr(clone_record, "resource"):
+                object.__setattr__(clone_record, "resource", masked_resource)
             kept.append(clone)
         if not kept:
             return LogRecordExportResult.SUCCESS
         return self._inner.export(kept)
+
+    def force_flush(self, timeout_millis: int = 10000) -> bool:
+        # LogRecordExporter.force_flush became abstract in OpenTelemetry 1.44.
+        # NeatLogs still supports earlier SDK releases whose exporters do not
+        # expose it, so absence means there is no exporter-level buffer to flush.
+        force_flush = getattr(self._inner, "force_flush", None)
+        if force_flush is None:
+            return True
+        result = force_flush(timeout_millis)
+        return True if result is None else bool(result)
 
     def shutdown(self) -> None:
         self._runner.shutdown()

--- a/neatlogs/core/span_processor.py
+++ b/neatlogs/core/span_processor.py
@@ -5,7 +5,6 @@ Transport is handled by BatchSpanProcessor + OTLPSpanExporter (added in init.py)
 
 import json
 import os
-import random
 import threading
 import time
 from typing import Any, Callable, Dict, List, Optional
@@ -18,7 +17,6 @@ from opentelemetry.trace import Status, StatusCode
 
 from .attribute_processor import UnifiedAttributeProcessor
 from .logger import get_logger
-from .mask import apply_mask
 
 logger = get_logger()
 
@@ -140,13 +138,11 @@ def is_rootless_infra_http(span) -> bool:
 class NeatlogsSpanProcessor(SpanProcessor):
     def __init__(
         self,
-        sample_rate: float = 1.0,
         debug: bool = False,
         mask: Optional[Callable[[Dict[str, Any]], Any]] = None,
         emit_completion_markers: bool = True,
         own_all_spans: bool = False,
     ):
-        self.sample_rate = sample_rate
         self.debug = debug
         self.mask = mask
         self.emit_completion_markers = emit_completion_markers
@@ -398,15 +394,18 @@ class NeatlogsSpanProcessor(SpanProcessor):
                 logger.debug(f"[SpanProcessor.on_end] Span ending: {span.name}")
 
             # 1. Log raw OTel span (before any processing)
-            if self._raw_log_file_handle and not self._raw_log_file_handle.closed:
+            per_span_mask = bool((span.attributes or {}).get("neatlogs.mask_id"))
+            if (
+                not self.mask
+                and not per_span_mask
+                and self._raw_log_file_handle
+                and not self._raw_log_file_handle.closed
+            ):
                 try:
                     self._raw_log_file_handle.write(span.to_json() + "\n")
                     self._raw_log_file_handle.flush()
                 except Exception as e:
                     logger.warning(f"Failed to write span to raw log file: {e}")
-
-            if self.sample_rate < 1.0 and random.random() > self.sample_rate:
-                return
 
             # 1b. Root I/O backfill. Children close before their root (nested spans),
             # so by the time a root span ends we've already seen every descendant's
@@ -554,14 +553,8 @@ class NeatlogsSpanProcessor(SpanProcessor):
             results = self._inject_crewai_task_templates([span_data])
             span_data = results[0] if results else span_data
 
-            # A per-span mask_id (from @span(mask=)/trace(mask=)) takes precedence
-            # over the global init(mask=); mask whenever either exists.
-            mask_id = (span_data.get("attributes") or {}).get("neatlogs.mask_id")
-            has_mask = bool(mask_id) or self.mask is not None
-
-            # Write normalized neatlogs.* keys onto the (still-mutable) OTel span,
-            # then mask the whole surface once so non-idempotent masks (e.g.
-            # translation) aren't applied twice.
+            # Write normalized neatlogs.* keys onto the still-mutable OTel span.
+            # Masking happens later, once, on a clone in the batched exporter worker.
             final_attrs = span_data.get("attributes") or {}
             try:
                 span_attrs = span._attributes
@@ -574,26 +567,16 @@ class NeatlogsSpanProcessor(SpanProcessor):
                         ):
                             span_attrs[_k] = list(_v)
 
-                    if has_mask:
-                        snapshot = {
-                            "name": span_data.get("name"),
-                            "attributes": dict(span_attrs),
-                        }
-                        masked = apply_mask(snapshot, self.mask)
-                        masked_attrs = (masked or snapshot).get("attributes") or {}
-                        for _k in list(span_attrs.keys()):
-                            if _k in masked_attrs and masked_attrs[_k] != span_attrs[_k]:
-                                span_attrs[_k] = masked_attrs[_k]
-                        # Mirror masked values so the file log reuses them.
-                        for _k in list(final_attrs.keys()):
-                            if _k in masked_attrs:
-                                final_attrs[_k] = masked_attrs[_k]
-                        span_data["attributes"] = final_attrs
             except Exception as _wb_exc:
                 if self.debug:
                     logger.debug(f"[SpanProcessor] Attr write-back failed: {_wb_exc}")
 
-            if self._processed_log_file_handle and not self._processed_log_file_handle.closed:
+            if (
+                not self.mask
+                and not per_span_mask
+                and self._processed_log_file_handle
+                and not self._processed_log_file_handle.closed
+            ):
                 try:
                     self._processed_log_file_handle.write(json.dumps(span_data) + "\n")
                     self._processed_log_file_handle.flush()

--- a/neatlogs/decorators/_base.py
+++ b/neatlogs/decorators/_base.py
@@ -4,6 +4,7 @@ Decorator primitives for Neatlogs custom orchestration spans.
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import inspect
 import json
@@ -208,6 +209,134 @@ def _decorate_span(
         # that users can override auto-captured values if needed.
         code_attrs = _capture_code_attrs(func)
         merged_attrs = {**code_attrs, **(attributes or {})}
+
+        def _prepare_stream_span(span, args, kwargs, *, is_root: bool):
+            from ..core.end_user import apply_end_user_attributes
+            from ..core.mask import register_mask
+            from ..core.session import apply_session_attributes
+
+            _set_common_span_attrs(
+                span,
+                openinference_kind=openinference_kind,
+                name=span_name,
+                version=version,
+                tags=tags,
+                metadata=metadata,
+                attributes=merged_attrs,
+            )
+            apply_session_attributes(span, session_id, is_root=is_root)
+            apply_end_user_attributes(span, end_user_id, end_user_metadata, is_root=is_root)
+            if mask is not None:
+                span.set_attribute("neatlogs.mask_id", register_mask(mask))
+            if description:
+                span.set_attribute("neatlogs.description", description)
+            bound = _bind_call_args(func, args, kwargs)
+            if cap_in:
+                span.set_attribute("input.value", _safe_json_dumps(bound))
+                span.set_attribute("input.mime_type", "application/json")
+            return bound
+
+        def _record_stream_chunk(span, index: int, value: Any) -> None:
+            span.add_event(
+                "neatlogs.stream.chunk",
+                {
+                    "neatlogs.stream.chunk.index": index,
+                    "neatlogs.stream.chunk.value": _safe_json_dumps(value),
+                    "neatlogs.stream.chunk.mime_type": "application/json",
+                },
+            )
+
+        def _finish_stream(span, chunks: list[Any], bound_inputs: Dict[str, Any]) -> None:
+            span.set_attribute("neatlogs.stream.chunk_count", len(chunks))
+            if postprocess_result is not None:
+                try:
+                    postprocess_result(span, chunks, bound_inputs)
+                except Exception:
+                    pass
+            if cap_out:
+                span.set_attribute("output.value", _safe_json_dumps(chunks))
+                span.set_attribute("output.mime_type", "application/json")
+            span.set_status(Status(StatusCode.OK))
+
+        if inspect.isasyncgenfunction(func):
+
+            @functools.wraps(func)
+            async def async_generator_wrapper(*args: Any, **kwargs: Any):
+                from ..core.log import _CaptureStdoutContext
+
+                is_root = _is_root_span()
+                with neatlogs_span(__name__, span_name, kind=otel_trace.SpanKind.INTERNAL) as span:
+                    bound_inputs = _prepare_stream_span(span, args, kwargs, is_root=is_root)
+                    chunks: list[Any] = []
+                    stdout_ctx = _CaptureStdoutContext() if capture_stdout else None
+                    if stdout_ctx:
+                        stdout_ctx.__enter__()
+                    try:
+                        async for chunk in func(*args, **kwargs):
+                            _record_stream_chunk(span, len(chunks), chunk)
+                            chunks.append(chunk)
+                            yield chunk
+                        _finish_stream(span, chunks, bound_inputs)
+                    except (GeneratorExit, asyncio.CancelledError):
+                        span.set_attribute("neatlogs.stream.cancelled", True)
+                        span.set_attribute("neatlogs.stream.chunk_count", len(chunks))
+                        if cap_out:
+                            span.set_attribute("output.value", _safe_json_dumps(chunks))
+                            span.set_attribute("output.mime_type", "application/json")
+                        raise
+                    except Exception as exc:
+                        span.set_attribute("neatlogs.stream.chunk_count", len(chunks))
+                        if cap_out:
+                            span.set_attribute("output.value", _safe_json_dumps(chunks))
+                            span.set_attribute("output.mime_type", "application/json")
+                        span.record_exception(exc)
+                        span.set_status(Status(StatusCode.ERROR, str(exc)))
+                        raise
+                    finally:
+                        if stdout_ctx:
+                            stdout_ctx.__exit__(None, None, None)
+
+            return async_generator_wrapper
+
+        if inspect.isgeneratorfunction(func):
+
+            @functools.wraps(func)
+            def generator_wrapper(*args: Any, **kwargs: Any):
+                from ..core.log import _CaptureStdoutContext
+
+                is_root = _is_root_span()
+                with neatlogs_span(__name__, span_name, kind=otel_trace.SpanKind.INTERNAL) as span:
+                    bound_inputs = _prepare_stream_span(span, args, kwargs, is_root=is_root)
+                    chunks: list[Any] = []
+                    stdout_ctx = _CaptureStdoutContext() if capture_stdout else None
+                    if stdout_ctx:
+                        stdout_ctx.__enter__()
+                    try:
+                        for chunk in func(*args, **kwargs):
+                            _record_stream_chunk(span, len(chunks), chunk)
+                            chunks.append(chunk)
+                            yield chunk
+                        _finish_stream(span, chunks, bound_inputs)
+                    except GeneratorExit:
+                        span.set_attribute("neatlogs.stream.cancelled", True)
+                        span.set_attribute("neatlogs.stream.chunk_count", len(chunks))
+                        if cap_out:
+                            span.set_attribute("output.value", _safe_json_dumps(chunks))
+                            span.set_attribute("output.mime_type", "application/json")
+                        raise
+                    except Exception as exc:
+                        span.set_attribute("neatlogs.stream.chunk_count", len(chunks))
+                        if cap_out:
+                            span.set_attribute("output.value", _safe_json_dumps(chunks))
+                            span.set_attribute("output.mime_type", "application/json")
+                        span.record_exception(exc)
+                        span.set_status(Status(StatusCode.ERROR, str(exc)))
+                        raise
+                    finally:
+                        if stdout_ctx:
+                            stdout_ctx.__exit__(None, None, None)
+
+            return generator_wrapper
 
         if inspect.iscoroutinefunction(func):
 

--- a/neatlogs/decorators/_base.py
+++ b/neatlogs/decorators/_base.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import functools
 import inspect
 import json
-import os
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, Union
 
@@ -15,13 +14,6 @@ from opentelemetry import trace as otel_trace
 from opentelemetry.trace import Status, StatusCode
 
 F = TypeVar("F", bound=Callable[..., Any])
-
-
-def _should_capture_content() -> bool:
-    v = os.getenv("NEATLOGS_TRACE_CONTENT")
-    if v is None:
-        return True
-    return v.lower() not in ("false", "0", "no")
 
 
 def _capture_code_attrs(func: Callable[..., Any]) -> Dict[str, Any]:
@@ -202,9 +194,13 @@ def _decorate_span(
 
         span_name = name or func.__name__
 
-        cap = _should_capture_content()
-        cap_in = cap if capture_input is None else capture_input
-        cap_out = cap if capture_output is None else capture_output
+        # Full-fidelity capture is the SDK default. Privacy-sensitive callers
+        # can disable either side explicitly on this decorator, while the
+        # exporter-level mask remains the global privacy boundary. A process
+        # environment switch cannot truthfully protect provider wrappers that
+        # do not consult it, so decorators must not pretend otherwise.
+        cap_in = True if capture_input is None else capture_input
+        cap_out = True if capture_output is None else capture_output
 
         # Capture code location once at decoration time — these are static
         # properties of the decorated function so there is no per-call overhead.

--- a/neatlogs/errors.py
+++ b/neatlogs/errors.py
@@ -1,0 +1,9 @@
+"""Public, catchable Neatlogs SDK errors."""
+
+
+class NeatlogsError(Exception):
+    """Base class for Neatlogs-specific failures."""
+
+
+class NeatlogsConfigurationError(NeatlogsError, ValueError):
+    """Raised before startup when SDK configuration is invalid or contradictory."""

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -3,7 +3,9 @@ Neatlogs SDK.
 """
 
 import atexit
+import concurrent.futures
 import functools
+import math
 import os
 import re
 import signal
@@ -11,12 +13,7 @@ import sys
 import threading
 from typing import Any, Callable, Dict, List, Optional
 
-try:
-    from opentelemetry import logs
-except ImportError:
-    from opentelemetry import _logs as logs  # type: ignore[no-redef]
-
-from opentelemetry import metrics, trace
+from opentelemetry import trace as otel_trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
@@ -24,15 +21,15 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_ATTRIBUTE_COUNT_LIMIT,
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
 )
-from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import SpanLimits, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
 
 from ._wrap_utils import _normalize_traces_endpoint
 from .core.logger import get_logger
 from .core.span_processor import CompletionMarkerSpanProcessor, NeatlogsSpanProcessor
+from .errors import NeatlogsConfigurationError
 from .instrumentation.manager import InstrumentationManager
 from .version import __version__
 
@@ -42,76 +39,8 @@ logger = get_logger()
 _initialized = False
 _tracer_provider = None
 _owns_tracer_provider = False  # True only when neatlogs created the provider (safe to shut down)
-_isolated_provider = False  # True when isolated (explicit tracer_provider= OR auto-detected)
-
-# Foreign LLM-observability instrumentors that own the global OTel pipeline and
-# resolve their span parent from the GLOBAL current-span. If one is active while
-# neatlogs would otherwise reuse the global provider, spans cross-contaminate both
-# ways. Their presence is the auto-detect signal to isolate onto a private provider.
-#
-# NOTE: `openinference` is deliberately NOT listed. The bare
-# `openinference-instrumentation-*` packages are neatlogs' OWN instrumentation
-# backend (hard dependency) — neatlogs imports them itself the moment it
-# instruments anything, and they are always importable. So their presence in
-# sys.modules / on disk carries no information about a co-tenant and would cause
-# a false-positive isolation (spurious for every standalone user, and — because
-# the modules stay resident after shutdown — for every re-init in one process).
-# Genuine OpenInference-based co-tenants (Arize Phoenix, Arize) import `phoenix`/
-# `arize` and are detected via those entries below.
-_FOREIGN_LLM_INSTRUMENTORS = (
-    "openlit",
-    "langfuse",
-    "traceloop",  # traceloop-sdk / openllmetry
-    "phoenix",  # arize-phoenix (uses OpenInference under the hood)
-    "arize",
-    "logfire",
-)
 
 
-def _foreign_llm_instrumentor_active():
-    """Return the name of a loaded foreign LLM-observability instrumentor, or None.
-
-    Import presence in ``sys.modules`` is the signal: these packages install their
-    instrumentation onto the global provider at import/init time, so being loaded
-    in-process means their spans are (or will be) flowing through the global
-    pipeline neatlogs would otherwise share.
-    """
-    for name in _FOREIGN_LLM_INSTRUMENTORS:
-        if name in sys.modules:
-            return name
-    return None
-
-
-def _foreign_llm_instrumentor_installed():
-    """Return the name of an INSTALLED (importable) foreign LLM instrumentor, or None.
-
-    Unlike ``_foreign_llm_instrumentor_active`` (which requires the package to be
-    imported already), this only checks that it is importable. That is the signal
-    we need when neatlogs is the FIRST tracing SDK to init: the foreign tool
-    (openlit/langfuse/…) frequently loads LATER — e.g. in a FastAPI startup event
-    that runs after an import-time ``neatlogs.init()``. If neatlogs claimed the
-    global provider now, that later instrumentor would bind to OUR provider and
-    both pipelines would cross-contaminate. Detecting the package on-disk lets us
-    pre-emptively stay private and leave the global slot free for the co-tenant,
-    WITHOUT requiring the customer to pass ``isolate=True``.
-
-    A user who has a foreign package installed but genuinely wants neatlogs to own
-    the global provider (e.g. to capture their own raw-OTel spans) can force the
-    legacy behaviour with ``isolate=False``.
-    """
-    import importlib.util
-
-    for name in _FOREIGN_LLM_INSTRUMENTORS:
-        try:
-            if importlib.util.find_spec(name) is not None:
-                return name
-        except (ImportError, ValueError):
-            # find_spec can raise for namespace-package edge cases; treat as absent.
-            continue
-    return None
-
-
-_meter_provider = None
 _log_provider = None
 _span_processor = None
 _transport_span_processors = []
@@ -137,6 +66,16 @@ _session_config = {
 def is_debug_enabled() -> bool:
     """Return True if neatlogs was initialized with debug=True."""
     return _debug_mode
+
+
+def _trace_sampler(sample_rate: float) -> ParentBased:
+    """Validate one trace-level rate and preserve the parent's sampling decision."""
+    if isinstance(sample_rate, bool) or not isinstance(sample_rate, (int, float)):
+        raise NeatlogsConfigurationError("sample_rate must be a finite number from 0.0 to 1.0")
+    rate = float(sample_rate)
+    if not math.isfinite(rate) or rate < 0.0 or rate > 1.0:
+        raise NeatlogsConfigurationError("sample_rate must be a finite number from 0.0 to 1.0")
+    return ParentBased(root=TraceIdRatioBased(rate))
 
 
 def _restore_shutdown_signal_handlers() -> None:
@@ -319,7 +258,7 @@ def init(
               Pass a list of span kind strings, e.g. ["LLM", "TOOL"]. This selection
               is persisted so the dashboard reflects it. When None (default), the
               project setting is preserved.
-        tracer_provider: Opt-in FULL ISOLATION. Pass a private ``TracerProvider`` (one you
+        tracer_provider: Pass a private ``TracerProvider`` that Neatlogs may configure.
               created but did NOT install as the OTel global) and neatlogs will emit ALL of
               its spans — auto-instrumented, wrap()/trace()/@span, and the internal
               completion marker — into that provider ONLY. Use this when another tool
@@ -328,28 +267,9 @@ def init(
               neatlogs span reaches the other backend and no foreign span reaches neatlogs.
               neatlogs never shuts this provider down and never claims the global
               meter/logger providers. When None (default), behaviour is auto-detected
-              (see ``isolate``): neatlogs isolates automatically when a foreign LLM
-              instrumentor owns the global provider, and otherwise owns-or-reuses it.
-        isolate: Override the auto-isolation decision. When None (default), neatlogs
-              AUTO-DETECTS and isolates onto a private provider — with NO customer
-              code change — in either of these cases:
-                * a foreign LLM-observability instrumentor
-                  (openlit/langfuse/traceloop/openinference/…) already owns the
-                  global tracer provider (it loaded first), OR
-                * neatlogs is the first tracing SDK to load but a foreign
-                  instrumentor is INSTALLED (importable) and may attach to the
-                  global provider later (the common FastAPI-startup ordering, where
-                  neatlogs.init runs at import time and openlit.init runs in a
-                  startup event).
-              In both cases neatlogs routes ALL its spans through a private provider
-              so the two pipelines share nothing — no neatlogs span reaches the
-              foreign backend, no foreign span reaches neatlogs, and no foreign span
-              inherits a neatlogs parent. When NO foreign instrumentor is installed,
-              neatlogs owns-or-reuses the global provider exactly as before (standalone
-              behaviour is unchanged). Pass True to force isolation unconditionally, or
-              False to force the legacy own-or-reuse behaviour even when a foreign
-              instrumentor is present. Passing ``tracer_provider=`` implies isolation
-              regardless of this flag.
+              unnecessary because Neatlogs creates an SDK-private provider by default.
+        isolate: Deprecated compatibility option. Neatlogs is always isolated and
+              never installs or reuses the process-global tracer provider.
         register_shutdown_handlers: Register SIGINT and SIGTERM handlers that end
               active Neatlogs spans child-first and flush before preserving normal
               signal termination. Defaults to True. Set False only when the host
@@ -361,6 +281,17 @@ def init(
         if debug:
             logger.warning("Neatlogs already initialized, skipping re-initialization")
         return
+
+    sampler = _trace_sampler(sample_rate)
+    if tracer_provider is not None and float(sample_rate) != 1.0:
+        raise NeatlogsConfigurationError(
+            "sample_rate cannot configure a caller-owned tracer_provider; "
+            "configure its sampler directly or omit tracer_provider"
+        )
+    if tracer_provider is not None and tracer_provider is otel_trace.get_tracer_provider():
+        raise NeatlogsConfigurationError(
+            "tracer_provider must be private and must not be the process-global provider"
+        )
 
     disable_export_resolved = bool(disable_export) or (
         os.getenv("NEATLOGS_DISABLE_EXPORT", "").lower() in ("true", "1", "yes")
@@ -453,9 +384,7 @@ def init(
         resource_attrs["neatlogs.pii.span_types"] = ",".join(pii_span_types)
     resource = Resource.create(resource_attrs)
 
-    global _tracer_provider, _owns_tracer_provider, _isolated_provider
-    existing_provider = trace.get_tracer_provider()
-
+    global _tracer_provider, _owns_tracer_provider
     if tracer_provider is not None:
         # ISOLATED MODE. The caller handed us a PRIVATE provider (never installed
         # as the OTel global) so neatlogs shares NO pipeline with a co-tenant such
@@ -467,7 +396,6 @@ def init(
         # meter/logger providers below. This is what makes isolation total.
         provider = tracer_provider
         _owns_tracer_provider = False
-        _isolated_provider = True
         # Merge neatlogs' resource (service.name + neatlogs.workflow_name + tags/pii)
         # onto the caller's provider so exported spans carry workflow_name — the
         # branches that build their OWN provider pass resource= at construction,
@@ -481,87 +409,15 @@ def init(
                 logger.debug("Could not merge neatlogs resource onto provided provider")
         if debug:
             logger.debug("Using explicitly provided tracer provider (isolated mode)")
-    elif existing_provider and hasattr(existing_provider, "add_span_processor"):
-        # A real provider already owns the global pipeline. Two sub-cases:
-        _foreign = None if isolate is False else _foreign_llm_instrumentor_active()
-        if isolate is True or _foreign is not None:
-            # AUTO-DETECT ISOLATION. A foreign LLM-observability instrumentor
-            # (openlit/langfuse/traceloop/…) owns the global provider AND resolves
-            # its parent from the global current-span. Reusing that provider would
-            # cross-contaminate both pipelines: neatlogs spans export to the foreign
-            # backend, and foreign spans (a) export to neatlogs and (b) inherit a
-            # neatlogs parent. So we build a PRIVATE provider neatlogs never installs
-            # globally — identical semantics to an explicit tracer_provider=.
-            provider = TracerProvider(
-                resource=resource,
-                span_limits=_span_limits_for_capture_everything(),
-            )
-            _owns_tracer_provider = True  # we made it; safe to shut down
-            _isolated_provider = True
-            if debug:
-                _why = (
-                    f"detected foreign LLM instrumentor '{_foreign}'"
-                    if _foreign is not None
-                    else "isolate=True was requested"
-                )
-                logger.info(
-                    f"Auto-isolation engaged: {_why} owning the global tracer "
-                    f"provider — routing all neatlogs spans through a private "
-                    f"provider so the two pipelines share nothing."
-                )
-        else:
-            # Reuse a provider set by the host app / another SDK (plain OpenTelemetry
-            # with no foreign LLM instrumentor). We do NOT own it — shutdown() must
-            # never tear it down, or it would kill the co-tenant's exporter too.
-            provider = existing_provider
-            _owns_tracer_provider = False
-            _isolated_provider = False
-            if debug:
-                logger.debug("Using existing tracer provider (not owned by neatlogs)")
     else:
-        sampler = None
-        if sample_rate < 1.0:
-            sampler = TraceIdRatioBased(sample_rate)
-            if debug:
-                logger.debug(f"Using TraceIdRatioBased sampler with rate {sample_rate}")
-
         provider = TracerProvider(
             resource=resource,
             sampler=sampler,
             span_limits=_span_limits_for_capture_everything(),
         )
         _owns_tracer_provider = True
-
-        # neatlogs is the first tracing SDK to load (no real global provider yet).
-        # We must still decide whether to claim the global slot or stay private. A
-        # foreign LLM instrumentor (openlit/langfuse/…) frequently attaches to the
-        # global provider LATER — e.g. in a FastAPI startup event that runs after an
-        # import-time neatlogs.init(). If we claimed the global now, that later
-        # instrumentor would bind to OUR provider and both pipelines would
-        # cross-contaminate. So when isolation is requested OR a foreign instrumentor
-        # is merely INSTALLED (importable), we pre-emptively keep a private provider
-        # and leave the global slot free for the co-tenant to own — no isolate=True
-        # required from the customer.
-        _foreign_installed = None if isolate is False else _foreign_llm_instrumentor_installed()
-        if isolate is True or _foreign_installed is not None:
-            _isolated_provider = True
-            if debug:
-                _why = (
-                    "isolate=True was requested"
-                    if isolate is True
-                    else f"foreign LLM instrumentor '{_foreign_installed}' is installed "
-                    f"(may attach to the global provider later)"
-                )
-                logger.info(
-                    f"Pre-emptive isolation: {_why} — neatlogs loaded first but keeps "
-                    f"a PRIVATE tracer provider and leaves the global slot free for the "
-                    f"co-tenant so the two pipelines share nothing."
-                )
-        else:
-            trace.set_tracer_provider(provider)
-            _isolated_provider = False
-            if debug:
-                logger.debug("Created new tracer provider (owned by neatlogs)")
+        if debug:
+            logger.debug("Created SDK-private tracer provider (owned by neatlogs)")
 
     _tracer_provider = provider
 
@@ -575,13 +431,12 @@ def init(
     # NeatlogsSpanProcessor: pure pre-processing (attribute normalization + file logging)
     global _span_processor
     _span_processor = NeatlogsSpanProcessor(
-        sample_rate=sample_rate,
         debug=debug,
         mask=mask,
         emit_completion_markers=False,
         # A private/isolated pipeline contains only Neatlogs execution spans,
         # even when the caller retains provider shutdown ownership.
-        own_all_spans=_owns_tracer_provider or _isolated_provider,
+        own_all_spans=True,
     )
     provider.add_span_processor(_span_processor)
 
@@ -597,6 +452,7 @@ def init(
         # warmups, outbound fetches outside any traced request) are never sent — on
         # their own they're junk rootless traces the backend can't simplify. Nested
         # HTTP spans (with a parent) still export normally.
+        from .core.masking_exporter import MaskingSpanExporter
         from .core.span_processor import is_rootless_infra_http
 
         class _FilteredOTLPExporter:
@@ -618,7 +474,7 @@ def init(
                 return self._inner.force_flush(timeout_millis)
 
         batch_processor = BatchSpanProcessor(
-            _FilteredOTLPExporter(otlp_exporter),
+            _FilteredOTLPExporter(MaskingSpanExporter(otlp_exporter, mask)),
             max_export_batch_size=batch_size,
             schedule_delay_millis=int(flush_interval * 1000),
         )
@@ -642,18 +498,6 @@ def init(
     if debug:
         logger.debug("Neatlogs tracer provider initialized")
 
-    global _meter_provider
-    _meter_provider = MeterProvider(resource=resource)
-    # In isolated mode, never claim the GLOBAL meter provider — that would clobber
-    # a co-tenant's (e.g. their OpenTelemetry/Langfuse) meter pipeline. neatlogs
-    # currently emits no metrics of its own, so a non-global provider is harmless.
-    if not _isolated_provider:
-        metrics.set_meter_provider(_meter_provider)
-        if debug:
-            logger.debug("Neatlogs meter provider initialized")
-    elif debug:
-        logger.debug("Isolated mode: skipping global meter provider registration")
-
     # --- Logs signal (opt-in) ---
     # neatlogs.log(), capture_stdout=True, and logging.* auto-capture all require
     # capture_logs=True. When False, nothing is captured as LOG spans.
@@ -662,6 +506,7 @@ def init(
         from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 
         from .core.log_exporter import NeatlogsLogFilter
+        from .core.masking_exporter import MaskingLogExporter
 
         logs_endpoint = f"{_base_url}/v1/logs"
         _otlp_log_exporter = OTLPLogExporter(
@@ -672,14 +517,8 @@ def init(
         # NeatlogsLogFilter drops external-module and no-trace records before
         # BatchLogRecordProcessor batches and sends them via OTLPLogExporter.
         _log_provider.add_log_record_processor(
-            NeatlogsLogFilter(BatchLogRecordProcessor(_otlp_log_exporter))
+            NeatlogsLogFilter(BatchLogRecordProcessor(MaskingLogExporter(_otlp_log_exporter, mask)))
         )
-        # Isolated mode: don't claim the GLOBAL logger provider (would clobber a
-        # co-tenant's log pipeline). LoggingInstrumentor below is still bound to
-        # our _log_provider explicitly via logger_provider=, so capture still works.
-        if not _isolated_provider:
-            logs.set_logger_provider(_log_provider)
-
         try:
             import logging as _stdlib_logging
 
@@ -736,8 +575,8 @@ def init(
 
 
 def flush(timeout_millis: int = 30000) -> bool:
-    """Flush all pending spans and metrics."""
-    global _tracer_provider, _meter_provider
+    """Flush the process-default Neatlogs pipeline only."""
+    global _tracer_provider
     success = True
 
     # Log provider must flush BEFORE tracer provider: the tracer batch includes
@@ -753,27 +592,59 @@ def flush(timeout_millis: int = 30000) -> bool:
             logger.error(f"Error flushing logs: {e}", exc_info=True)
             success = False
 
-    if _tracer_provider:
+    for processor in _transport_span_processors:
         try:
-            logger.debug("Flushing tracer provider...")
-            ok = _tracer_provider.force_flush(timeout_millis=timeout_millis)
-            success = bool(ok) and success
-            logger.debug("Tracer provider flushed successfully")
+            logger.debug("Flushing Neatlogs trace processor...")
+            ok = processor.force_flush(timeout_millis=timeout_millis)
+            success = (ok is None or bool(ok)) and success
         except Exception as e:
             logger.error(f"Error flushing spans: {e}", exc_info=True)
             success = False
 
-    if _meter_provider:
-        try:
-            logger.debug("Flushing meter provider...")
-            ok = _meter_provider.force_flush(timeout_millis=timeout_millis)
-            success = bool(ok) and success
-            logger.debug("Meter provider flushed successfully")
-        except Exception as e:
-            logger.error(f"Error flushing metrics: {e}", exc_info=True)
-            success = False
-
     return success
+
+
+def get_log_provider() -> Optional[LoggerProvider]:
+    """Return the SDK-private default log provider, when log capture is enabled."""
+    return _log_provider
+
+
+def flush_all(timeout_millis: int = 30000) -> Dict[str, bool]:
+    """Flush every live Neatlogs pipeline concurrently under one deadline.
+
+    Only processors/exporters installed by Neatlogs are flushed. The process-global
+    OpenTelemetry provider and caller/foreign processors are never touched.
+    """
+    from .core.client_registry import snapshot_clients
+
+    clients = snapshot_clients()
+    operations = [("default", flush)] if _initialized else []
+    operations.extend(
+        (f"client:{client.workflow_name}:{id(client):x}", client.flush) for client in clients
+    )
+    if not operations:
+        return {}
+
+    results: Dict[str, bool] = {}
+    timeout_seconds = max(0, timeout_millis) / 1000
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=len(operations))
+    try:
+        futures = {
+            executor.submit(operation, timeout_millis): name for name, operation in operations
+        }
+        done, pending = concurrent.futures.wait(futures, timeout=timeout_seconds)
+        for future in done:
+            name = futures[future]
+            try:
+                results[name] = bool(future.result())
+            except Exception:
+                results[name] = False
+        for future in pending:
+            results[futures[future]] = False
+            future.cancel()
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+    return results
 
 
 def get_session_config():
@@ -817,7 +688,7 @@ def shutdown(timeout_millis: int = 30000, termination_reason: str = "shutdown") 
 
 def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
     """End active Neatlogs spans, then flush and shut down SDK providers."""
-    global _tracer_provider, _owns_tracer_provider, _meter_provider, _log_provider, _span_processor, _initialized
+    global _tracer_provider, _owns_tracer_provider, _log_provider, _span_processor, _initialized
     global _instrumentation_manager, _transport_span_processors, _completion_span_processor
 
     try:
@@ -894,16 +765,6 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
             logger.error(f"Error shutting down tracer provider: {e}", exc_info=True)
             success = False
 
-    if _meter_provider:
-        try:
-            logger.debug("Shutting down meter provider...")
-            ok = _meter_provider.shutdown()
-            success = (ok is None or bool(ok)) and success
-            logger.debug("Meter provider shut down successfully")
-        except Exception as e:
-            logger.error(f"Error shutting down meter provider: {e}", exc_info=True)
-            success = False
-
     try:
         from opentelemetry.instrumentation.logging import LoggingInstrumentor
 
@@ -932,11 +793,8 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
     except Exception:
         pass
 
-    global _isolated_provider
-    _isolated_provider = False
     _initialized = False
     _tracer_provider = None
-    _meter_provider = None
     _log_provider = None
     _span_processor = None
     _transport_span_processors = []

--- a/neatlogs/schema_v2.py
+++ b/neatlogs/schema_v2.py
@@ -1,0 +1,39 @@
+"""Access to the canonical, language-neutral NeatLogs telemetry contract v2."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib import resources
+from typing import Any
+
+TELEMETRY_CONTRACT_VERSION = "2.0.0"
+TELEMETRY_SCHEMA_VERSION = 2
+TELEMETRY_SCHEMA_SHA256 = "9aec0e1b4e2fba718a1bad060798a881543c56ec8b887c6b0fb8ab147bbaee75"
+
+
+def telemetry_schema_bytes() -> bytes:
+    """Return the exact public schema bytes shipped with this SDK."""
+
+    return (
+        resources.files("neatlogs")
+        .joinpath("contracts/v2/neatlogs-telemetry.schema.json")
+        .read_bytes()
+    )
+
+
+def telemetry_schema() -> dict[str, Any]:
+    """Return the parsed canonical telemetry schema."""
+
+    return json.loads(telemetry_schema_bytes())
+
+
+def verify_telemetry_schema() -> None:
+    """Fail if packaging or a local edit changed the frozen contract bytes."""
+
+    actual = hashlib.sha256(telemetry_schema_bytes()).hexdigest()
+    if actual != TELEMETRY_SCHEMA_SHA256:
+        raise RuntimeError(
+            "NeatLogs telemetry schema v2 digest mismatch: "
+            f"expected {TELEMETRY_SCHEMA_SHA256}, received {actual}"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,7 @@ exclude = [
 [tool.setuptools.package-data]
 neatlogs = [
     "config/*.json",
+    "contracts/v2/*.json",
 ]
 
 [tool.setuptools.exclude-package-data]

--- a/tests/unit/test_code_params_capture.py
+++ b/tests/unit/test_code_params_capture.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 from opentelemetry import trace
 
+from neatlogs._wrap_utils import set_neatlogs_provider
 from neatlogs.decorators._base import _decorate_span
 from neatlogs.decorators.orchestration import span as neatlogs_span
 
@@ -22,13 +23,14 @@ from neatlogs.decorators.orchestration import span as neatlogs_span
 
 
 def _install(tracer_provider):
-    """Install ``tracer_provider`` as the global provider for the current test.
+    """Register the test provider explicitly with both test pipelines.
 
     The autouse ``reset_neatlogs_and_otel_state`` fixture in ``conftest.py``
     clears the OTel ``set_tracer_provider`` guard between tests, so this is
     safe to call repeatedly.
     """
     trace.set_tracer_provider(tracer_provider)
+    set_neatlogs_provider(tracer_provider)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_crewai_prompt_fidelity.py
+++ b/tests/unit/test_crewai_prompt_fidelity.py
@@ -4,7 +4,6 @@ import json
 import sys
 from pathlib import Path
 
-from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
@@ -84,9 +83,12 @@ def test_example_uses_automatic_crewai_instrumentation() -> None:
 def _install_test_tracer(in_memory_span_exporter) -> None:
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
-    trace.set_tracer_provider(provider)
-    # isolate=False pins neatlogs to the provider set above — see test_crewai_tool_fidelity.
-    neatlogs.init(api_key="test-key", disable_export=True, instrumentations=[], isolate=False)
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=[],
+        tracer_provider=provider,
+    )
 
 
 def test_crewai_string_input_preserves_content_after_10000_characters(

--- a/tests/unit/test_crewai_tool_fidelity.py
+++ b/tests/unit/test_crewai_tool_fidelity.py
@@ -5,7 +5,6 @@ import types
 from datetime import datetime, timezone
 
 import pytest
-from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import StatusCode
@@ -16,11 +15,12 @@ import neatlogs
 def _install_test_tracer(in_memory_span_exporter) -> None:
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
-    trace.set_tracer_provider(provider)
-    # isolate=False pins neatlogs to the provider set above. Without it, auto-isolation engages
-    # whenever a foreign instrumentor (logfire, traceloop, …) is merely importable in the venv and
-    # spans go to a private provider this exporter never sees.
-    neatlogs.init(api_key="test-key", disable_export=True, instrumentations=[], isolate=False)
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=[],
+        tracer_provider=provider,
+    )
 
 
 def _crewai_module():

--- a/tests/unit/test_decorator_capture_policy.py
+++ b/tests/unit/test_decorator_capture_policy.py
@@ -2,11 +2,13 @@
 
 from opentelemetry import trace
 
+from neatlogs._wrap_utils import set_neatlogs_provider
 from neatlogs.decorators.orchestration import span
 
 
 def _install(tracer_provider):
     trace.set_tracer_provider(tracer_provider)
+    set_neatlogs_provider(tracer_provider)
 
 
 def _finished(in_memory_span_exporter, name):

--- a/tests/unit/test_decorator_capture_policy.py
+++ b/tests/unit/test_decorator_capture_policy.py
@@ -1,0 +1,43 @@
+"""Decorator capture defaults to full fidelity with explicit local controls."""
+
+from opentelemetry import trace
+
+from neatlogs.decorators.orchestration import span
+
+
+def _install(tracer_provider):
+    trace.set_tracer_provider(tracer_provider)
+
+
+def _finished(in_memory_span_exporter, name):
+    return next(item for item in in_memory_span_exporter.get_finished_spans() if item.name == name)
+
+
+def test_default_capture_records_input_and_output(tracer_provider, in_memory_span_exporter):
+    _install(tracer_provider)
+
+    @span(kind="WORKFLOW")
+    def answer(question: str):
+        return {"answer": question.upper()}
+
+    answer("hello")
+
+    captured = _finished(in_memory_span_exporter, "answer")
+    assert captured.attributes["input.value"] == '{"question": "hello"}'
+    assert captured.attributes["output.value"] == '{"answer": "HELLO"}'
+
+
+def test_explicit_capture_controls_remain_local_and_deterministic(
+    tracer_provider, in_memory_span_exporter
+):
+    _install(tracer_provider)
+
+    @span(kind="WORKFLOW", capture_input=False, capture_output=False)
+    def answer(question: str):
+        return question.upper()
+
+    answer("hello")
+
+    captured = _finished(in_memory_span_exporter, "answer")
+    assert "input.value" not in captured.attributes
+    assert "output.value" not in captured.attributes

--- a/tests/unit/test_decorator_streaming.py
+++ b/tests/unit/test_decorator_streaming.py
@@ -1,0 +1,77 @@
+import pytest
+from opentelemetry import trace as otel_trace
+
+import neatlogs
+from neatlogs._wrap_utils import set_neatlogs_provider
+
+
+def test_sync_generator_span_stays_open_and_records_every_chunk(
+    tracer_provider, in_memory_span_exporter
+):
+    otel_trace.set_tracer_provider(tracer_provider)
+    set_neatlogs_provider(tracer_provider)
+
+    @neatlogs.span(kind="CHAIN")
+    def stream():
+        yield {"delta": "a"}
+        yield {"delta": "b"}
+
+    result = stream()
+    assert next(result) == {"delta": "a"}
+    assert in_memory_span_exporter.get_finished_spans() == ()
+    assert list(result) == [{"delta": "b"}]
+
+    finished = in_memory_span_exporter.get_finished_spans()
+    assert len(finished) == 1
+    assert finished[0].attributes["neatlogs.stream.chunk_count"] == 2
+    assert [event.name for event in finished[0].events] == [
+        "neatlogs.stream.chunk",
+        "neatlogs.stream.chunk",
+    ]
+    assert [event.attributes["neatlogs.stream.chunk.index"] for event in finished[0].events] == [
+        0,
+        1,
+    ]
+    assert finished[0].attributes["output.value"] == '[{"delta": "a"}, {"delta": "b"}]'
+
+
+def test_sync_generator_close_exports_partial_output(tracer_provider, in_memory_span_exporter):
+    otel_trace.set_tracer_provider(tracer_provider)
+    set_neatlogs_provider(tracer_provider)
+
+    @neatlogs.span(kind="CHAIN")
+    def stream():
+        yield "first"
+        yield "never-consumed"
+
+    result = stream()
+    assert next(result) == "first"
+    result.close()
+
+    finished = in_memory_span_exporter.get_finished_spans()
+    assert len(finished) == 1
+    assert finished[0].attributes["neatlogs.stream.cancelled"] is True
+    assert finished[0].attributes["output.value"] == '["first"]'
+
+
+@pytest.mark.asyncio
+async def test_async_generator_span_stays_open_and_records_every_chunk(
+    tracer_provider, in_memory_span_exporter
+):
+    otel_trace.set_tracer_provider(tracer_provider)
+    set_neatlogs_provider(tracer_provider)
+
+    @neatlogs.span(kind="CHAIN")
+    async def stream():
+        yield "a"
+        yield "b"
+
+    result = stream()
+    assert await anext(result) == "a"
+    assert in_memory_span_exporter.get_finished_spans() == ()
+    assert [chunk async for chunk in result] == ["b"]
+
+    finished = in_memory_span_exporter.get_finished_spans()
+    assert len(finished) == 1
+    assert finished[0].attributes["neatlogs.stream.chunk_count"] == 2
+    assert len(finished[0].events) == 2

--- a/tests/unit/test_graceful_trace_shutdown.py
+++ b/tests/unit/test_graceful_trace_shutdown.py
@@ -177,7 +177,6 @@ def test_shutdown_is_same_thread_reentrant(monkeypatch):
 
     monkeypatch.setattr(init_module, "_span_processor", ReentrantProcessor())
     monkeypatch.setattr(init_module, "_tracer_provider", None)
-    monkeypatch.setattr(init_module, "_meter_provider", None)
     monkeypatch.setattr(init_module, "_log_provider", None)
     monkeypatch.setattr(init_module, "_instrumentation_manager", None)
 
@@ -214,7 +213,6 @@ def test_shutdown_drains_logs_before_trace_completion(monkeypatch):
     monkeypatch.setattr(init_module, "_tracer_provider", Provider())
     monkeypatch.setattr(init_module, "_owns_tracer_provider", True)
     monkeypatch.setattr(init_module, "_log_provider", Logs())
-    monkeypatch.setattr(init_module, "_meter_provider", None)
     monkeypatch.setattr(init_module, "_span_processor", Lifecycle())
     monkeypatch.setattr(init_module, "_completion_span_processor", None)
     monkeypatch.setattr(init_module, "_instrumentation_manager", None)

--- a/tests/unit/test_mask_application.py
+++ b/tests/unit/test_mask_application.py
@@ -138,3 +138,35 @@ def test_global_mask_covers_logs_and_drops_failed_items():
     provider.get_logger("test").emit(body="must-not-export")
     provider.shutdown()
     assert inner.get_finished_logs() == ()
+
+
+def test_masking_log_exporter_force_flush_delegates(monkeypatch):
+    inner = InMemoryLogRecordExporter()
+    calls = []
+    monkeypatch.setattr(
+        inner,
+        "force_flush",
+        lambda timeout_millis=10000: calls.append(timeout_millis) or True,
+        raising=False,
+    )
+    exporter = MaskingLogExporter(inner, mask=None)
+
+    assert exporter.force_flush(1234) is True
+    assert calls == [1234]
+
+    exporter.shutdown()
+
+
+def test_masking_log_exporter_force_flush_supports_legacy_exporters():
+    class LegacyLogExporter:
+        def export(self, _batch):
+            return None
+
+        def shutdown(self):
+            return None
+
+    exporter = MaskingLogExporter(LegacyLogExporter(), mask=None)
+
+    assert exporter.force_flush() is True
+
+    exporter.shutdown()

--- a/tests/unit/test_mask_application.py
+++ b/tests/unit/test_mask_application.py
@@ -1,140 +1,140 @@
-"""
-Regression tests for client-side mask application in NeatlogsSpanProcessor.
+"""Masking is applied once, off the normalizer, at the final exporter boundary."""
 
-Guards two bugs fixed in span_processor.on_end (§7b/§7c/§8):
-  1. A per-span mask (@span(mask=)/trace(mask=), stamped as neatlogs.mask_id)
-     must reach the EXPORTED span, not just the file log. Previously the mask
-     sites gated on self.mask (global only), so a per-span-only mask was a no-op
-     on export.
-  2. The mask must be applied EXACTLY ONCE per span. Previously §7b + §7c (+ §8)
-     applied it 2-3x, which silently double-transforms non-idempotent masks
-     (e.g. translation).
+import asyncio
 
-These tests drive the processor directly with a fake ReadableSpan so they run
-with no exporter/backend and no LLM calls.
-"""
-
-from types import SimpleNamespace
-
-import pytest
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter, SimpleLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from neatlogs.core.mask import register_mask
+from neatlogs.core.masking_exporter import MaskingLogExporter, MaskingSpanExporter
 from neatlogs.core.span_processor import NeatlogsSpanProcessor
 
 
-class _MutableAttrs(dict):
-    """Stand-in for OTel BoundedAttributes: a mutable mapping."""
-
-    _immutable = False
-
-
-def _make_span(attrs, name="child", trace_id=0x1, span_id=0x2, parent_id=None):
-    """Minimal ReadableSpan-like object the processor's on_end reads from."""
-    ctx = SimpleNamespace(trace_id=trace_id, span_id=span_id)
-    parent = SimpleNamespace(span_id=parent_id) if parent_id is not None else None
-    status = SimpleNamespace(status_code=SimpleNamespace(name="OK"), description=None)
-    scope = SimpleNamespace(name="neatlogs.test")
-    a = _MutableAttrs(attrs)
-    return SimpleNamespace(
-        name=name,
-        attributes=a,
-        _attributes=a,
-        context=ctx,
-        parent=parent,
-        start_time=1,
-        end_time=2,
-        status=status,
-        events=[],
-        resource=SimpleNamespace(attributes={}),
-        instrumentation_scope=scope,
-        kind=None,
-    )
+def _pipeline(mask=None):
+    provider = TracerProvider(resource=Resource.create({"secret.resource": "resource-secret"}))
+    inner = InMemorySpanExporter()
+    provider.add_span_processor(NeatlogsSpanProcessor(mask=mask, own_all_spans=True))
+    provider.add_span_processor(SimpleSpanProcessor(MaskingSpanExporter(inner, mask)))
+    return provider, inner
 
 
 def _counting_mask(counter, tag):
-    def mask(span):
+    def mask(snapshot):
         counter["n"] += 1
-        attrs = span.get("attributes", {}) or {}
-        for k in list(attrs):
-            v = attrs[k]
-            if isinstance(v, str) and any(h in k.lower() for h in ("input", "output", "value")):
-                attrs[k] = f"[{tag}#{counter['n']}]" + v
-        return span
+        attrs = snapshot.get("attributes", {})
+        for key in list(attrs):
+            if "value" in key:
+                attrs[key] = f"[{tag}#{counter['n']}]" + str(attrs[key])
+        return snapshot
 
     return mask
 
 
-def test_global_mask_applied_once_and_exported():
+def test_global_mask_applied_once_to_exported_clone():
     counter = {"n": 0}
-    proc = NeatlogsSpanProcessor(mask=_counting_mask(counter, "G"))
-    span = _make_span(
-        {
-            "openinference.span.kind": "CHAIN",
-            "input.value": "IN",
-            "output.value": "OUT",
-        }
-    )
-    proc.on_end(span)
+    provider, inner = _pipeline(_counting_mask(counter, "G"))
+    span = provider.get_tracer("neatlogs.test").start_span("child")
+    span.set_attribute("openinference.span.kind", "CHAIN")
+    span.set_attribute("input.value", "IN")
+    span.set_attribute("output.value", "OUT")
+    span.end()
+    provider.shutdown()
 
-    assert counter["n"] == 1, f"global mask applied {counter['n']}x, expected 1"
-    # Value on the EXPORTED span (span._attributes) is masked exactly once.
-    assert span._attributes["input.value"] == "[G#1]IN"
-    assert span._attributes["output.value"] == "[G#1]OUT"
+    assert counter["n"] == 1
+    exported = inner.get_finished_spans()[0]
+    assert exported.attributes["input.value"] == "[G#1]IN"
+    assert exported.attributes["output.value"] == "[G#1]OUT"
 
 
-def test_per_span_mask_without_global_reaches_export():
-    """The bug that mattered most: per-span mask, NO global mask."""
-    counter = {"n": 0}
-    proc = NeatlogsSpanProcessor(mask=None)  # no global mask
-    mask_id = register_mask(_counting_mask(counter, "S"))
-    span = _make_span(
-        {
-            "openinference.span.kind": "CHAIN",
-            "neatlogs.mask_id": mask_id,
-            "input.value": "IN",
-            "output.value": "OUT",
-        }
-    )
-    proc.on_end(span)
+def test_per_span_mask_takes_precedence_and_internal_id_is_not_exported():
+    global_count, span_count = {"n": 0}, {"n": 0}
+    provider, inner = _pipeline(_counting_mask(global_count, "G"))
+    mask_id = register_mask(_counting_mask(span_count, "S"))
+    span = provider.get_tracer("neatlogs.test").start_span("child")
+    span.set_attribute("openinference.span.kind", "CHAIN")
+    span.set_attribute("neatlogs.mask_id", mask_id)
+    span.set_attribute("input.value", "IN")
+    span.end()
+    provider.shutdown()
 
-    assert counter["n"] == 1, f"per-span mask applied {counter['n']}x, expected 1"
-    assert (
-        span._attributes["input.value"] == "[S#1]IN"
-    ), "per-span mask did not reach the exported span"
-    assert span._attributes["output.value"] == "[S#1]OUT"
+    exported = inner.get_finished_spans()[0]
+    assert span_count["n"] == 1
+    assert global_count["n"] == 0
+    assert exported.attributes["input.value"] == "[S#1]IN"
+    assert "neatlogs.mask_id" not in exported.attributes
 
 
-def test_per_span_mask_takes_precedence_over_global():
-    gcount, scount = {"n": 0}, {"n": 0}
-    proc = NeatlogsSpanProcessor(mask=_counting_mask(gcount, "G"))
-    mask_id = register_mask(_counting_mask(scount, "S"))
-    span = _make_span(
-        {
-            "openinference.span.kind": "CHAIN",
-            "neatlogs.mask_id": mask_id,
-            "input.value": "IN",
-        }
-    )
-    proc.on_end(span)
+def test_mask_covers_events_resources_and_name():
+    def mask(snapshot):
+        snapshot["name"] = "masked-name"
+        snapshot["events"][0]["attributes"]["secret"] = "***"
+        snapshot["resource"]["attributes"]["secret.resource"] = "***"
+        return snapshot
 
-    assert scount["n"] == 1, "per-span mask should run exactly once"
-    assert gcount["n"] == 0, "global mask must NOT run when a per-span mask exists"
-    assert span._attributes["input.value"] == "[S#1]IN"
+    provider, inner = _pipeline(mask)
+    span = provider.get_tracer("neatlogs.test").start_span("secret-name")
+    span.set_attribute("openinference.span.kind", "CHAIN")
+    span.add_event("chunk", {"secret": "event-secret"})
+    span.end()
+    provider.shutdown()
 
-
-def test_no_mask_leaves_values_untouched():
-    proc = NeatlogsSpanProcessor(mask=None)
-    span = _make_span(
-        {
-            "openinference.span.kind": "CHAIN",
-            "input.value": "IN",
-        }
-    )
-    proc.on_end(span)
-    assert span._attributes["input.value"] == "IN"
+    exported = inner.get_finished_spans()[0]
+    assert exported.name == "masked-name"
+    assert exported.events[0].attributes["secret"] == "***"
+    assert exported.resource.attributes["secret.resource"] == "***"
 
 
-if __name__ == "__main__":
-    import sys
+def test_awaitable_mask_runs_and_callback_failure_fails_closed():
+    async def async_mask(snapshot):
+        await asyncio.sleep(0)
+        snapshot["attributes"]["input.value"] = "***"
+        return snapshot
 
-    sys.exit(pytest.main([__file__, "-v", "-p", "no:logfire"]))
+    provider, inner = _pipeline(async_mask)
+    span = provider.get_tracer("neatlogs.test").start_span("async")
+    span.set_attribute("openinference.span.kind", "CHAIN")
+    span.set_attribute("input.value", "secret")
+    span.end()
+    provider.shutdown()
+    assert inner.get_finished_spans()[0].attributes["input.value"] == "***"
+
+    def broken_mask(_snapshot):
+        raise RuntimeError("do not leak")
+
+    provider, inner = _pipeline(broken_mask)
+    span = provider.get_tracer("neatlogs.test").start_span("broken")
+    span.set_attribute("openinference.span.kind", "CHAIN")
+    span.set_attribute("input.value", "must-not-export")
+    span.end()
+    provider.shutdown()
+    assert inner.get_finished_spans() == ()
+
+
+def test_global_mask_covers_logs_and_drops_failed_items():
+    def mask(snapshot):
+        snapshot["body"] = "***"
+        snapshot["attributes"]["secret"] = "***"
+        return snapshot
+
+    provider = LoggerProvider()
+    inner = InMemoryLogRecordExporter()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(MaskingLogExporter(inner, mask)))
+    provider.get_logger("test").emit(body="secret body", attributes={"secret": "value"})
+    provider.shutdown()
+    exported = inner.get_finished_logs()[0].log_record
+    assert exported.body == "***"
+    assert exported.attributes["secret"] == "***"
+
+    def broken(_snapshot):
+        raise RuntimeError("drop")
+
+    provider = LoggerProvider()
+    inner = InMemoryLogRecordExporter()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(MaskingLogExporter(inner, broken)))
+    provider.get_logger("test").emit(body="must-not-export")
+    provider.shutdown()
+    assert inner.get_finished_logs() == ()

--- a/tests/unit/test_secondary_client.py
+++ b/tests/unit/test_secondary_client.py
@@ -11,6 +11,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 import neatlogs
 from neatlogs._wrap_utils import get_neatlogs_provider, get_tracer
+from neatlogs.init import get_log_provider
 
 
 def _client(name: str, *, capture_logs: bool = False):
@@ -116,7 +117,26 @@ def test_structured_logs_use_the_active_client():
     second.shutdown()
 
 
-def test_flushing_one_client_does_not_flush_another(monkeypatch):
+def test_structured_logs_use_the_private_default_log_provider():
+    neatlogs.init(
+        api_key="unused",
+        workflow_name="default",
+        capture_logs=True,
+        disable_export=True,
+        instrumentations=[],
+    )
+    provider = get_log_provider()
+    assert provider is not None
+    logs = InMemoryLogRecordExporter()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(logs))
+
+    with neatlogs.trace("run", kind="WORKFLOW"):
+        neatlogs.log("private message")
+
+    assert [str(item.log_record.body) for item in logs.get_finished_logs()] == ["private message"]
+
+
+def test_flushing_one_client_touches_no_other_or_caller_owned_provider(monkeypatch):
     first, first_provider, _ = _client("first")
     second, second_provider, _ = _client("second")
     first_flushes = []
@@ -128,10 +148,33 @@ def test_flushing_one_client_does_not_flush_another(monkeypatch):
 
     first.flush()
 
-    assert first_flushes == [1]
+    assert first_flushes == []
     assert second_flushes == []
 
     first.shutdown()
+    second.shutdown()
+
+
+def test_flush_all_discovers_live_clients_and_unregisters_closed_clients(monkeypatch):
+    first, _, _ = _client("first")
+    second, _, _ = _client("second")
+    calls = []
+    monkeypatch.setattr(first, "flush", lambda timeout_millis=30000: calls.append("first") or True)
+    monkeypatch.setattr(
+        second, "flush", lambda timeout_millis=30000: calls.append("second") or True
+    )
+
+    results = neatlogs.flush_all()
+    assert set(calls) == {"first", "second"}
+    assert len(results) == 2
+    assert all(results.values())
+
+    first.shutdown()
+    calls.clear()
+    results = neatlogs.flush_all()
+    assert calls == ["second"]
+    assert len(results) == 1
+
     second.shutdown()
 
 

--- a/tests/unit/test_session_identity.py
+++ b/tests/unit/test_session_identity.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from opentelemetry import trace
 
 import neatlogs
+from neatlogs._wrap_utils import set_neatlogs_provider
 from neatlogs.core.context import trace as nl_trace
 from neatlogs.core.end_user import END_USER_ID_KEY
 from neatlogs.core.identity import identify
@@ -18,6 +19,7 @@ from neatlogs.decorators.orchestration import span as neatlogs_span
 
 def _install(tracer_provider):
     trace.set_tracer_provider(tracer_provider)
+    set_neatlogs_provider(tracer_provider)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_telemetry_schema_v2.py
+++ b/tests/unit/test_telemetry_schema_v2.py
@@ -1,0 +1,33 @@
+import hashlib
+import json
+
+import neatlogs
+
+EXPECTED_PRECEDENCE = [
+    "native-v2",
+    "neatlogs-direct",
+    "otel-genai",
+    "openinference",
+    "provider-specific",
+    "external-legacy",
+    "unknown-raw",
+]
+
+
+def test_canonical_telemetry_schema_is_packaged_verbatim():
+    schema_bytes = neatlogs.telemetry_schema_bytes()
+
+    assert hashlib.sha256(schema_bytes).hexdigest() == neatlogs.TELEMETRY_SCHEMA_SHA256
+    assert json.loads(schema_bytes) == neatlogs.telemetry_schema()
+    neatlogs.verify_telemetry_schema()
+
+
+def test_canonical_telemetry_policy_is_consumed_by_the_sdk():
+    schema = neatlogs.telemetry_schema()
+    policy = schema["x-neatlogs-policy"]
+
+    assert neatlogs.TELEMETRY_SCHEMA_VERSION == 2
+    assert policy["contract_version"] == neatlogs.TELEMETRY_CONTRACT_VERSION
+    assert policy["conflict_precedence"] == EXPECTED_PRECEDENCE
+    assert policy["tool_calls"]["execution_is_separate_tool_span"] is True
+    assert policy["root_finalization"]["launch_sdk_auto_workflow_roots"] is True

--- a/tests/unit/test_trace_sampling_and_provider_ownership.py
+++ b/tests/unit/test_trace_sampling_and_provider_ownership.py
@@ -1,0 +1,92 @@
+import math
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+import neatlogs
+from neatlogs._wrap_utils import get_neatlogs_provider
+
+
+def _export_from(provider: TracerProvider) -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return exporter
+
+
+def test_init_never_claims_or_reuses_the_global_provider():
+    global_provider = TracerProvider()
+    global_exporter = _export_from(global_provider)
+    otel_trace.set_tracer_provider(global_provider)
+
+    neatlogs.init(
+        api_key="unused",
+        disable_export=True,
+        instrumentations=[],
+    )
+    private_provider = get_neatlogs_provider()
+    assert private_provider is not None
+    assert private_provider is not global_provider
+    private_exporter = _export_from(private_provider)
+
+    with neatlogs.trace("private-root", kind="WORKFLOW"):
+        pass
+    global_span = global_provider.get_tracer("host").start_span("host-root")
+    global_span.end()
+
+    assert {span.name for span in private_exporter.get_finished_spans()} == {"private-root"}
+    assert {span.name for span in global_exporter.get_finished_spans()} == {"host-root"}
+
+
+def test_zero_sample_rate_drops_the_whole_trace_not_individual_children():
+    neatlogs.init(
+        api_key="unused",
+        disable_export=True,
+        instrumentations=[],
+        sample_rate=0.0,
+    )
+    provider = get_neatlogs_provider()
+    assert provider is not None
+    exporter = _export_from(provider)
+
+    with neatlogs.trace("root", kind="WORKFLOW"):
+        with neatlogs.trace("child", kind="CHAIN"):
+            pass
+
+    assert exporter.get_finished_spans() == ()
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1, math.nan, math.inf, -math.inf, True, "1"])
+def test_invalid_sample_rate_is_a_typed_configuration_error(value):
+    with pytest.raises(neatlogs.NeatlogsConfigurationError, match="sample_rate"):
+        neatlogs.init(
+            api_key="unused",
+            disable_export=True,
+            instrumentations=[],
+            sample_rate=value,
+        )
+
+
+def test_caller_owned_provider_rejects_an_unenforceable_sample_rate():
+    with pytest.raises(neatlogs.NeatlogsConfigurationError, match="caller-owned"):
+        neatlogs.Client(
+            api_key="unused",
+            workflow_name="test",
+            disable_export=True,
+            tracer_provider=TracerProvider(),
+            sample_rate=0.5,
+        )
+
+
+def test_explicit_global_provider_is_rejected():
+    provider = TracerProvider()
+    otel_trace.set_tracer_provider(provider)
+    with pytest.raises(neatlogs.NeatlogsConfigurationError, match="process-global"):
+        neatlogs.init(
+            api_key="unused",
+            disable_export=True,
+            instrumentations=[],
+            tracer_provider=provider,
+        )


### PR DESCRIPTION
This integrated branch builds on and supersedes PR #73.

It adds:
- race-safe graceful finalization from the existing PR
- SDK-private provider ownership and parent-based sampling
- removal of exporter-level random sampling and global provider mutation
- async/generator lifecycle handling, fail-closed exporter masking, and logs-first flush-all
- typed configuration errors and canonical endpoint behavior
- packaged canonical telemetry contract v2 with an exact digest gate

Verification:
- 217 Python unit tests passed with the async plugin active
- formatting checks passed
- wheel and source distribution build successfully
- the wheel contains the exact canonical schema digest