### PR TITLE
fix: correlate Doctor v2 probes and support optional providers

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -44,14 +44,20 @@ pip install "neatlogs[google-genai]"
 
 Requires **Python >= 3.10, < 3.14**.
 
-Before initialization, run the local doctor to validate the installed package,
-schema hash, endpoint, sampler, private-provider contract, and observable export
-health without sending telemetry or changing SDK state:
+Before initialization, run the local Doctor. It sends generated non-user workflow
+and tool spans through an isolated instance of the installed SDK's normalization,
+masking, capture, and flush pipeline. It performs no backend request and requires
+no API key:
 
 ```bash
-python -m neatlogs doctor --json
-# or: neatlogs-doctor --json
+python -m neatlogs doctor --local --json
+# or: neatlogs-doctor --local --json
 ```
+
+A passing local result proves that this installed SDK pipeline works. It does not
+prove that an application's own instrumentors or backend export are working. Use
+`doctor_captured_local_v2()` inside the instrumented application to validate its
+actual final masked envelope, or `doctor --probe` for authenticated backend stages.
 
 ---
 

--- a/README.MD
+++ b/README.MD
@@ -44,6 +44,15 @@ pip install "neatlogs[google-genai]"
 
 Requires **Python >= 3.10, < 3.14**.
 
+Before initialization, run the local doctor to validate the installed package,
+schema hash, endpoint, sampler, private-provider contract, and observable export
+health without sending telemetry or changing SDK state:
+
+```bash
+python -m neatlogs doctor --json
+# or: neatlogs-doctor --json
+```
+
 ---
 
 ## Quickstart

--- a/neatlogs/__init__.py
+++ b/neatlogs/__init__.py
@@ -34,7 +34,9 @@ from .core.llm_binder import bind_templates
 from .core.log import log
 from .core.propagation import extract_trace_context, inject_trace_context
 from .decorators import span
-from .init import flush, init, shutdown
+from .doctor import DOCTOR_FORMAT_VERSION, DoctorCheck, DoctorResult, doctor
+from .errors import NeatlogsConfigurationError, NeatlogsError
+from .init import flush, flush_all, init, shutdown
 from .prompt.client import (
     AsyncPromptClient,
     CachedPrompt,
@@ -54,6 +56,16 @@ from .prompt.client import (
     update_prompt,
 )
 from .prompt.template import PromptTemplate, SystemPromptTemplate, UserPromptTemplate
+from .schema_v2 import (
+    TELEMETRY_CONTRACT_VERSION,
+    TELEMETRY_SCHEMA_SHA256,
+    TELEMETRY_SCHEMA_VERSION,
+    telemetry_manifest,
+    telemetry_schema,
+    telemetry_schema_bytes,
+    validate_telemetry_fixture,
+    verify_telemetry_schema,
+)
 from .version import __version__
 
 
@@ -277,7 +289,22 @@ __all__ = [
     "Client",
     "init",
     "flush",
+    "flush_all",
     "shutdown",
+    "doctor",
+    "DoctorCheck",
+    "DoctorResult",
+    "DOCTOR_FORMAT_VERSION",
+    "NeatlogsError",
+    "NeatlogsConfigurationError",
+    "TELEMETRY_CONTRACT_VERSION",
+    "TELEMETRY_SCHEMA_VERSION",
+    "TELEMETRY_SCHEMA_SHA256",
+    "telemetry_manifest",
+    "telemetry_schema",
+    "telemetry_schema_bytes",
+    "verify_telemetry_schema",
+    "validate_telemetry_fixture",
     "span",
     "trace",
     "identify",

--- a/neatlogs/__init__.py
+++ b/neatlogs/__init__.py
@@ -35,6 +35,13 @@ from .core.log import log
 from .core.propagation import extract_trace_context, inject_trace_context
 from .decorators import span
 from .doctor import DOCTOR_FORMAT_VERSION, DoctorCheck, DoctorResult, doctor
+from .doctor_v2 import (
+    DOCTOR_V2_FORMAT_VERSION,
+    doctor_captured_local_v2,
+    doctor_local_v2,
+    doctor_probe_v2,
+    doctor_semantic_digest,
+)
 from .errors import NeatlogsConfigurationError, NeatlogsError
 from .init import flush, flush_all, init, shutdown
 from .prompt.client import (
@@ -295,6 +302,11 @@ __all__ = [
     "DoctorCheck",
     "DoctorResult",
     "DOCTOR_FORMAT_VERSION",
+    "DOCTOR_V2_FORMAT_VERSION",
+    "doctor_local_v2",
+    "doctor_captured_local_v2",
+    "doctor_probe_v2",
+    "doctor_semantic_digest",
     "NeatlogsError",
     "NeatlogsConfigurationError",
     "TELEMETRY_CONTRACT_VERSION",

--- a/neatlogs/__main__.py
+++ b/neatlogs/__main__.py
@@ -3,22 +3,125 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
+import time
 
 from .doctor import doctor
+from .doctor_v2 import (
+    clear_doctor_capture,
+    doctor_captured_local_v2,
+    doctor_probe_v2,
+)
+from .version import __version__
+
+
+class _UsageError(Exception):
+    pass
+
+
+class _DoctorParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise _UsageError(message)
+
+
+def _print_v2(result: dict, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return
+    print(f"Neatlogs Doctor: {result['status'].upper()}")
+    for check in result.get("checks", []):
+        print(f"[{check['status'].upper()}] {check['reason_code']}: {check['message']}")
+    if result.get("first_failure"):
+        print(f"First failure: {result['first_failure']}")
+
+
+def _standalone_local() -> dict:
+    """Exercise an isolated generated pipeline without backend access."""
+
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+    from .core.masking_exporter import MaskingSpanExporter
+    from .core.span_processor import NeatlogsSpanProcessor
+
+    class _MemorySink(SpanExporter):
+        def export(self, spans):
+            return SpanExportResult.SUCCESS
+
+        def shutdown(self):
+            return None
+
+    clear_doctor_capture()
+    provider = TracerProvider()
+    provider.add_span_processor(
+        NeatlogsSpanProcessor(emit_completion_markers=False, own_all_spans=True)
+    )
+    provider.add_span_processor(
+        SimpleSpanProcessor(MaskingSpanExporter(_MemorySink(), lambda snapshot: snapshot))
+    )
+    tracer = provider.get_tracer("neatlogs.doctor", __version__)
+    started = time.monotonic()
+    with tracer.start_as_current_span("doctor.workflow") as root:
+        trace_id = f"{root.get_span_context().trace_id:032x}"
+        root.set_attribute("neatlogs.span.kind", "WORKFLOW")
+        root.set_attribute("input.value", '{"prompt":"generated diagnostic input"}')
+        root.set_attribute("output.value", '{"result":"generated diagnostic output"}')
+        root.set_attribute("neatlogs.llm.tool_calls.0.id", "doctor_call_1")
+        root.set_attribute("neatlogs.llm.tool_calls.0.name", "diagnostic_tool")
+        with tracer.start_as_current_span("doctor.tool") as tool:
+            tool.set_attribute("neatlogs.span.kind", "TOOL")
+            tool.set_attribute("neatlogs.tool.call_id", "doctor_call_1")
+            tool.set_attribute("neatlogs.tool.name", "diagnostic_tool")
+            tool.set_attribute("input.value", '{"value":1}')
+            tool.set_attribute("output.value", '{"value":2}')
+    flushed = provider.force_flush(timeout_millis=5_000)
+    duration_ms = max(0, round((time.monotonic() - started) * 1_000))
+    result = doctor_captured_local_v2(
+        trace_id,
+        flush_outcome="success" if flushed else "timeout",
+        flush_duration_ms=duration_ms,
+    )
+    provider.shutdown()
+    if result is None:
+        raise RuntimeError("isolated Doctor capture was unavailable")
+    return result
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="neatlogs")
+    parser = _DoctorParser(prog="neatlogs")
     commands = parser.add_subparsers(dest="command", required=True)
     doctor_parser = commands.add_parser(
         "doctor", help="run read-only, network-free SDK diagnostics"
     )
+    modes = doctor_parser.add_mutually_exclusive_group()
+    modes.add_argument("--local", action="store_true")
+    modes.add_argument("--probe", action="store_true")
     doctor_parser.add_argument("--endpoint")
     doctor_parser.add_argument("--sample-rate", type=float, default=1.0)
     doctor_parser.add_argument("--disable-export", action="store_true", default=None)
     doctor_parser.add_argument("--json", action="store_true")
-    args = parser.parse_args(argv)
+    try:
+        args = parser.parse_args(argv)
+    except _UsageError as exc:
+        print(f"neatlogs: {exc}", file=sys.stderr)
+        print("Usage: neatlogs doctor (--local | --probe) [--json]", file=sys.stderr)
+        return 4
+
+    if args.local or args.probe:
+        if args.sample_rate != 1.0 or args.disable_export:
+            print(
+                "neatlogs: --sample-rate and --disable-export belong to legacy Doctor mode",
+                file=sys.stderr,
+            )
+            return 4
+        result = doctor_probe_v2(endpoint=args.endpoint) if args.probe else _standalone_local()
+        _print_v2(result, args.json)
+        if result["status"] == "pass":
+            return 0
+        if result["status"] == "warn":
+            return 1
+        return 3 if args.probe else 2
 
     result = doctor(
         endpoint=args.endpoint,

--- a/neatlogs/__main__.py
+++ b/neatlogs/__main__.py
@@ -1,0 +1,44 @@
+"""Small, dependency-free Neatlogs command line entry point."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .doctor import doctor
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="neatlogs")
+    commands = parser.add_subparsers(dest="command", required=True)
+    doctor_parser = commands.add_parser(
+        "doctor", help="run read-only, network-free SDK diagnostics"
+    )
+    doctor_parser.add_argument("--endpoint")
+    doctor_parser.add_argument("--sample-rate", type=float, default=1.0)
+    doctor_parser.add_argument("--disable-export", action="store_true", default=None)
+    doctor_parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    result = doctor(
+        endpoint=args.endpoint,
+        sample_rate=args.sample_rate,
+        disable_export=args.disable_export,
+    )
+    if args.json:
+        print(result.to_json())
+    else:
+        print(f"Neatlogs doctor: {'PASS' if result.ready else 'FAIL'}")
+        for check in result.checks:
+            print(f"[{check.status.upper()}] {check.reason_code}: {check.message}")
+    return 0 if result.ready else 1
+
+
+def doctor_main(argv: list[str] | None = None) -> int:
+    """Entry point for the dedicated ``neatlogs-doctor`` executable."""
+
+    return main(["doctor", *(sys.argv[1:] if argv is None else argv)])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/neatlogs/_wrap_utils.py
+++ b/neatlogs/_wrap_utils.py
@@ -11,6 +11,7 @@ Only contains truly shared concerns:
 import inspect
 import json
 import os
+import threading
 import time
 from contextvars import ContextVar
 from typing import Any, Callable, Dict, List, Mapping, Optional
@@ -879,6 +880,10 @@ class SyncStreamWrapper:
         self._first_chunk_time: Optional[float] = None
         self._chunks: List[Any] = []
         self._finalized = False
+        self._captured_chars = 0
+        self._chunk_count = 0
+        self._lock = threading.Lock()
+        span.set_attribute("neatlogs.stream.completion_state", "not_streamed")
 
     def __iter__(self):
         return self
@@ -887,16 +892,25 @@ class SyncStreamWrapper:
         try:
             chunk = next(self._stream)
         except StopIteration:
-            self._finalize()
+            self._finalize("complete")
             raise
-        except Exception as e:
+        except BaseException as e:
             self._finalize_error(e)
             raise
 
         if self._first_chunk_time is None:
             self._first_chunk_time = time.perf_counter()
-        self._chunks.append(chunk)
+        self._chunk_count += 1
+        self._capture(chunk)
         return chunk
+
+    def _capture(self, chunk: Any) -> None:
+        size = len(serialize(chunk, max_length=100_000))
+        if self._captured_chars + size <= 100_000:
+            self._chunks.append(chunk)
+            self._captured_chars += size
+        else:
+            self._span.set_attribute("neatlogs.stream.output_truncated", True)
 
     def __enter__(self):
         if hasattr(self._stream, "__enter__"):
@@ -906,27 +920,57 @@ class SyncStreamWrapper:
     def __exit__(self, *args):
         if hasattr(self._stream, "__exit__"):
             self._stream.__exit__(*args)
-        self._finalize()
+        self._finalize("consumer_cancelled" if args and args[0] else "complete")
 
-    def _finalize(self):
-        if self._finalized:
+    def close(self):
+        try:
+            close = getattr(self._stream, "close", None)
+            if close is not None:
+                close()
+        finally:
+            self._finalize("consumer_cancelled")
+
+    def _claim_finalize(self) -> bool:
+        with self._lock:
+            if self._finalized:
+                return False
+            self._finalized = True
+            return True
+
+    def _finalize(self, state="complete"):
+        if not self._claim_finalize():
             return
-        self._finalized = True
+        self._span.set_attribute("neatlogs.stream.completion_state", state)
+        self._span.set_attribute("neatlogs.stream.chunk_count", self._chunk_count)
         elapsed_ms = (time.perf_counter() - self._start_time) * 1000
         ttft_ms = None
         if self._first_chunk_time is not None:
             ttft_ms = (self._first_chunk_time - self._start_time) * 1000
-        self._finalizer(self._span, self._chunks, elapsed_ms, ttft_ms)
+        if state == "complete":
+            self._finalizer(self._span, self._chunks, elapsed_ms, ttft_ms)
+        else:
+            self._span.set_attribute("output.value", serialize(self._chunks))
+            self._span.set_attribute("output.mime_type", "application/json")
+            self._span.end()
 
     def _finalize_error(self, error: Exception):
-        if self._finalized:
+        if not self._claim_finalize():
             return
-        self._finalized = True
+        self._span.set_attribute("neatlogs.stream.completion_state", "provider_error")
+        self._span.set_attribute("neatlogs.stream.chunk_count", self._chunk_count)
+        self._span.set_attribute("output.value", serialize(self._chunks))
+        self._span.set_attribute("output.mime_type", "application/json")
         from opentelemetry.trace import StatusCode
 
         self._span.set_status(StatusCode.ERROR, str(error))
         self._span.record_exception(error)
         self._span.end()
+
+    def __del__(self):
+        try:
+            self._finalize("consumer_cancelled")
+        except Exception:
+            pass
 
     def __getattr__(self, name):
         return getattr(self._stream, name)
@@ -945,6 +989,10 @@ class AsyncStreamWrapper:
         self._first_chunk_time: Optional[float] = None
         self._chunks: List[Any] = []
         self._finalized = False
+        self._captured_chars = 0
+        self._chunk_count = 0
+        self._lock = threading.Lock()
+        span.set_attribute("neatlogs.stream.completion_state", "not_streamed")
 
     def __aiter__(self):
         return self
@@ -953,15 +1001,21 @@ class AsyncStreamWrapper:
         try:
             chunk = await self._stream.__anext__()
         except StopAsyncIteration:
-            self._finalize()
+            self._finalize("complete")
             raise
-        except Exception as e:
+        except BaseException as e:
             self._finalize_error(e)
             raise
 
         if self._first_chunk_time is None:
             self._first_chunk_time = time.perf_counter()
-        self._chunks.append(chunk)
+        self._chunk_count += 1
+        size = len(serialize(chunk, max_length=100_000))
+        if self._captured_chars + size <= 100_000:
+            self._chunks.append(chunk)
+            self._captured_chars += size
+        else:
+            self._span.set_attribute("neatlogs.stream.output_truncated", True)
         return chunk
 
     async def __aenter__(self):
@@ -972,27 +1026,57 @@ class AsyncStreamWrapper:
     async def __aexit__(self, *args):
         if hasattr(self._stream, "__aexit__"):
             await self._stream.__aexit__(*args)
-        self._finalize()
+        self._finalize("consumer_cancelled" if args and args[0] else "complete")
 
-    def _finalize(self):
-        if self._finalized:
+    async def aclose(self):
+        try:
+            close = getattr(self._stream, "aclose", None)
+            if close is not None:
+                await close()
+        finally:
+            self._finalize("consumer_cancelled")
+
+    def _claim_finalize(self) -> bool:
+        with self._lock:
+            if self._finalized:
+                return False
+            self._finalized = True
+            return True
+
+    def _finalize(self, state="complete"):
+        if not self._claim_finalize():
             return
-        self._finalized = True
+        self._span.set_attribute("neatlogs.stream.completion_state", state)
+        self._span.set_attribute("neatlogs.stream.chunk_count", self._chunk_count)
         elapsed_ms = (time.perf_counter() - self._start_time) * 1000
         ttft_ms = None
         if self._first_chunk_time is not None:
             ttft_ms = (self._first_chunk_time - self._start_time) * 1000
-        self._finalizer(self._span, self._chunks, elapsed_ms, ttft_ms)
+        if state == "complete":
+            self._finalizer(self._span, self._chunks, elapsed_ms, ttft_ms)
+        else:
+            self._span.set_attribute("output.value", serialize(self._chunks))
+            self._span.set_attribute("output.mime_type", "application/json")
+            self._span.end()
 
     def _finalize_error(self, error: Exception):
-        if self._finalized:
+        if not self._claim_finalize():
             return
-        self._finalized = True
+        self._span.set_attribute("neatlogs.stream.completion_state", "provider_error")
+        self._span.set_attribute("neatlogs.stream.chunk_count", self._chunk_count)
+        self._span.set_attribute("output.value", serialize(self._chunks))
+        self._span.set_attribute("output.mime_type", "application/json")
         from opentelemetry.trace import StatusCode
 
         self._span.set_status(StatusCode.ERROR, str(error))
         self._span.record_exception(error)
         self._span.end()
+
+    def __del__(self):
+        try:
+            self._finalize("consumer_cancelled")
+        except Exception:
+            pass
 
     def __getattr__(self, name):
         return getattr(self._stream, name)

--- a/neatlogs/client.py
+++ b/neatlogs/client.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import math
 import threading
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 from opentelemetry import trace as otel_trace
@@ -21,6 +22,7 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import SpanLimits, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
 
 from ._wrap_utils import (
     _ForeignParentGuardTracer,
@@ -28,8 +30,11 @@ from ._wrap_utils import (
     activate_client,
     reset_active_client,
 )
+from .core.client_registry import register_client, unregister_client
 from .core.log_exporter import NeatlogsLogFilter
+from .core.masking_exporter import MaskingLogExporter, MaskingSpanExporter
 from .core.span_processor import CompletionMarkerSpanProcessor, NeatlogsSpanProcessor
+from .errors import NeatlogsConfigurationError
 from .version import __version__
 
 
@@ -67,6 +72,8 @@ class Client:
         capture_logs: bool = False,
         batch_size: int = 100,
         flush_interval: float = 5.0,
+        sample_rate: float = 1.0,
+        mask: Callable[[dict[str, Any]], Any] | None = None,
         disable_export: bool = False,
         tracer_provider: TracerProvider | None = None,
     ) -> None:
@@ -78,6 +85,20 @@ class Client:
             raise ValueError("workflow_name is required")
         if tags is not None and not all(isinstance(tag, str) for tag in tags):
             raise ValueError("All tags must be strings")
+        if isinstance(sample_rate, bool) or not isinstance(sample_rate, (int, float)):
+            raise NeatlogsConfigurationError("sample_rate must be a finite number from 0.0 to 1.0")
+        rate = float(sample_rate)
+        if not math.isfinite(rate) or rate < 0.0 or rate > 1.0:
+            raise NeatlogsConfigurationError("sample_rate must be a finite number from 0.0 to 1.0")
+        if tracer_provider is not None and rate != 1.0:
+            raise NeatlogsConfigurationError(
+                "sample_rate cannot configure a caller-owned tracer_provider; "
+                "configure its sampler directly or omit tracer_provider"
+            )
+        if tracer_provider is not None and tracer_provider is otel_trace.get_tracer_provider():
+            raise NeatlogsConfigurationError(
+                "tracer_provider must be private and must not be the process-global provider"
+            )
 
         self.workflow_name = name
         self._state = "running"
@@ -98,6 +119,7 @@ class Client:
 
         self.tracer_provider = tracer_provider or TracerProvider(
             resource=resource,
+            sampler=ParentBased(root=TraceIdRatioBased(rate)),
             span_limits=SpanLimits(max_span_attributes=10_000),
         )
         if tracer_provider is not None:
@@ -107,6 +129,7 @@ class Client:
                 pass
 
         self._span_processor = NeatlogsSpanProcessor(
+            mask=mask,
             emit_completion_markers=False,
             # A private provider is an isolated project pipeline. A caller-owned
             # provider may be shared with host telemetry, so ownership is marked
@@ -125,8 +148,9 @@ class Client:
                 endpoint=traces_endpoint,
                 headers={"x-api-key": key},
             )
+            masking_exporter = MaskingSpanExporter(exporter, mask)
             batch_processor = BatchSpanProcessor(
-                exporter,
+                masking_exporter,
                 max_export_batch_size=batch_size,
                 schedule_delay_millis=int(flush_interval * 1000),
             )
@@ -137,9 +161,13 @@ class Client:
             self.tracer_provider.add_span_processor(batch_processor)
             self.tracer_provider.add_span_processor(completion_processor)
             self._transport_processors = [batch_processor, completion_processor]
+            self._exporters = [masking_exporter]
             self._completion_processor = completion_processor
+        else:
+            self._exporters = []
 
         self.log_provider: LoggerProvider | None = None
+        self._log_exporters = []
         if capture_logs:
             self.log_provider = LoggerProvider(resource=resource)
             if not disable_export:
@@ -149,11 +177,14 @@ class Client:
                     endpoint=f"{base_url}/v1/logs",
                     headers={"x-api-key": key},
                 )
+                masking_log_exporter = MaskingLogExporter(log_exporter, mask)
+                self._log_exporters.append(masking_log_exporter)
                 self.log_provider.add_log_record_processor(
-                    NeatlogsLogFilter(BatchLogRecordProcessor(log_exporter))
+                    NeatlogsLogFilter(BatchLogRecordProcessor(masking_log_exporter))
                 )
 
         atexit.register(self.shutdown)
+        register_client(self)
 
     def get_tracer(self, scope: str):
         tracer = self._tracers.get(scope)
@@ -195,11 +226,16 @@ class Client:
                 self.log_provider.force_flush(timeout_millis=timeout_millis)
             except Exception:
                 success = False
-        try:
-            result = self.tracer_provider.force_flush(timeout_millis=timeout_millis)
-            success = bool(result) and success
-        except Exception:
-            success = False
+        for processor in self._transport_processors:
+            try:
+                result = processor.force_flush(timeout_millis=timeout_millis)
+                success = (result is None or bool(result)) and success
+            except Exception:
+                success = False
+        success = (
+            all(exporter.health.healthy for exporter in self._exporters + self._log_exporters)
+            and success
+        )
         return success
 
     def shutdown(
@@ -235,6 +271,7 @@ class Client:
                 atexit.unregister(self.shutdown)
             except Exception:
                 pass
+            unregister_client(self)
 
     def _perform_shutdown(self, timeout_millis: int, termination_reason: str) -> bool:
         success = True

--- a/neatlogs/contracts/v2/manifest.json
+++ b/neatlogs/contracts/v2/manifest.json
@@ -1,0 +1,8 @@
+{
+  "contract_version": "2.0.0",
+  "schema_version": 2,
+  "schema_file": "neatlogs-telemetry.schema.json",
+  "schema_id": "https://schemas.neatlogs.com/telemetry/v2/neatlogs-telemetry.schema.json",
+  "schema_sha256": "1ce32734138c2ffc316c4299f5ae3eebec2f94381a538a383af49ba93eec9f9d",
+  "authority": "https://github.com/neatlogs/skills/tree/main/contracts/v2"
+}

--- a/neatlogs/contracts/v2/neatlogs-telemetry.schema.json
+++ b/neatlogs/contracts/v2/neatlogs-telemetry.schema.json
@@ -1,0 +1,1998 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.neatlogs.com/telemetry/v2/neatlogs-telemetry.schema.json",
+  "title": "NeatLogs Canonical Telemetry Span Envelope v2",
+  "description": "The language-neutral canonical span representation used after capture normalization and before masking/export.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trace_id",
+    "span_id",
+    "parent_span_id",
+    "name",
+    "kind",
+    "ownership",
+    "wrapper",
+    "input",
+    "output",
+    "status",
+    "error",
+    "code",
+    "provenance",
+    "conflicts",
+    "semantic",
+    "attributes"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 2
+    },
+    "trace_id": {
+      "$ref": "#/$defs/traceId"
+    },
+    "span_id": {
+      "$ref": "#/$defs/spanId"
+    },
+    "parent_span_id": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/spanId"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "kind": {
+      "$ref": "#/$defs/spanKind"
+    },
+    "start_time_unix_nano": {
+      "$ref": "#/$defs/uint64String"
+    },
+    "end_time_unix_nano": {
+      "$ref": "#/$defs/uint64String"
+    },
+    "ownership": {
+      "$ref": "#/$defs/ownership"
+    },
+    "wrapper": {
+      "$ref": "#/$defs/wrapper"
+    },
+    "input": {
+      "$ref": "#/$defs/typedValue"
+    },
+    "output": {
+      "$ref": "#/$defs/typedValue"
+    },
+    "status": {
+      "$ref": "#/$defs/status"
+    },
+    "error": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/error"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "code": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/codeLocation"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "provenance": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/provenance"
+      }
+    },
+    "conflicts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/conflict"
+      }
+    },
+    "semantic": {
+      "$ref": "#/$defs/semantic"
+    },
+    "attributes": {
+      "type": "object",
+      "description": "Non-canonical source attributes retained for compatibility and debugging. They never override canonical fields.",
+      "additionalProperties": {
+        "$ref": "#/$defs/jsonValue"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "LLM"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/llmSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "enum": [
+              "TOOL",
+              "MCP_TOOL"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/toolSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "RETRIEVER"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/retrieverSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "RERANKER"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/rerankerSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "EMBEDDING"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/embeddingSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "VECTOR_STORE"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/vectorStoreSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "MEMORY"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/memorySemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "GUARDRAIL"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/guardrailSemantic"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "LOG"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "semantic": {
+            "$ref": "#/$defs/logSemantic"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "traceId": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{32}$"
+    },
+    "spanId": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{16}$"
+    },
+    "uint64String": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)$"
+    },
+    "jsonValue": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        }
+      ]
+    },
+    "spanKind": {
+      "type": "string",
+      "enum": [
+        "WORKFLOW",
+        "AGENT",
+        "CHAIN",
+        "TASK",
+        "LLM",
+        "TOOL",
+        "MCP_TOOL",
+        "RETRIEVER",
+        "RERANKER",
+        "EMBEDDING",
+        "VECTOR_STORE",
+        "MEMORY",
+        "GUARDRAIL",
+        "LOG",
+        "HTTP",
+        "UNKNOWN"
+      ]
+    },
+    "ownership": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner",
+        "provider_generation",
+        "project_key_id",
+        "propagation"
+      ],
+      "properties": {
+        "owner": {
+          "type": "string",
+          "enum": [
+            "neatlogs-sdk",
+            "neatlogs-ingest-adapter",
+            "neatlogs-backend-recovery",
+            "external-otel"
+          ]
+        },
+        "provider_generation": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "project_key_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "propagation": {
+          "type": "string",
+          "enum": [
+            "local-private-context",
+            "explicit-neatlogs-remote",
+            "backend-projection",
+            "external-ingest"
+          ]
+        }
+      }
+    },
+    "wrapper": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "captured",
+        "integration",
+        "integration_version",
+        "capture_fidelity"
+      ],
+      "properties": {
+        "captured": {
+          "type": "boolean"
+        },
+        "integration": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "integration_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "capture_fidelity": {
+          "type": "string",
+          "enum": [
+            "native",
+            "normalized",
+            "flattened",
+            "synthetic-recovery",
+            "unknown"
+          ]
+        }
+      }
+    },
+    "typedValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "value",
+        "media"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "none",
+            "text",
+            "json",
+            "messages",
+            "documents",
+            "media",
+            "binary-reference"
+          ]
+        },
+        "value": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "media": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/mediaReference"
+          }
+        }
+      }
+    },
+    "mediaReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "sha256",
+        "mime_type",
+        "byte_length",
+        "source",
+        "purpose",
+        "state",
+        "safe_preview"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "mime_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "byte_length": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "inline",
+            "url",
+            "file",
+            "provider",
+            "uploaded",
+            "generated"
+          ]
+        },
+        "purpose": {
+          "type": "string",
+          "enum": [
+            "input",
+            "output",
+            "tool-argument",
+            "tool-result",
+            "document",
+            "raw-stream",
+            "overflow"
+          ]
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "inline",
+            "pending-upload",
+            "available",
+            "failed",
+            "expired"
+          ]
+        },
+        "safe_preview": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 4096
+        }
+      }
+    },
+    "status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "source"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "UNSET",
+            "OK",
+            "ERROR"
+          ]
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "application",
+            "provider",
+            "sdk",
+            "backend-recovery",
+            "unknown"
+          ]
+        }
+      }
+    },
+    "error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "message",
+        "stack",
+        "escaped"
+      ],
+      "properties": {
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "stack": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "escaped": {
+          "type": "boolean"
+        }
+      }
+    },
+    "codeLocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "file",
+        "function",
+        "line",
+        "column",
+        "namespace"
+      ],
+      "properties": {
+        "file": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "function": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "line": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "column": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "namespace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "sourceDialect": {
+      "type": "string",
+      "enum": [
+        "native-v2",
+        "neatlogs-direct",
+        "otel-genai",
+        "openinference",
+        "provider-specific",
+        "external-legacy",
+        "unknown-raw"
+      ]
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "source_dialect",
+        "source_key",
+        "precedence",
+        "action"
+      ],
+      "properties": {
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_dialect": {
+          "$ref": "#/$defs/sourceDialect"
+        },
+        "source_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "precedence": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 7
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "accepted",
+            "synthesized",
+            "missing",
+            "ignored-lower-precedence",
+            "retained-raw",
+            "rejected-invalid"
+          ]
+        }
+      }
+    },
+    "conflict": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "winner_source_key",
+        "loser_source_key",
+        "reason_code"
+      ],
+      "properties": {
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "winner_source_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "loser_source_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason_code": {
+          "type": "string",
+          "enum": [
+            "LOWER_PRECEDENCE",
+            "INVALID_TYPE",
+            "INVALID_JSON",
+            "EMPTY_VALUE",
+            "DUPLICATE_SEMANTIC_VALUE",
+            "UNSUPPORTED_SOURCE"
+          ]
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role",
+        "name",
+        "content",
+        "tool_calls",
+        "tool_call_id"
+      ],
+      "properties": {
+        "role": {
+          "type": "string",
+          "enum": [
+            "system",
+            "developer",
+            "user",
+            "assistant",
+            "tool"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/contentPart"
+          }
+        },
+        "tool_calls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolCall"
+          }
+        },
+        "tool_call_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "contentPart": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "text"
+          ],
+          "properties": {
+            "type": {
+              "const": "text"
+            },
+            "text": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "reference"
+          ],
+          "properties": {
+            "type": {
+              "enum": [
+                "image",
+                "audio",
+                "document",
+                "video"
+              ]
+            },
+            "reference": {
+              "$ref": "#/$defs/mediaReference"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "call_id",
+            "value",
+            "is_error"
+          ],
+          "properties": {
+            "type": {
+              "const": "tool_result"
+            },
+            "call_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "value": {
+              "$ref": "#/$defs/jsonValue"
+            },
+            "is_error": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "toolDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name",
+        "description",
+        "schema",
+        "configuration"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "configuration": {
+          "$ref": "#/$defs/jsonValue"
+        }
+      }
+    },
+    "toolCall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "id_origin",
+        "type",
+        "name",
+        "arguments",
+        "choice_index",
+        "tool_index"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id_origin": {
+          "type": "string",
+          "enum": [
+            "neatlogs-direct",
+            "provider",
+            "deterministic-synthetic"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "arguments": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "choice_index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tool_index": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "toolResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "call_id",
+        "value",
+        "is_error",
+        "media"
+      ],
+      "properties": {
+        "call_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "value": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "is_error": {
+          "type": "boolean"
+        },
+        "media": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/mediaReference"
+          }
+        }
+      }
+    },
+    "llmParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "temperature",
+        "top_p",
+        "top_k",
+        "max_output_tokens",
+        "stop",
+        "seed",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "reasoning",
+        "service_tier",
+        "provider_options"
+      ],
+      "properties": {
+        "temperature": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "top_p": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "top_k": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "max_output_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "stop": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "seed": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "frequency_penalty": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "presence_penalty": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "response_format": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "reasoning": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "service_tier": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "provider_options": {
+          "$ref": "#/$defs/jsonValue"
+        }
+      }
+    },
+    "llmRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "model",
+        "operation",
+        "messages",
+        "tools",
+        "parameters"
+      ],
+      "properties": {
+        "provider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation": {
+          "type": "string",
+          "enum": [
+            "chat",
+            "completion",
+            "responses",
+            "generate",
+            "unknown"
+          ]
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/message"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolDefinition"
+          }
+        },
+        "parameters": {
+          "$ref": "#/$defs/llmParameters"
+        }
+      }
+    },
+    "llmChoice": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "choice_index",
+        "message",
+        "finish_reason"
+      ],
+      "properties": {
+        "choice_index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "message": {
+          "$ref": "#/$defs/message"
+        },
+        "finish_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "llmResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "model",
+        "choices",
+        "finish_reasons"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "choices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/llmChoice"
+          }
+        },
+        "finish_reasons": {
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "llmUsage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "reasoning_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "cost_usd"
+      ],
+      "properties": {
+        "input_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "output_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "total_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "reasoning_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "cache_read_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "cache_write_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "cost_usd": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    },
+    "streamEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sequence",
+        "time_unix_nano",
+        "type",
+        "choice_index",
+        "tool_index",
+        "value"
+      ],
+      "properties": {
+        "sequence": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "time_unix_nano": {
+          "$ref": "#/$defs/uint64String"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "output_text.delta",
+            "reasoning.delta",
+            "tool_call.delta",
+            "choice.finish",
+            "usage",
+            "error"
+          ]
+        },
+        "choice_index": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "tool_index": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "value": {
+          "$ref": "#/$defs/jsonValue"
+        }
+      }
+    },
+    "llmStream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "completion_state",
+        "time_to_first_token_ms",
+        "chunk_count",
+        "choice_count",
+        "events",
+        "raw_chunks"
+      ],
+      "properties": {
+        "completion_state": {
+          "type": "string",
+          "description": "How stream consumption terminated. Partial consumer cancellation is never reported as a complete success.",
+          "enum": [
+            "not_streamed",
+            "complete",
+            "consumer_cancelled",
+            "provider_error"
+          ]
+        },
+        "time_to_first_token_ms": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "chunk_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "choice_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/streamEvent"
+          }
+        },
+        "raw_chunks": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/mediaReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "llmSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "request",
+        "response",
+        "usage",
+        "stream"
+      ],
+      "properties": {
+        "kind": {
+          "const": "LLM"
+        },
+        "request": {
+          "$ref": "#/$defs/llmRequest"
+        },
+        "response": {
+          "$ref": "#/$defs/llmResponse"
+        },
+        "usage": {
+          "$ref": "#/$defs/llmUsage"
+        },
+        "stream": {
+          "$ref": "#/$defs/llmStream"
+        }
+      }
+    },
+    "toolSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "definition",
+        "call",
+        "result",
+        "requesting_span_id",
+        "transport"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "TOOL",
+            "MCP_TOOL"
+          ]
+        },
+        "definition": {
+          "$ref": "#/$defs/toolDefinition"
+        },
+        "call": {
+          "$ref": "#/$defs/toolCall"
+        },
+        "result": {
+          "$ref": "#/$defs/toolResult"
+        },
+        "requesting_span_id": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/spanId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "transport": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/mcpTransport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "content",
+        "score",
+        "metadata",
+        "media"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "content": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "score": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "media": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/mediaReference"
+          }
+        }
+      }
+    },
+    "retrieverSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "query",
+        "documents",
+        "top_k",
+        "filters"
+      ],
+      "properties": {
+        "kind": {
+          "const": "RETRIEVER"
+        },
+        "query": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/document"
+          }
+        },
+        "top_k": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "filters": {
+          "$ref": "#/$defs/jsonValue"
+        }
+      }
+    },
+    "rerankerSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "model",
+        "query",
+        "input_documents",
+        "output_documents",
+        "top_n"
+      ],
+      "properties": {
+        "kind": {
+          "const": "RERANKER"
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "query": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "input_documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/document"
+          }
+        },
+        "output_documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/document"
+          }
+        },
+        "top_n": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    },
+    "embeddingSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "provider",
+        "model",
+        "inputs",
+        "vectors",
+        "dimensions",
+        "usage"
+      ],
+      "properties": {
+        "kind": {
+          "const": "EMBEDDING"
+        },
+        "provider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        },
+        "vectors": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "dimensions": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "usage": {
+          "$ref": "#/$defs/llmUsage"
+        }
+      }
+    },
+    "vectorStoreSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "provider",
+        "operation",
+        "collection",
+        "query",
+        "documents"
+      ],
+      "properties": {
+        "kind": {
+          "const": "VECTOR_STORE"
+        },
+        "provider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "collection": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "query": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "documents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/document"
+          }
+        }
+      }
+    },
+    "memorySemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "operation",
+        "memory_id",
+        "scope",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "const": "MEMORY"
+        },
+        "operation": {
+          "type": "string",
+          "enum": [
+            "read",
+            "write",
+            "update",
+            "delete",
+            "search",
+            "unknown"
+          ]
+        },
+        "memory_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scope": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "value": {
+          "$ref": "#/$defs/jsonValue"
+        }
+      }
+    },
+    "guardrailSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "name",
+        "action",
+        "triggered",
+        "score",
+        "reason"
+      ],
+      "properties": {
+        "kind": {
+          "const": "GUARDRAIL"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggered": {
+          "type": "boolean"
+        },
+        "score": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "mcpTransport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "transport",
+        "server",
+        "method",
+        "request_id"
+      ],
+      "properties": {
+        "transport": {
+          "type": "string",
+          "enum": [
+            "stdio",
+            "sse",
+            "streamable-http",
+            "websocket",
+            "unknown"
+          ]
+        },
+        "server": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "request_id": {
+          "type": [
+            "string",
+            "number",
+            "null"
+          ]
+        }
+      }
+    },
+    "logSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "severity_text",
+        "severity_number",
+        "body",
+        "logger_name"
+      ],
+      "properties": {
+        "kind": {
+          "const": "LOG"
+        },
+        "severity_text": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "severity_number": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "body": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "logger_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "operationSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "operation",
+        "role",
+        "metadata",
+        "recovery"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "WORKFLOW",
+            "AGENT",
+            "CHAIN",
+            "TASK",
+            "HTTP",
+            "UNKNOWN"
+          ]
+        },
+        "operation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "role": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/$defs/jsonValue"
+        },
+        "recovery": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/recovery"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "recovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "synthetic",
+        "reason",
+        "recovery_span_id",
+        "genuine_root_span_id",
+        "reconciled"
+      ],
+      "properties": {
+        "synthetic": {
+          "const": true
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recovery_span_id": {
+          "$ref": "#/$defs/spanId"
+        },
+        "genuine_root_span_id": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/spanId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "reconciled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "semantic": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/llmSemantic"
+        },
+        {
+          "$ref": "#/$defs/toolSemantic"
+        },
+        {
+          "$ref": "#/$defs/retrieverSemantic"
+        },
+        {
+          "$ref": "#/$defs/rerankerSemantic"
+        },
+        {
+          "$ref": "#/$defs/embeddingSemantic"
+        },
+        {
+          "$ref": "#/$defs/vectorStoreSemantic"
+        },
+        {
+          "$ref": "#/$defs/memorySemantic"
+        },
+        {
+          "$ref": "#/$defs/guardrailSemantic"
+        },
+        {
+          "$ref": "#/$defs/logSemantic"
+        },
+        {
+          "$ref": "#/$defs/operationSemantic"
+        }
+      ]
+    }
+  },
+  "x-neatlogs-policy": {
+    "contract_version": "2.0.0",
+    "attribute_prefix": "neatlogs.v2",
+    "conflict_precedence": [
+      "native-v2",
+      "neatlogs-direct",
+      "otel-genai",
+      "openinference",
+      "provider-specific",
+      "external-legacy",
+      "unknown-raw"
+    ],
+    "tool_calls": {
+      "assistant_requests_live_in_assistant_message": true,
+      "execution_is_separate_tool_span": true,
+      "id_precedence": [
+        "neatlogs-direct",
+        "provider",
+        "deterministic-synthetic"
+      ],
+      "retain_unlinked_execution": true,
+      "forbid_name_timing_merge": true
+    },
+    "root_finalization": {
+      "launch_sdk_auto_workflow_roots": true,
+      "launch_completion_markers": true,
+      "stale_root_recovery_is_safety_net": true,
+      "recovered_root_status_must_not_be_fabricated_ok": true,
+      "preserve_late_genuine_root_identity": true,
+      "logical_root_only_finalization": "deferred-post-launch"
+    },
+    "launch_scope": {
+      "sdk_transport": "otlp-http-protobuf",
+      "python_openinference_compatibility": "retain-where-active",
+      "sdk_product_apis_excluded": [
+        "datasets",
+        "evaluations",
+        "scoring",
+        "experiments",
+        "new-prompt-apis"
+      ],
+      "new_go_integrations": false,
+      "typescript_edge_entrypoint": false
+    },
+    "compatibility": [
+      {
+        "dialect": "neatlogs-direct",
+        "patterns": [
+          "neatlogs.span.kind",
+          "neatlogs.workflow.*",
+          "neatlogs.agent.*",
+          "neatlogs.llm.*",
+          "neatlogs.tool.*",
+          "neatlogs.retriever.*",
+          "neatlogs.reranker.*",
+          "neatlogs.embedding.*",
+          "neatlogs.vector_store.*",
+          "neatlogs.memory.*",
+          "neatlogs.guardrail.*",
+          "neatlogs.mcp.*",
+          "neatlogs.code.*"
+        ],
+        "launch_state": "accepted"
+      },
+      {
+        "dialect": "otel-genai",
+        "patterns": [
+          "gen_ai.*"
+        ],
+        "launch_state": "accepted-at-normalization-boundary"
+      },
+      {
+        "dialect": "openinference",
+        "patterns": [
+          "openinference.span.kind",
+          "input.value",
+          "input.mime_type",
+          "output.value",
+          "output.mime_type",
+          "llm.*",
+          "tool.*",
+          "retrieval.*",
+          "embedding.*"
+        ],
+        "launch_state": "accepted-for-active-python-integrations"
+      },
+      {
+        "dialect": "provider-specific",
+        "patterns": [
+          "ai.*",
+          "openai.*",
+          "anthropic.*",
+          "aws.bedrock.*",
+          "google_genai.*",
+          "vertex_ai.*"
+        ],
+        "launch_state": "accepted-at-source-adapter"
+      },
+      {
+        "dialect": "external-legacy",
+        "patterns": [
+          "traceloop.*",
+          "openlit.*"
+        ],
+        "launch_state": "accepted-with-provenance"
+      },
+      {
+        "dialect": "unknown-raw",
+        "patterns": [
+          "*"
+        ],
+        "launch_state": "retain-raw-never-overwrite-canonical"
+      }
+    ],
+    "compatibility_removal_gate": {
+      "minimum_releases": 2,
+      "minimum_observation_days": 30,
+      "requires_zero_mapping_hits": true,
+      "requires_source_adapter_migration": true,
+      "requires_golden_fixture_removal_review": true
+    },
+    "deferred_post_launch": [
+      "logical-root-only-finalization",
+      "automatic-root-removal",
+      "completion-marker-removal",
+      "user-defined-export-filter",
+      "runtime-tracing-toggle",
+      "new-go-integrations",
+      "typescript-edge-entrypoint",
+      "sdk-datasets-evaluations-scoring-experiments"
+    ]
+  }
+}

--- a/neatlogs/core/client_registry.py
+++ b/neatlogs/core/client_registry.py
@@ -1,0 +1,23 @@
+"""Thread-safe weak registry of live Neatlogs client pipelines."""
+
+import threading
+import weakref
+from typing import Any
+
+_lock = threading.RLock()
+_clients: weakref.WeakSet[Any] = weakref.WeakSet()
+
+
+def register_client(client: Any) -> None:
+    with _lock:
+        _clients.add(client)
+
+
+def unregister_client(client: Any) -> None:
+    with _lock:
+        _clients.discard(client)
+
+
+def snapshot_clients() -> tuple[Any, ...]:
+    with _lock:
+        return tuple(_clients)

--- a/neatlogs/core/mask.py
+++ b/neatlogs/core/mask.py
@@ -17,10 +17,7 @@ Example::
     neatlogs.init(mask=redact)
 """
 
-import logging
 from typing import Any, Callable, Dict, Optional
-
-logger = logging.getLogger(__name__)
 
 # Module-level registry: str(id(fn)) -> callable
 # Entries are permanent for the lifetime of the callable object; no cleanup needed.
@@ -34,35 +31,11 @@ def register_mask(fn: Callable) -> str:
     return key
 
 
-def apply_mask(
-    span_data: Dict[str, Any],
-    global_mask: Optional[Callable],
-) -> Dict[str, Any]:
-    """Apply the effective mask callable to *span_data*.
-
-    Per-span mask (stored in ``attributes["neatlogs.mask_id"]``) takes
-    precedence over the global mask.  Returns the (possibly modified) dict.
-    """
+def effective_mask(span_data: Dict[str, Any], global_mask: Optional[Callable]):
+    """Return the registered per-span mask, otherwise the global mask."""
     mask_id = (span_data.get("attributes") or {}).get("neatlogs.mask_id")
-    mask_fn: Optional[Callable] = None
-
     if mask_id:
-        mask_fn = _MASK_REGISTRY.get(str(mask_id))
-
-    if mask_fn is None:
-        mask_fn = global_mask
-
-    if mask_fn is None:
-        return span_data
-
-    try:
-        result = mask_fn(span_data)
-        return result if result is not None else span_data
-    except Exception as exc:
-        logger.warning(
-            "[neatlogs] mask callable raised an exception for span '%s': %s — "
-            "original span data will be exported unchanged.",
-            span_data.get("name"),
-            exc,
-        )
-        return span_data
+        registered = _MASK_REGISTRY.get(str(mask_id))
+        if registered is not None:
+            return registered
+    return global_mask

--- a/neatlogs/core/masking_exporter.py
+++ b/neatlogs/core/masking_exporter.py
@@ -181,6 +181,16 @@ class MaskingSpanExporter(SpanExporter):
         if not kept:
             return SpanExportResult.FAILURE if spans else SpanExportResult.SUCCESS
         try:
+            # Doctor observes only the finished post-mask batch. Capture is
+            # bounded, local, and must never affect telemetry delivery.
+            try:
+                from ..doctor_v2 import capture_prepared_spans
+
+                capture_prepared_spans(kept)
+            except Exception:
+                # Do not interpolate exception text: user-defined attribute
+                # containers may include sensitive values in their messages.
+                logger.error("[neatlogs] doctor capture failed safely")
             result = self._inner.export(kept)
         except Exception:
             self.health.fail()

--- a/neatlogs/core/masking_exporter.py
+++ b/neatlogs/core/masking_exporter.py
@@ -6,6 +6,7 @@ import asyncio
 import concurrent.futures
 import copy
 import inspect
+import json
 import logging
 import threading
 from collections.abc import Mapping, Sequence
@@ -21,6 +22,59 @@ from opentelemetry.trace import Link, Status, StatusCode
 from .mask import effective_mask
 
 logger = logging.getLogger(__name__)
+
+_MAX_MASK_VALUE_DEPTH = 32
+
+
+def _prepare_mask_value(value: Any, depth: int = 0):
+    """Detach values and expose JSON-encoded OTel attributes to redactors."""
+    if depth >= _MAX_MASK_VALUE_DEPTH:
+        # Never leak an application-owned mutable reference to user callbacks.
+        # Values beyond the traversal budget stay opaque but detached.
+        return copy.deepcopy(value), ("scalar", None)
+    if isinstance(value, str) and value.lstrip().startswith(("{", "[")):
+        try:
+            prepared, shape = _prepare_mask_value(json.loads(value), depth + 1)
+            return prepared, ("json", shape)
+        except (TypeError, ValueError):
+            pass
+    if isinstance(value, Mapping):
+        prepared, children = {}, {}
+        for key, item in value.items():
+            prepared_item, shape = _prepare_mask_value(item, depth + 1)
+            prepared[key] = prepared_item
+            children[key] = shape
+        return prepared, ("mapping", children)
+    if isinstance(value, list):
+        pairs = [_prepare_mask_value(item, depth + 1) for item in value]
+        return [item for item, _ in pairs], ("list", [shape for _, shape in pairs])
+    if isinstance(value, tuple):
+        pairs = [_prepare_mask_value(item, depth + 1) for item in value]
+        return [item for item, _ in pairs], ("list", [shape for _, shape in pairs])
+    return copy.deepcopy(value), ("scalar", None)
+
+
+def _restore_mask_value(value: Any, shape, depth: int = 0):
+    if depth >= _MAX_MASK_VALUE_DEPTH:
+        return value
+    kind, detail = shape
+    if kind == "json":
+        # A callback may intentionally replace the complete serialized value.
+        # Preserve that public wire-type operation instead of double-encoding it.
+        if isinstance(value, str):
+            return value
+        return json.dumps(_restore_mask_value(value, detail, depth + 1), separators=(",", ":"))
+    if kind == "mapping" and isinstance(value, Mapping):
+        return {
+            key: _restore_mask_value(item, detail.get(key, ("scalar", None)), depth + 1)
+            for key, item in value.items()
+        }
+    if kind == "list" and isinstance(value, (list, tuple)):
+        return [
+            _restore_mask_value(item, detail[index] if index < len(detail) else ("scalar", None), depth + 1)
+            for index, item in enumerate(value)
+        ]
+    return value
 
 
 def _invoke(mask: Callable, snapshot: dict[str, Any], timeout: float):
@@ -38,7 +92,7 @@ class _MaskRunner:
         )
 
     def apply(self, mask: Callable, snapshot: dict[str, Any]) -> dict[str, Any] | None:
-        candidate = copy.deepcopy(snapshot)
+        candidate, shape = _prepare_mask_value(snapshot)
         future = self._executor.submit(_invoke, mask, candidate, self.timeout_seconds)
         try:
             result = future.result(timeout=self.timeout_seconds)
@@ -53,7 +107,15 @@ class _MaskRunner:
         if not isinstance(result, Mapping):
             logger.error("[neatlogs] mask returned non-mapping; telemetry item dropped")
             return None
-        return dict(result)
+        try:
+            restored = _restore_mask_value(result, shape)
+        except (TypeError, ValueError, RecursionError):
+            logger.error("[neatlogs] mask produced unserializable telemetry; item dropped")
+            return None
+        if not isinstance(restored, Mapping):
+            logger.error("[neatlogs] mask produced invalid restored telemetry; item dropped")
+            return None
+        return dict(restored)
 
     def shutdown(self) -> None:
         self._executor.shutdown(wait=False, cancel_futures=True)

--- a/neatlogs/core/masking_exporter.py
+++ b/neatlogs/core/masking_exporter.py
@@ -1,0 +1,274 @@
+"""Fail-closed masking at Neatlogs' final telemetry export boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import copy
+import inspect
+import logging
+import threading
+from collections.abc import Mapping, Sequence
+from typing import Any, Callable
+
+from opentelemetry.sdk._logs import ReadableLogRecord
+from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import Event, ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.trace import Link, Status, StatusCode
+
+from .mask import effective_mask
+
+logger = logging.getLogger(__name__)
+
+
+def _invoke(mask: Callable, snapshot: dict[str, Any], timeout: float):
+    result = mask(snapshot)
+    if inspect.isawaitable(result):
+        return asyncio.run(asyncio.wait_for(result, timeout=timeout))
+    return result
+
+
+class _MaskRunner:
+    def __init__(self, timeout_seconds: float) -> None:
+        self.timeout_seconds = timeout_seconds
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=4, thread_name_prefix="neatlogs-mask"
+        )
+
+    def apply(self, mask: Callable, snapshot: dict[str, Any]) -> dict[str, Any] | None:
+        candidate = copy.deepcopy(snapshot)
+        future = self._executor.submit(_invoke, mask, candidate, self.timeout_seconds)
+        try:
+            result = future.result(timeout=self.timeout_seconds)
+        except Exception as exc:
+            future.cancel()
+            logger.error("[neatlogs] mask failed; telemetry item dropped (%s)", type(exc).__name__)
+            return None
+        # None is an explicit privacy-preserving drop. In-place callbacks must
+        # return their candidate; silently exporting on None is not fail closed.
+        if result is None:
+            return None
+        if not isinstance(result, Mapping):
+            logger.error("[neatlogs] mask returned non-mapping; telemetry item dropped")
+            return None
+        return dict(result)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+
+class _Health:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.failures = 0
+        self.drops = 0
+
+    def fail(self, *, dropped: bool = False) -> None:
+        with self._lock:
+            self.failures += 1
+            if dropped:
+                self.drops += 1
+
+    @property
+    def healthy(self) -> bool:
+        with self._lock:
+            return self.failures == 0
+
+
+def _attrs(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in value.items() if item is not None}
+
+
+def _span_snapshot(span: ReadableSpan) -> dict[str, Any]:
+    return {
+        "signal": "span",
+        "name": span.name,
+        "attributes": dict(span.attributes or {}),
+        "events": [
+            {
+                "name": event.name,
+                "timestamp": event.timestamp,
+                "attributes": dict(event.attributes or {}),
+            }
+            for event in span.events
+        ],
+        "links": [
+            {
+                "trace_id": f"{link.context.trace_id:032x}",
+                "span_id": f"{link.context.span_id:016x}",
+                "attributes": dict(link.attributes or {}),
+            }
+            for link in span.links
+        ],
+        "resource": {"attributes": dict(span.resource.attributes or {})},
+        "status": {"code": span.status.status_code.name, "description": span.status.description},
+    }
+
+
+def _masked_span(span: ReadableSpan, snapshot: Mapping[str, Any]) -> ReadableSpan:
+    events = [
+        Event(
+            str(item.get("name") or "event"),
+            attributes=_attrs(item.get("attributes")),
+            timestamp=item.get("timestamp"),
+        )
+        for item in snapshot.get("events", ())
+        if isinstance(item, Mapping)
+    ]
+    links = [
+        Link(span.links[index].context, attributes=_attrs(item.get("attributes")))
+        for index, item in enumerate(snapshot.get("links", ()))
+        if index < len(span.links) and isinstance(item, Mapping)
+    ]
+    resource_data = snapshot.get("resource")
+    resource_attrs = (
+        _attrs(resource_data.get("attributes")) if isinstance(resource_data, Mapping) else {}
+    )
+    status_data = snapshot.get("status")
+    status = span.status
+    if isinstance(status_data, Mapping):
+        try:
+            code = StatusCode[str(status_data.get("code") or span.status.status_code.name)]
+        except KeyError:
+            code = span.status.status_code
+        status = Status(code, status_data.get("description"))
+    attributes = _attrs(snapshot.get("attributes"))
+    attributes.pop("neatlogs.mask_id", None)
+    return ReadableSpan(
+        name=str(snapshot.get("name") or span.name),
+        context=span.context,
+        parent=span.parent,
+        resource=Resource(resource_attrs, schema_url=span.resource.schema_url),
+        attributes=attributes,
+        events=events,
+        links=links,
+        kind=span.kind,
+        status=status,
+        start_time=span.start_time,
+        end_time=span.end_time,
+        instrumentation_scope=span.instrumentation_scope,
+    )
+
+
+class MaskingSpanExporter(SpanExporter):
+    """Clone and mask spans without exposing the shared ReadableSpan to callbacks."""
+
+    def __init__(
+        self, inner: SpanExporter, mask: Callable | None, timeout_seconds: float = 5.0
+    ) -> None:
+        self._inner = inner
+        self._global_mask = mask
+        self._runner = _MaskRunner(timeout_seconds)
+        self.health = _Health()
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        kept = []
+        for span in spans:
+            snapshot = _span_snapshot(span)
+            mask = effective_mask(snapshot, self._global_mask)
+            if mask is None:
+                kept.append(span)
+                continue
+            masked = self._runner.apply(mask, snapshot)
+            if masked is None:
+                self.health.fail(dropped=True)
+            else:
+                kept.append(_masked_span(span, masked))
+        if not kept:
+            return SpanExportResult.FAILURE if spans else SpanExportResult.SUCCESS
+        try:
+            result = self._inner.export(kept)
+        except Exception:
+            self.health.fail()
+            raise
+        if result is not SpanExportResult.SUCCESS:
+            self.health.fail()
+        return result
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        result = self._inner.force_flush(timeout_millis)
+        return (result is None or bool(result)) and self.health.healthy
+
+    def shutdown(self) -> None:
+        self._runner.shutdown()
+        self._inner.shutdown()
+
+
+def _log_snapshot(item: ReadableLogRecord) -> dict[str, Any]:
+    record = item.log_record
+    return {
+        "signal": "log",
+        "name": item.instrumentation_scope.name if item.instrumentation_scope else "log",
+        "body": record.body,
+        "attributes": dict(record.attributes or {}),
+        "resource": {"attributes": dict(item.resource.attributes or {})},
+        "severity_text": record.severity_text,
+        "event_name": record.event_name,
+    }
+
+
+class MaskingLogExporter(LogRecordExporter):
+    def __init__(
+        self, inner: LogRecordExporter, mask: Callable | None, timeout_seconds: float = 5.0
+    ) -> None:
+        self._inner = inner
+        self._mask = mask
+        self._runner = _MaskRunner(timeout_seconds)
+        self.health = _Health()
+
+    def export(self, batch: Sequence[ReadableLogRecord]) -> LogRecordExportResult:
+        if self._mask is None:
+            try:
+                result = self._inner.export(batch)
+            except Exception:
+                self.health.fail()
+                raise
+            if result is not LogRecordExportResult.SUCCESS:
+                self.health.fail()
+            return result
+        kept = []
+        for item in batch:
+            masked = self._runner.apply(self._mask, _log_snapshot(item))
+            if masked is None:
+                self.health.fail(dropped=True)
+                continue
+            clone = copy.copy(item)
+            record = copy.copy(item.log_record)
+            record.body = masked.get("body")
+            record.attributes = _attrs(masked.get("attributes"))
+            record.severity_text = masked.get("severity_text")
+            record.event_name = masked.get("event_name")
+            object.__setattr__(clone, "log_record", record)
+            resource_data = masked.get("resource")
+            resource_attrs = (
+                _attrs(resource_data.get("attributes"))
+                if isinstance(resource_data, Mapping)
+                else {}
+            )
+            object.__setattr__(
+                clone, "resource", Resource(resource_attrs, schema_url=item.resource.schema_url)
+            )
+            kept.append(clone)
+        if not kept:
+            return LogRecordExportResult.FAILURE if batch else LogRecordExportResult.SUCCESS
+        try:
+            result = self._inner.export(kept)
+        except Exception:
+            self.health.fail()
+            raise
+        if result is not LogRecordExportResult.SUCCESS:
+            self.health.fail()
+        return result
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        method = getattr(self._inner, "force_flush", None)
+        result = method(timeout_millis) if method else True
+        return (result is None or bool(result)) and self.health.healthy
+
+    def shutdown(self) -> None:
+        self._runner.shutdown()
+        self._inner.shutdown()

--- a/neatlogs/core/span_processor.py
+++ b/neatlogs/core/span_processor.py
@@ -18,7 +18,6 @@ from opentelemetry.trace import Status, StatusCode
 
 from .attribute_processor import UnifiedAttributeProcessor
 from .logger import get_logger
-from .mask import apply_mask
 
 logger = get_logger()
 
@@ -398,7 +397,13 @@ class NeatlogsSpanProcessor(SpanProcessor):
                 logger.debug(f"[SpanProcessor.on_end] Span ending: {span.name}")
 
             # 1. Log raw OTel span (before any processing)
-            if self._raw_log_file_handle and not self._raw_log_file_handle.closed:
+            per_span_mask = bool((span.attributes or {}).get("neatlogs.mask_id"))
+            if (
+                not self.mask
+                and not per_span_mask
+                and self._raw_log_file_handle
+                and not self._raw_log_file_handle.closed
+            ):
                 try:
                     self._raw_log_file_handle.write(span.to_json() + "\n")
                     self._raw_log_file_handle.flush()
@@ -554,14 +559,8 @@ class NeatlogsSpanProcessor(SpanProcessor):
             results = self._inject_crewai_task_templates([span_data])
             span_data = results[0] if results else span_data
 
-            # A per-span mask_id (from @span(mask=)/trace(mask=)) takes precedence
-            # over the global init(mask=); mask whenever either exists.
-            mask_id = (span_data.get("attributes") or {}).get("neatlogs.mask_id")
-            has_mask = bool(mask_id) or self.mask is not None
-
-            # Write normalized neatlogs.* keys onto the (still-mutable) OTel span,
-            # then mask the whole surface once so non-idempotent masks (e.g.
-            # translation) aren't applied twice.
+            # Canonicalize first. Masking happens later on a private clone at the
+            # final Neatlogs exporter boundary.
             final_attrs = span_data.get("attributes") or {}
             try:
                 span_attrs = span._attributes
@@ -574,26 +573,16 @@ class NeatlogsSpanProcessor(SpanProcessor):
                         ):
                             span_attrs[_k] = list(_v)
 
-                    if has_mask:
-                        snapshot = {
-                            "name": span_data.get("name"),
-                            "attributes": dict(span_attrs),
-                        }
-                        masked = apply_mask(snapshot, self.mask)
-                        masked_attrs = (masked or snapshot).get("attributes") or {}
-                        for _k in list(span_attrs.keys()):
-                            if _k in masked_attrs and masked_attrs[_k] != span_attrs[_k]:
-                                span_attrs[_k] = masked_attrs[_k]
-                        # Mirror masked values so the file log reuses them.
-                        for _k in list(final_attrs.keys()):
-                            if _k in masked_attrs:
-                                final_attrs[_k] = masked_attrs[_k]
-                        span_data["attributes"] = final_attrs
             except Exception as _wb_exc:
                 if self.debug:
                     logger.debug(f"[SpanProcessor] Attr write-back failed: {_wb_exc}")
 
-            if self._processed_log_file_handle and not self._processed_log_file_handle.closed:
+            if (
+                not self.mask
+                and not per_span_mask
+                and self._processed_log_file_handle
+                and not self._processed_log_file_handle.closed
+            ):
                 try:
                     self._processed_log_file_handle.write(json.dumps(span_data) + "\n")
                     self._processed_log_file_handle.flush()

--- a/neatlogs/decorators/_base.py
+++ b/neatlogs/decorators/_base.py
@@ -4,10 +4,10 @@ Decorator primitives for Neatlogs custom orchestration spans.
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import inspect
 import json
-import os
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, Union
 
@@ -15,13 +15,6 @@ from opentelemetry import trace as otel_trace
 from opentelemetry.trace import Status, StatusCode
 
 F = TypeVar("F", bound=Callable[..., Any])
-
-
-def _should_capture_content() -> bool:
-    v = os.getenv("NEATLOGS_TRACE_CONTENT")
-    if v is None:
-        return True
-    return v.lower() not in ("false", "0", "no")
 
 
 def _capture_code_attrs(func: Callable[..., Any]) -> Dict[str, Any]:
@@ -202,9 +195,10 @@ def _decorate_span(
 
         span_name = name or func.__name__
 
-        cap = _should_capture_content()
-        cap_in = cap if capture_input is None else capture_input
-        cap_out = cap if capture_output is None else capture_output
+        # Capture defaults are explicit SDK behavior. Privacy-sensitive callers
+        # can disable either side per span, or mask at the export boundary.
+        cap_in = True if capture_input is None else capture_input
+        cap_out = True if capture_output is None else capture_output
 
         # Capture code location once at decoration time — these are static
         # properties of the decorated function so there is no per-call overhead.
@@ -212,6 +206,116 @@ def _decorate_span(
         # that users can override auto-captured values if needed.
         code_attrs = _capture_code_attrs(func)
         merged_attrs = {**code_attrs, **(attributes or {})}
+
+        def _prepare_stream(span, args, kwargs, is_root):
+            from ..core.end_user import apply_end_user_attributes
+            from ..core.mask import register_mask
+            from ..core.session import apply_session_attributes
+
+            _set_common_span_attrs(
+                span,
+                openinference_kind=openinference_kind,
+                name=span_name,
+                version=version,
+                tags=tags,
+                metadata=metadata,
+                attributes=merged_attrs,
+            )
+            apply_session_attributes(span, session_id, is_root=is_root)
+            apply_end_user_attributes(span, end_user_id, end_user_metadata, is_root=is_root)
+            if mask is not None:
+                span.set_attribute("neatlogs.mask_id", register_mask(mask))
+            if description:
+                span.set_attribute("neatlogs.description", description)
+            bound = _bind_call_args(func, args, kwargs)
+            if cap_in:
+                span.set_attribute("input.value", _safe_json_dumps(bound))
+                span.set_attribute("input.mime_type", "application/json")
+            span.set_attribute("neatlogs.stream.completion_state", "not_streamed")
+            return bound
+
+        def _capture_chunk(span, chunks, captured_chars, chunk, index):
+            encoded = _safe_json_dumps(chunk)
+            span.add_event(
+                "neatlogs.stream.chunk",
+                {
+                    "neatlogs.stream.chunk.index": index,
+                    "neatlogs.stream.chunk.value": encoded[:100_000],
+                    "neatlogs.stream.chunk.mime_type": "application/json",
+                },
+            )
+            if captured_chars + len(encoded) <= 100_000:
+                chunks.append(chunk)
+                return captured_chars + len(encoded)
+            span.set_attribute("neatlogs.stream.output_truncated", True)
+            return captured_chars
+
+        def _finish_stream(span, chunks, bound, state, chunk_count, error=None):
+            span.set_attribute("neatlogs.stream.completion_state", state)
+            span.set_attribute("neatlogs.stream.chunk_count", chunk_count)
+            if postprocess_result is not None:
+                try:
+                    postprocess_result(span, chunks, bound)
+                except Exception:
+                    pass
+            if cap_out:
+                span.set_attribute("output.value", _safe_json_dumps(chunks)[:100_000])
+                span.set_attribute("output.mime_type", "application/json")
+            if error is not None:
+                span.record_exception(error)
+                span.set_status(Status(StatusCode.ERROR, str(error)))
+            elif state == "complete":
+                span.set_status(Status(StatusCode.OK))
+
+        if inspect.isasyncgenfunction(func):
+
+            @functools.wraps(func)
+            async def async_generator_wrapper(*args: Any, **kwargs: Any):
+                is_root = _is_root_span()
+                with neatlogs_span(__name__, span_name, kind=otel_trace.SpanKind.INTERNAL) as span:
+                    bound = _prepare_stream(span, args, kwargs, is_root)
+                    chunks, captured_chars, chunk_count = [], 0, 0
+                    try:
+                        async for chunk in func(*args, **kwargs):
+                            captured_chars = _capture_chunk(
+                                span, chunks, captured_chars, chunk, chunk_count
+                            )
+                            chunk_count += 1
+                            yield chunk
+                        _finish_stream(span, chunks, bound, "complete", chunk_count)
+                    except (GeneratorExit, asyncio.CancelledError):
+                        _finish_stream(span, chunks, bound, "consumer_cancelled", chunk_count)
+                        raise
+                    except BaseException as exc:
+                        _finish_stream(span, chunks, bound, "provider_error", chunk_count, exc)
+                        raise
+
+            return async_generator_wrapper
+
+        if inspect.isgeneratorfunction(func):
+
+            @functools.wraps(func)
+            def generator_wrapper(*args: Any, **kwargs: Any):
+                is_root = _is_root_span()
+                with neatlogs_span(__name__, span_name, kind=otel_trace.SpanKind.INTERNAL) as span:
+                    bound = _prepare_stream(span, args, kwargs, is_root)
+                    chunks, captured_chars, chunk_count = [], 0, 0
+                    try:
+                        for chunk in func(*args, **kwargs):
+                            captured_chars = _capture_chunk(
+                                span, chunks, captured_chars, chunk, chunk_count
+                            )
+                            chunk_count += 1
+                            yield chunk
+                        _finish_stream(span, chunks, bound, "complete", chunk_count)
+                    except GeneratorExit:
+                        _finish_stream(span, chunks, bound, "consumer_cancelled", chunk_count)
+                        raise
+                    except BaseException as exc:
+                        _finish_stream(span, chunks, bound, "provider_error", chunk_count, exc)
+                        raise
+
+            return generator_wrapper
 
         if inspect.iscoroutinefunction(func):
 

--- a/neatlogs/doctor.py
+++ b/neatlogs/doctor.py
@@ -1,0 +1,384 @@
+"""Read-only, network-free SDK readiness diagnostics."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import math
+import os
+import platform
+import sys
+from dataclasses import asdict, dataclass, field
+from importlib import metadata
+from typing import Any, Literal
+from urllib.parse import urlparse
+
+from opentelemetry import trace as otel_trace
+
+from .schema_v2 import (
+    TELEMETRY_CONTRACT_VERSION,
+    TELEMETRY_SCHEMA_SHA256,
+    verify_telemetry_schema,
+)
+from .version import __version__
+
+DOCTOR_FORMAT_VERSION = "neatlogs.doctor/v1"
+DoctorStatus = Literal["pass", "warn", "fail", "unknown"]
+
+
+@dataclass(frozen=True)
+class DoctorCheck:
+    """One stable diagnostic whose bounded message never contains secrets."""
+
+    name: str
+    status: DoctorStatus
+    reason_code: str
+    message: str
+    details: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        if not self.details:
+            value.pop("details")
+        return value
+
+
+@dataclass(frozen=True)
+class DoctorResult:
+    """Versioned local-readiness result shared with other Neatlogs SDKs."""
+
+    format_version: str
+    sdk_version: str
+    ready: bool
+    checks: tuple[DoctorCheck, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "format_version": self.format_version,
+            "sdk_version": self.sdk_version,
+            "ready": self.ready,
+            "checks": [check.to_dict() for check in self.checks],
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+
+def _check(
+    name: str,
+    status: DoctorStatus,
+    reason_code: str,
+    message: str,
+    details: dict[str, str] | None = None,
+) -> DoctorCheck:
+    return DoctorCheck(name, status, reason_code, message, details or {})
+
+
+def _runtime_check() -> DoctorCheck:
+    version = platform.python_version()
+    supported = (3, 10) <= sys.version_info[:2] < (3, 14)
+    return _check(
+        "runtime",
+        "pass" if supported else "fail",
+        "PYTHON_RUNTIME_SUPPORTED" if supported else "PYTHON_RUNTIME_UNSUPPORTED",
+        "Python runtime is supported" if supported else "Python 3.10 through 3.13 is required",
+        {"version": version},
+    )
+
+
+def _package_check() -> DoctorCheck:
+    try:
+        installed = metadata.version("neatlogs")
+    except metadata.PackageNotFoundError:
+        return _check(
+            "package",
+            "warn",
+            "PACKAGE_METADATA_UNAVAILABLE",
+            "Installed Neatlogs package metadata is unavailable",
+        )
+    if installed != __version__:
+        return _check(
+            "package",
+            "fail",
+            "PACKAGE_VERSION_MISMATCH",
+            "Imported and installed Neatlogs versions do not match",
+            {"imported_version": __version__, "installed_version": installed},
+        )
+    return _check(
+        "package",
+        "pass",
+        "PACKAGE_METADATA_PRESENT",
+        "Neatlogs package metadata is present",
+        {"version": installed},
+    )
+
+
+def _schema_check() -> DoctorCheck:
+    try:
+        verify_telemetry_schema()
+    except Exception:
+        return _check(
+            "schema",
+            "fail",
+            "SCHEMA_V2_INVALID",
+            "Packaged telemetry schema or manifest failed validation",
+        )
+    return _check(
+        "schema",
+        "pass",
+        "SCHEMA_V2_HASH_VALID",
+        "Packaged telemetry schema v2 hash is valid",
+        {
+            "contract_version": TELEMETRY_CONTRACT_VERSION,
+            "schema_sha256": TELEMETRY_SCHEMA_SHA256,
+        },
+    )
+
+
+def _transport_check() -> DoctorCheck:
+    return _check(
+        "transport",
+        "pass",
+        "TRANSPORT_OTLP_HTTP_PROTOBUF",
+        "SDK transport is OTLP HTTP/protobuf",
+        {"path": "/v1/traces"},
+    )
+
+
+def _endpoint_check(endpoint: str | None) -> DoctorCheck:
+    raw = (endpoint if endpoint is not None else os.getenv("NEATLOGS_ENDPOINT", "")).strip()
+    raw = raw or "https://ingest.neatlogs.com"
+    try:
+        parsed = urlparse(raw)
+        valid_origin = (
+            parsed.scheme in {"http", "https"}
+            and bool(parsed.netloc)
+            and parsed.username is None
+            and parsed.password is None
+            and not parsed.query
+            and not parsed.fragment
+        )
+    except (TypeError, ValueError):
+        valid_origin = False
+        parsed = None
+    if not valid_origin or parsed is None:
+        return _check(
+            "endpoint",
+            "fail",
+            "ENDPOINT_INVALID",
+            "Endpoint must be HTTP(S) without credentials, query, or fragment",
+        )
+    if parsed.path.rstrip("/") not in {"", "/v1/traces"}:
+        return _check(
+            "endpoint",
+            "fail",
+            "ENDPOINT_PATH_UNSUPPORTED",
+            "Endpoint must be an origin or end in /v1/traces",
+            {"scheme": parsed.scheme, "host": parsed.netloc},
+        )
+    return _check(
+        "endpoint",
+        "pass",
+        "ENDPOINT_VALID",
+        "Endpoint is valid",
+        {"scheme": parsed.scheme, "host": parsed.netloc},
+    )
+
+
+def _sampler_check(sample_rate: float) -> DoctorCheck:
+    valid = (
+        not isinstance(sample_rate, bool)
+        and isinstance(sample_rate, (int, float))
+        and math.isfinite(float(sample_rate))
+        and 0.0 <= float(sample_rate) <= 1.0
+    )
+    if not valid:
+        return _check(
+            "sampler",
+            "fail",
+            "SAMPLER_INVALID",
+            "Sample rate must be finite and between 0 and 1",
+        )
+    return _check(
+        "sampler",
+        "pass",
+        "SAMPLER_PARENT_BASED_VALID",
+        "ParentBased trace sampling is valid",
+        {"root_sample_rate": format(float(sample_rate), "g")},
+    )
+
+
+def _selected_runtime(client: Any | None) -> tuple[Any | None, Any | None, list[Any]]:
+    from ._wrap_utils import get_active_client
+
+    active = client or get_active_client()
+    if active is not None:
+        return (
+            active.tracer_provider,
+            active._span_processor,
+            list(active._exporters + active._log_exporters),
+        )
+    state = importlib.import_module("neatlogs.init")
+    if not state._initialized:
+        return None, None, []
+    return state._tracer_provider, state._span_processor, list(state._export_health)
+
+
+def _ownership_check(provider: Any | None) -> DoctorCheck:
+    if provider is None:
+        return _check(
+            "ownership",
+            "pass",
+            "OTEL_PROVIDER_PRIVATE",
+            "Neatlogs creates or requires a private provider and leaves global OpenTelemetry state untouched",
+        )
+    if provider is otel_trace.get_tracer_provider():
+        return _check(
+            "ownership",
+            "fail",
+            "OTEL_PROVIDER_NOT_PRIVATE",
+            "Selected Neatlogs provider unexpectedly matches the process-global provider",
+        )
+    return _check(
+        "ownership",
+        "pass",
+        "OTEL_PROVIDER_PRIVATE",
+        "Selected Neatlogs provider is private",
+    )
+
+
+def _queue_check(
+    disable_export: bool | None, exporters: list[Any], provider: Any | None
+) -> DoctorCheck:
+    disabled = (
+        disable_export if disable_export is not None else provider is not None and not exporters
+    )
+    if disabled:
+        return _check(
+            "queue",
+            "warn",
+            "EXPORT_QUEUE_DISABLED",
+            "Export is disabled, so no batch queue is active",
+        )
+    return _check(
+        "queue",
+        "pass",
+        "EXPORT_QUEUE_BATCHED",
+        "Export uses the OpenTelemetry batch span processor",
+    )
+
+
+def _export_health_check(provider: Any | None, exporters: list[Any]) -> DoctorCheck:
+    if provider is None:
+        return _check(
+            "export_health",
+            "unknown",
+            "EXPORT_HEALTH_UNOBSERVABLE",
+            "No running Neatlogs runtime is selected",
+        )
+    failures = sum(int(getattr(item.health, "failures", 0)) for item in exporters)
+    drops = sum(int(getattr(item.health, "drops", 0)) for item in exporters)
+    details = {"dropped_spans": str(drops), "export_failures": str(failures)}
+    if failures or drops:
+        return _check(
+            "export_health",
+            "fail",
+            "EXPORT_HEALTH_UNHEALTHY",
+            "The selected runtime has masking drops or exporter failures",
+            details,
+        )
+    return _check(
+        "export_health",
+        "pass",
+        "EXPORT_HEALTHY",
+        "The selected runtime has no observed export failures or drops",
+        details,
+    )
+
+
+def _root_check(provider: Any | None, processor: Any | None) -> DoctorCheck:
+    if provider is None or processor is None:
+        return _check(
+            "root", "unknown", "ROOT_UNOBSERVABLE", "No running Neatlogs runtime is selected"
+        )
+    from ._wrap_utils import _current_neatlogs_parent
+
+    current = _current_neatlogs_parent() or otel_trace.get_current_span()
+    context = current.get_span_context()
+    if not context.is_valid:
+        return _check(
+            "root",
+            "unknown",
+            "ROOT_NOT_ACTIVE",
+            "Context does not carry an active root owned by the selected runtime",
+        )
+    with processor._active_spans_lock:
+        active = dict(processor._active_spans)
+    span = active.get(context.span_id)
+    if span is None:
+        return _check(
+            "root",
+            "unknown",
+            "ROOT_NOT_ACTIVE",
+            "Context does not carry an active root owned by the selected runtime",
+        )
+    seen: set[int] = set()
+    while span.parent is not None and span.parent.span_id in active:
+        if span.context.span_id in seen:
+            return _check(
+                "root",
+                "fail",
+                "ROOT_OWNERSHIP_INVALID",
+                "Owned context does not resolve to one active root",
+            )
+        seen.add(span.context.span_id)
+        span = active[span.parent.span_id]
+    root = span.get_span_context()
+    if not root.is_valid:
+        return _check(
+            "root",
+            "fail",
+            "ROOT_OWNERSHIP_INVALID",
+            "Owned context does not resolve to one valid root",
+        )
+    return _check(
+        "root",
+        "pass",
+        "ROOT_IDS_VALID",
+        "Active owned root has valid trace and span IDs",
+        {"trace_id": f"{root.trace_id:032x}", "span_id": f"{root.span_id:016x}"},
+    )
+
+
+def doctor(
+    *,
+    endpoint: str | None = None,
+    sample_rate: float = 1.0,
+    disable_export: bool | None = None,
+    client: Any | None = None,
+) -> DoctorResult:
+    """Inspect local configuration and observable runtime health without mutation.
+
+    This function never initializes, flushes, shuts down, exports, or performs a
+    network request. Credential values are neither accepted nor returned.
+    """
+
+    provider, processor, exporters = _selected_runtime(client)
+    checks = (
+        _runtime_check(),
+        _package_check(),
+        _schema_check(),
+        _transport_check(),
+        _endpoint_check(endpoint),
+        _sampler_check(sample_rate),
+        _ownership_check(provider),
+        _queue_check(disable_export, exporters, provider),
+        _export_health_check(provider, exporters),
+        _root_check(provider, processor),
+    )
+    return DoctorResult(
+        format_version=DOCTOR_FORMAT_VERSION,
+        sdk_version=__version__,
+        ready=not any(check.status == "fail" for check in checks),
+        checks=checks,
+    )

--- a/neatlogs/doctor_v2.py
+++ b/neatlogs/doctor_v2.py
@@ -32,6 +32,8 @@ _latest_trace_id: str | None = None
 
 _REMEDIATION = {
     "CREDENTIAL_MISSING": "SET_CREDENTIAL",
+    "AUTH_FAILED": "CHECK_INGEST_CREDENTIAL",
+    "BACKEND_PROBE_UNAVAILABLE": "CHECK_DIAGNOSTIC_ENDPOINT",
     "PROVIDER_OWNERSHIP_AMBIGUOUS": "USE_PRIVATE_PROVIDER",
     "TRACE_ID_INVALID": "RECREATE_TRACE",
     "SPAN_ID_INVALID": "RECREATE_SPAN",
@@ -587,7 +589,14 @@ def doctor_probe_v2(
     session_id = None
     try:
         created_response = requests.post(
-            url, headers=headers, json={}, timeout=min(5.0, timeout_seconds)
+            url,
+            headers=headers,
+            json={
+                "envelope_digest": capture["semantic_digest"],
+                "fixture_version": "doctor-v2",
+                "trace_id": capture["trace_id"],
+            },
+            timeout=min(5.0, timeout_seconds),
         )
         created_response.raise_for_status()
         created = created_response.json()
@@ -683,12 +692,19 @@ def doctor_probe_v2(
             },
             "checks": [check],
         }
-    except (requests.RequestException, ValueError, TypeError, json.JSONDecodeError):
+    except (requests.RequestException, ValueError, TypeError, json.JSONDecodeError) as exc:
+        response = getattr(exc, "response", None)
+        response_status = getattr(response, "status_code", None)
+        reason_code = (
+            "AUTH_FAILED"
+            if response_status in {401, 403}
+            else "BACKEND_PROBE_UNAVAILABLE"
+        )
         return {
             "format_version": DOCTOR_V2_FORMAT_VERSION,
             "mode": "probe",
             "status": "fail",
-            "first_failure": "DIAGNOSTIC_NOT_VISIBLE",
+            "first_failure": reason_code,
             "runtime": {
                 "language": "python",
                 "sdk_version": __version__,
@@ -700,8 +716,12 @@ def doctor_probe_v2(
                 _check(
                     "probe",
                     "fail",
-                    "DIAGNOSTIC_NOT_VISIBLE",
-                    "The backend diagnostic session is unavailable",
+                    reason_code,
+                    (
+                        "The authenticated diagnostic session was rejected"
+                        if reason_code == "AUTH_FAILED"
+                        else "The backend diagnostic session is unavailable"
+                    ),
                 )
             ],
         }

--- a/neatlogs/doctor_v2.py
+++ b/neatlogs/doctor_v2.py
@@ -1,0 +1,717 @@
+"""Doctor v2 envelope capture, validation, and backend receipt probing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+from urllib.parse import urljoin, urlparse
+
+import requests
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import StatusCode, TraceFlags
+
+from .schema_v2 import TELEMETRY_SCHEMA_VERSION
+from .version import __version__
+
+DOCTOR_V2_FORMAT_VERSION = "neatlogs.doctor/v2"
+_TRACE_ID = re.compile(r"^[0-9a-f]{32}$")
+_SPAN_ID = re.compile(r"^[0-9a-f]{16}$")
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_MAX_CAPTURED_TRACES = 16
+_capture_lock = threading.RLock()
+_captures: OrderedDict[str, dict[str, dict[str, Any]]] = OrderedDict()
+_latest_trace_id: str | None = None
+
+_REMEDIATION = {
+    "CREDENTIAL_MISSING": "SET_CREDENTIAL",
+    "PROVIDER_OWNERSHIP_AMBIGUOUS": "USE_PRIVATE_PROVIDER",
+    "TRACE_ID_INVALID": "RECREATE_TRACE",
+    "SPAN_ID_INVALID": "RECREATE_SPAN",
+    "SPAN_ID_DUPLICATE": "RECREATE_SPAN",
+    "PARENT_ID_INVALID": "FIX_PARENT_CONTEXT",
+    "PARENT_MISSING": "FIX_PARENT_CONTEXT",
+    "ROOT_MISSING": "CREATE_ROOT_SPAN",
+    "ROOT_MULTIPLE": "USE_SINGLE_ROOT",
+    "ROOT_NOT_ENDED": "END_ROOT_SPAN",
+    "INPUT_JSON_INVALID": "SERIALIZE_INPUT_JSON",
+    "OUTPUT_JSON_INVALID": "SERIALIZE_OUTPUT_JSON",
+    "TOOL_CALL_MISSING": "CAPTURE_TOOL_REQUEST",
+    "TOOL_EXECUTION_MISSING": "CAPTURE_TOOL_EXECUTION",
+    "CHOICE_LOSS": "PRESERVE_ALL_CHOICES",
+    "STREAM_FRAGMENT_MISSING": "PRESERVE_STREAM_FRAGMENTS",
+    "PAYLOAD_ATTACHMENT_REQUIRED": "UPLOAD_PAYLOAD_ATTACHMENT",
+    "SAMPLING_INCONSISTENT": "FIX_PARENT_BASED_SAMPLING",
+    "QUEUE_SATURATED": "INCREASE_OR_DRAIN_QUEUE",
+    "EXPORT_RETRY_EXHAUSTED": "CHECK_TRANSPORT",
+    "FLUSH_TIMEOUT": "INCREASE_FLUSH_BUDGET",
+    "MASKING_FAILED_CLOSED": "FIX_MASK_CALLBACK",
+    "LOCAL_ENVELOPE_VALID": "NONE",
+    "STAGE_PENDING": "WAIT_FOR_RECEIPT",
+    "DIAGNOSTIC_EXPIRED": "CREATE_NEW_SESSION",
+    "DIAGNOSTIC_NOT_VISIBLE": "CONTACT_SUPPORT",
+    "DIGEST_MISMATCH": "CONTACT_SUPPORT",
+}
+
+
+def _json_value(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text or text[0] not in "[{":
+        return value
+    try:
+        return json.loads(text)
+    except (TypeError, ValueError):
+        return value
+
+
+def _first(attributes: Mapping[str, Any], keys: Sequence[str]) -> Any:
+    for key in keys:
+        if key in attributes:
+            return _json_value(attributes[key])
+    return None
+
+
+def _tool_calls(attributes: Mapping[str, Any]) -> list[dict[str, str]] | None:
+    value = _first(attributes, ("gen_ai.assistant.tool_calls", "neatlogs.llm.tool_calls"))
+    if isinstance(value, list):
+        calls = [
+            {key: item[key] for key in ("id", "name") if isinstance(item.get(key), str)}
+            for item in value
+            if isinstance(item, dict) and isinstance(item.get("id"), str)
+        ]
+        return calls or None
+    exploded: dict[int, dict[str, str]] = {}
+    for key, item in attributes.items():
+        match = re.match(r"^(?:neatlogs\.)?llm\.tool_calls\.(\d+)\.(id|name)$", key)
+        if match and isinstance(item, str):
+            exploded.setdefault(int(match.group(1)), {})[match.group(2)] = item
+    calls = [exploded[index] for index in sorted(exploded) if "id" in exploded[index]]
+    return calls or None
+
+
+def _diagnostic_span(span: ReadableSpan) -> dict[str, Any]:
+    context = span.get_span_context()
+    attributes = dict(span.attributes or {})
+    kind_value = attributes.get("neatlogs.span.kind", attributes.get("openinference.span.kind"))
+    kind = str(kind_value or "INTERNAL").removeprefix("Neatlogs.").upper()
+    parent = span.parent
+    output: dict[str, Any] = {
+        "span_id": f"{context.span_id:016x}",
+        "parent_span_id": f"{parent.span_id:016x}" if parent and parent.is_valid else None,
+        "name": span.name,
+        "kind": kind,
+        "status": (
+            "ERROR"
+            if span.status.status_code is StatusCode.ERROR
+            else "OK" if span.status.status_code is StatusCode.OK else "UNSET"
+        ),
+        "sampled": bool(context.trace_flags & TraceFlags.SAMPLED),
+        "ended": span.end_time is not None,
+        "start_time_ns": span.start_time,
+        "duration_ns": max(0, (span.end_time or span.start_time) - span.start_time),
+        "attributes": attributes,
+    }
+    fields = {
+        "input": _first(
+            attributes,
+            ("gen_ai.input.messages", "input.value", "neatlogs.input", "neatlogs.llm.input"),
+        ),
+        "output": _first(
+            attributes,
+            ("gen_ai.output.messages", "output.value", "neatlogs.output", "neatlogs.llm.output"),
+        ),
+        "choices": _first(attributes, ("gen_ai.response.choices", "neatlogs.llm.choices")),
+        "stream_fragments": _first(
+            attributes, ("gen_ai.stream.fragments", "neatlogs.stream.fragments")
+        ),
+    }
+    for key, value in fields.items():
+        if value is not None:
+            output[key] = value
+    calls = _tool_calls(attributes)
+    if calls:
+        output["tool_calls"] = calls
+    call_id = _first(attributes, ("neatlogs.tool.call_id", "neatlogs.tool_call.id", "tool_call_id"))
+    if kind == "TOOL" and isinstance(call_id, str):
+        output["tool_call"] = {"id": call_id}
+        if isinstance(attributes.get("neatlogs.tool.name"), str):
+            output["tool_call"]["name"] = attributes["neatlogs.tool.name"]
+    streaming = bool(
+        attributes.get("neatlogs.llm.is_streaming")
+        or attributes.get("neatlogs.tool.is_streaming")
+        or "stream_fragments" in output
+    )
+    if streaming:
+        output["streaming"] = True
+    return output
+
+
+def capture_prepared_spans(spans: Sequence[ReadableSpan]) -> None:
+    """Capture the final masked spans immediately before the network exporter."""
+
+    global _latest_trace_id
+    with _capture_lock:
+        for span in spans:
+            trace_id = f"{span.get_span_context().trace_id:032x}"
+            current = _captures.pop(trace_id, {})
+            item = _diagnostic_span(span)
+            current[item["span_id"]] = item
+            _captures[trace_id] = current
+            _latest_trace_id = trace_id
+        while len(_captures) > _MAX_CAPTURED_TRACES:
+            _captures.popitem(last=False)
+
+
+def clear_doctor_capture() -> None:
+    global _latest_trace_id
+    with _capture_lock:
+        _captures.clear()
+        _latest_trace_id = None
+
+
+def get_captured_envelope(trace_id: str | None = None) -> dict[str, Any] | None:
+    with _capture_lock:
+        selected = trace_id or _latest_trace_id
+        spans = list(_captures.get(selected or "", {}).values())
+        if not selected or not spans:
+            return None
+        roots = [span for span in spans if span["parent_span_id"] is None]
+        if not roots:
+            return None
+        return {"trace_id": selected, "root_span_id": roots[0]["span_id"], "spans": spans}
+
+
+def _canonical(value: Any) -> Any:
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("diagnostic envelope contains a non-finite number")
+        return 0 if value == 0 else value
+    if isinstance(value, Mapping):
+        return {str(key): _canonical(item) for key, item in sorted(value.items())}
+    if isinstance(value, (list, tuple)):
+        return [_canonical(item) for item in value]
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    raise TypeError("diagnostic envelope contains a non-JSON value")
+
+
+def doctor_semantic_digest(envelope: Mapping[str, Any]) -> str:
+    projection = {
+        "trace_id": envelope["trace_id"],
+        "root_span_id": envelope["root_span_id"],
+        "spans": sorted(envelope["spans"], key=lambda span: span["span_id"].lower()),
+    }
+    encoded = json.dumps(
+        _canonical(projection),
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _check(name: str, status: str, reason: str, message: str, details=None) -> dict[str, Any]:
+    return {
+        "name": name,
+        "status": status,
+        "reason_code": reason,
+        "message": message,
+        "remediation_code": _REMEDIATION.get(reason, "CONTACT_SUPPORT"),
+        **({"details": details} if details else {}),
+    }
+
+
+def doctor_local_v2(
+    envelope: Mapping[str, Any],
+    *,
+    flush_outcome: str = "success",
+    flush_timeout_ms: int = 5000,
+    flush_duration_ms: int | None = None,
+    private_provider: bool = True,
+    sample_rate: float = 1.0,
+    queue_capacity: int = 2048,
+    dropped_spans: int = 0,
+) -> dict[str, Any]:
+    """Validate one final normalized and masked export envelope."""
+
+    checks: list[dict[str, Any]] = []
+    trace_id = envelope.get("trace_id")
+    root_id = envelope.get("root_span_id")
+    spans = list(envelope.get("spans") or [])
+    if not isinstance(trace_id, str) or not _TRACE_ID.fullmatch(trace_id):
+        checks.append(
+            _check(
+                "trace_id",
+                "fail",
+                "TRACE_ID_INVALID",
+                "Trace ID must be 32 lowercase hexadecimal characters",
+            )
+        )
+    ids: set[str] = set()
+    for span in spans:
+        span_id = span.get("span_id")
+        if not isinstance(span_id, str) or not _SPAN_ID.fullmatch(span_id):
+            checks.append(
+                _check(
+                    "span_id",
+                    "fail",
+                    "SPAN_ID_INVALID",
+                    "Span ID must be 16 lowercase hexadecimal characters",
+                )
+            )
+        elif span_id in ids:
+            checks.append(
+                _check(
+                    "span_id",
+                    "fail",
+                    "SPAN_ID_DUPLICATE",
+                    "Span IDs must be unique",
+                    {"span_id": span_id},
+                )
+            )
+        ids.add(span_id)
+    roots = [span for span in spans if span.get("parent_span_id") is None]
+    if not roots or root_id not in ids:
+        checks.append(
+            _check("root", "fail", "ROOT_MISSING", "Exactly one declared root span is required")
+        )
+    elif len(roots) != 1 or roots[0].get("span_id") != root_id:
+        checks.append(
+            _check(
+                "root", "fail", "ROOT_MULTIPLE", "The envelope must contain one declared root span"
+            )
+        )
+    elif roots[0].get("ended") is not True:
+        checks.append(
+            _check("root", "fail", "ROOT_NOT_ENDED", "The root span must be ended before capture")
+        )
+    for span in spans:
+        span_id = span.get("span_id")
+        parent = span.get("parent_span_id")
+        if parent is not None and (not isinstance(parent, str) or not _SPAN_ID.fullmatch(parent)):
+            checks.append(
+                _check(
+                    "parent",
+                    "fail",
+                    "PARENT_ID_INVALID",
+                    "Parent ID must be a valid span ID",
+                    {"span_id": span_id},
+                )
+            )
+        elif parent is not None and parent not in ids:
+            checks.append(
+                _check(
+                    "parent",
+                    "fail",
+                    "PARENT_MISSING",
+                    "Parent span is absent from the envelope",
+                    {"span_id": span_id},
+                )
+            )
+        for field, reason in (("input", "INPUT_JSON_INVALID"), ("output", "OUTPUT_JSON_INVALID")):
+            if field in span:
+                try:
+                    _canonical(span[field])
+                except (TypeError, ValueError):
+                    checks.append(
+                        _check(
+                            field,
+                            "fail",
+                            reason,
+                            f"Span {field} is not canonical JSON",
+                            {"span_id": span_id},
+                        )
+                    )
+        if span.get("expected_choice_count", 0) > len(span.get("choices") or []):
+            checks.append(
+                _check(
+                    "choices",
+                    "fail",
+                    "CHOICE_LOSS",
+                    "The normalized response lost model choices",
+                    {"span_id": span_id},
+                )
+            )
+        if span.get("streaming") and not span.get("stream_fragments"):
+            checks.append(
+                _check(
+                    "stream",
+                    "fail",
+                    "STREAM_FRAGMENT_MISSING",
+                    "Streaming span has no captured fragments",
+                    {"span_id": span_id},
+                )
+            )
+        references = span.get("payload_references") or []
+        if span.get("oversized") and not any(
+            isinstance(ref, Mapping)
+            and isinstance(ref.get("digest"), str)
+            and _DIGEST.fullmatch(ref["digest"])
+            and ref.get("size", 0) > 0
+            and ref.get("mime_type")
+            for ref in references
+        ):
+            checks.append(
+                _check(
+                    "payload",
+                    "fail",
+                    "PAYLOAD_ATTACHMENT_REQUIRED",
+                    "Oversized content requires a valid payload reference",
+                    {"span_id": span_id},
+                )
+            )
+    requested = {
+        call["id"]
+        for span in spans
+        for call in (span.get("tool_calls") or [])
+        if isinstance(call, Mapping) and isinstance(call.get("id"), str)
+    }
+    # Schema-v2 choices preserve assistant-requested calls inside each choice.
+    for span in spans:
+        for choice in span.get("choices") or []:
+            if not isinstance(choice, Mapping):
+                continue
+            message = choice.get("message")
+            if not isinstance(message, Mapping):
+                continue
+            for call in message.get("tool_calls") or []:
+                if isinstance(call, Mapping) and isinstance(call.get("id"), str):
+                    requested.add(call["id"])
+    executed = {
+        span["tool_call"]["id"]
+        for span in spans
+        if isinstance(span.get("tool_call"), Mapping)
+        and isinstance(span["tool_call"].get("id"), str)
+    }
+    for call_id in sorted(requested - executed):
+        checks.append(
+            _check(
+                "tools",
+                "fail",
+                "TOOL_EXECUTION_MISSING",
+                "Assistant-requested tool call has no execution span",
+                {"call_id": call_id},
+            )
+        )
+    for call_id in sorted(executed - requested):
+        checks.append(
+            _check(
+                "tools",
+                "fail",
+                "TOOL_CALL_MISSING",
+                "Tool execution has no preserved assistant request",
+                {"call_id": call_id},
+            )
+        )
+    decisions = {span.get("sampled") for span in spans if isinstance(span.get("sampled"), bool)}
+    if len(decisions) > 1:
+        checks.append(
+            _check(
+                "sampling",
+                "fail",
+                "SAMPLING_INCONSISTENT",
+                "All spans must share the root sampling decision",
+            )
+        )
+    if not private_provider:
+        checks.append(
+            _check(
+                "ownership",
+                "fail",
+                "PROVIDER_OWNERSHIP_AMBIGUOUS",
+                "Doctor could not prove private provider ownership",
+            )
+        )
+    if flush_outcome == "timeout":
+        checks.append(
+            _check(
+                "flush",
+                "fail",
+                "FLUSH_TIMEOUT",
+                "Diagnostic capture did not flush within the deadline",
+            )
+        )
+    if not checks:
+        checks.append(
+            _check(
+                "local_envelope",
+                "pass",
+                "LOCAL_ENVELOPE_VALID",
+                "The final normalized local envelope is valid",
+            )
+        )
+    first = next((item for item in checks if item["status"] == "fail"), None)
+    digest = None
+    try:
+        digest = doctor_semantic_digest(envelope)
+    except (TypeError, ValueError, KeyError):
+        pass
+    capture = None
+    if (
+        digest
+        and isinstance(trace_id, str)
+        and _TRACE_ID.fullmatch(trace_id)
+        and isinstance(root_id, str)
+        and _SPAN_ID.fullmatch(root_id)
+    ):
+        capture = {
+            "trace_id": trace_id,
+            "root_span_id": root_id,
+            "span_count": len(spans),
+            "semantic_digest": digest,
+        }
+    result = {
+        "format_version": DOCTOR_V2_FORMAT_VERSION,
+        "mode": "local",
+        "status": (
+            "fail"
+            if first
+            else "warn" if any(item["status"] == "warn" for item in checks) else "pass"
+        ),
+        "first_failure": first["reason_code"] if first else None,
+        "runtime": {
+            "language": "python",
+            "sdk_version": __version__,
+            "schema_version": str(TELEMETRY_SCHEMA_VERSION),
+            "transport": "otlp_http_protobuf",
+        },
+        "sampling": {
+            "effective_sampler": "parentbased_traceidratio",
+            "root_sample_rate": sample_rate,
+            "sampled": next(iter(decisions), True),
+        },
+        "ownership": {
+            "provider": "private" if private_provider else "ambiguous",
+            "instrumentor_count": 0,
+        },
+        "queue": {
+            "mode": "diagnostic_capture",
+            "pending_spans": 0,
+            "dropped_spans": max(0, dropped_spans),
+            "capacity": queue_capacity,
+        },
+        "retry": {"attempts": 0, "window_ms": 0, "exhausted": False},
+        "flush": {
+            "outcome": flush_outcome,
+            "timeout_ms": flush_timeout_ms,
+            "duration_ms": flush_duration_ms,
+        },
+        "checks": checks,
+    }
+    if capture:
+        result["capture"] = capture
+    return result
+
+
+def doctor_captured_local_v2(trace_id: str | None = None, **options: Any) -> dict[str, Any] | None:
+    envelope = get_captured_envelope(trace_id)
+    return doctor_local_v2(envelope, **options) if envelope else None
+
+
+def _safe_endpoint(value: str) -> str:
+    parsed = urlparse(value)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+    ):
+        raise ValueError("invalid endpoint")
+    return f"{parsed.scheme}://{parsed.netloc}/api/diagnostics/v2/sessions"
+
+
+def doctor_probe_v2(
+    *, api_key: str | None = None, endpoint: str | None = None, timeout_seconds: float = 10.0
+) -> dict[str, Any]:
+    """Create and poll a scoped backend diagnostic session without exposing its token."""
+
+    import secrets
+
+    synthetic = {
+        "trace_id": secrets.token_hex(16),
+        "root_span_id": secrets.token_hex(8),
+        "spans": [],
+    }
+    synthetic["spans"].append(
+        {
+            "span_id": synthetic["root_span_id"],
+            "parent_span_id": None,
+            "name": "doctor.workflow",
+            "kind": "WORKFLOW",
+            "status": "OK",
+            "input": {"prompt": "generated diagnostic input"},
+            "output": {"result": "generated diagnostic output"},
+            "sampled": True,
+            "ended": True,
+        }
+    )
+    local = doctor_local_v2(synthetic)
+    capture = local["capture"]
+    key = (api_key if api_key is not None else os.getenv("NEATLOGS_API_KEY", "")).strip()
+    if not key:
+        return {
+            "format_version": DOCTOR_V2_FORMAT_VERSION,
+            "mode": "probe",
+            "status": "fail",
+            "first_failure": "CREDENTIAL_MISSING",
+            "runtime": {
+                "language": "python",
+                "sdk_version": __version__,
+                "schema_version": str(TELEMETRY_SCHEMA_VERSION),
+                "transport": "otlp_http_protobuf",
+            },
+            "capture": capture,
+            "checks": [
+                _check(
+                    "credentials",
+                    "fail",
+                    "CREDENTIAL_MISSING",
+                    "Configure an ingestion credential to run a backend probe",
+                )
+            ],
+        }
+    url = _safe_endpoint(
+        (endpoint or os.getenv("NEATLOGS_ENDPOINT") or "https://ingest.neatlogs.com").strip()
+    )
+    headers = {"x-api-key": key, "content-type": "application/json"}
+    session_id = None
+    try:
+        created_response = requests.post(
+            url, headers=headers, json={}, timeout=min(5.0, timeout_seconds)
+        )
+        created_response.raise_for_status()
+        created = created_response.json()
+        session_id, token = created.get("diagnostic_id"), created.get("probe_token")
+        if not isinstance(session_id, str) or not isinstance(token, str):
+            raise ValueError("invalid diagnostic session")
+        receipt_url = urljoin(url.rstrip("/") + "/", session_id)
+        deadline = time.monotonic() + timeout_seconds
+        receipt: dict[str, Any] = {
+            "status": "pending",
+            "stages": [],
+            "expires_at": created.get("expires_at"),
+        }
+        while time.monotonic() < deadline:
+            response = requests.get(
+                receipt_url,
+                headers={"x-api-key": key, "x-neatlogs-diagnostic-token": token},
+                timeout=min(5.0, max(0.1, deadline - time.monotonic())),
+            )
+            if response.ok:
+                receipt = response.json()
+            if receipt.get("status") in {"pass", "fail", "expired"}:
+                break
+            time.sleep(min(0.25, max(0, deadline - time.monotonic())))
+        stages = [item for item in receipt.get("stages", []) if isinstance(item, dict)]
+        required = (
+            "auth",
+            "schema_decode",
+            "pii",
+            "kafka",
+            "raw_durable",
+            "root_resolution",
+            "simplified_durable",
+            "visibility",
+        )
+        complete = receipt.get("status") == "pass" and all(
+            any(item.get("stage") == stage and item.get("status") == "accepted" for item in stages)
+            for stage in required
+        )
+        failed = next((item for item in stages if item.get("status") == "failed"), None)
+        local_digest = receipt.get("local_semantic_digest")
+        backend_digest = receipt.get("backend_semantic_digest")
+        digest_mismatch = any(
+            isinstance(value, str) and value != capture["semantic_digest"]
+            for value in (local_digest, backend_digest)
+        ) or (
+            isinstance(local_digest, str)
+            and isinstance(backend_digest, str)
+            and local_digest != backend_digest
+        )
+        reason = receipt.get("first_failure") or (failed or {}).get("reason_code")
+        if reason is None and digest_mismatch:
+            reason = "DIGEST_MISMATCH"
+        if reason is None and not complete:
+            reason = (
+                "DIAGNOSTIC_EXPIRED"
+                if receipt.get("status") == "expired"
+                else (
+                    "STAGE_PENDING"
+                    if receipt.get("status") == "pending"
+                    else "DIAGNOSTIC_NOT_VISIBLE"
+                )
+            )
+        if digest_mismatch:
+            complete = False
+        check = _check(
+            "probe_visibility",
+            "pass" if complete else "fail",
+            "DIAGNOSTIC_VISIBLE" if complete else reason,
+            (
+                "The diagnostic trace reached the authenticated read path"
+                if complete
+                else "The backend diagnostic did not reach every required stage"
+            ),
+        )
+        return {
+            "format_version": DOCTOR_V2_FORMAT_VERSION,
+            "mode": "probe",
+            "status": "pass" if complete else "fail",
+            "first_failure": reason,
+            "runtime": {
+                "language": "python",
+                "sdk_version": __version__,
+                "schema_version": str(TELEMETRY_SCHEMA_VERSION),
+                "transport": "otlp_http_protobuf",
+            },
+            "capture": capture,
+            "probe": {
+                "diagnostic_id": session_id,
+                "receipt_status": receipt.get("status", "pending"),
+                "expires_at": receipt.get("expires_at") or created.get("expires_at"),
+                "stages": stages,
+            },
+            "checks": [check],
+        }
+    except (requests.RequestException, ValueError, TypeError, json.JSONDecodeError):
+        return {
+            "format_version": DOCTOR_V2_FORMAT_VERSION,
+            "mode": "probe",
+            "status": "fail",
+            "first_failure": "DIAGNOSTIC_NOT_VISIBLE",
+            "runtime": {
+                "language": "python",
+                "sdk_version": __version__,
+                "schema_version": str(TELEMETRY_SCHEMA_VERSION),
+                "transport": "otlp_http_protobuf",
+            },
+            "capture": capture,
+            "checks": [
+                _check(
+                    "probe",
+                    "fail",
+                    "DIAGNOSTIC_NOT_VISIBLE",
+                    "The backend diagnostic session is unavailable",
+                )
+            ],
+        }
+    finally:
+        if session_id:
+            try:
+                requests.delete(
+                    urljoin(url.rstrip("/") + "/", session_id),
+                    headers={"x-api-key": key},
+                    timeout=2.0,
+                )
+            except requests.RequestException:
+                pass

--- a/neatlogs/errors.py
+++ b/neatlogs/errors.py
@@ -1,0 +1,6 @@
+class NeatlogsError(Exception):
+    """Base class for typed Neatlogs SDK failures."""
+
+
+class NeatlogsConfigurationError(NeatlogsError, ValueError):
+    """Raised when SDK configuration cannot be applied safely."""

--- a/neatlogs/google_genai.py
+++ b/neatlogs/google_genai.py
@@ -126,7 +126,14 @@ def _patch_models(models: Any) -> None:
 
             _set_input_attributes(span, contents, kwargs)
 
-            stream = orig_stream(*args, **kwargs)
+            try:
+                stream = orig_stream(*args, **kwargs)
+            except BaseException as exc:
+                span.set_attribute("neatlogs.stream.completion_state", "provider_error")
+                span.set_status(StatusCode.ERROR, str(exc))
+                span.record_exception(exc)
+                span.end()
+                raise
             return SyncStreamWrapper(stream, span, _finalize_stream)
 
         models.generate_content_stream = patched_generate_content_stream
@@ -209,7 +216,8 @@ def _patch_async_models(models: Any) -> None:
 
             try:
                 stream = await orig_stream(*args, **kwargs)
-            except Exception as e:
+            except BaseException as e:
+                span.set_attribute("neatlogs.stream.completion_state", "provider_error")
                 span.set_status(StatusCode.ERROR, str(e))
                 span.record_exception(e)
                 span.end()

--- a/neatlogs/google_genai.py
+++ b/neatlogs/google_genai.py
@@ -761,9 +761,12 @@ def _patch_google_genai_module() -> None:
     global _PATCHED, _ORIG_INIT
     if _PATCHED:
         return
-    _PATCHED = True
-
-    from google import genai as _genai
+    try:
+        from google import genai as _genai
+    except (ImportError, ModuleNotFoundError):
+        # The integration module remains importable without the optional
+        # google-genai distribution so duck-typed wrappers and helpers work.
+        return
 
     _ORIG_INIT = _genai.Client.__init__
 
@@ -772,6 +775,7 @@ def _patch_google_genai_module() -> None:
         wrap_google_genai_client(self)
 
     _genai.Client.__init__ = _patched_init
+    _PATCHED = True
 
 
 def _unpatch_google_genai_module() -> None:
@@ -779,7 +783,12 @@ def _unpatch_google_genai_module() -> None:
     if not _PATCHED:
         return
 
-    from google import genai as _genai
+    try:
+        from google import genai as _genai
+    except (ImportError, ModuleNotFoundError):
+        _PATCHED = False
+        _ORIG_INIT = None
+        return
 
     if _ORIG_INIT is not None:
         _genai.Client.__init__ = _ORIG_INIT
@@ -790,4 +799,7 @@ def _unpatch_google_genai_module() -> None:
 
 _patch_google_genai_module()
 
-from google import genai  # noqa: E402
+try:
+    from google import genai  # type: ignore[attr-defined] # noqa: E402
+except (ImportError, ModuleNotFoundError):
+    genai = None  # type: ignore[assignment]

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -3,7 +3,9 @@ Neatlogs SDK.
 """
 
 import atexit
+import concurrent.futures
 import functools
+import math
 import os
 import re
 import signal
@@ -11,12 +13,7 @@ import sys
 import threading
 from typing import Any, Callable, Dict, List, Optional
 
-try:
-    from opentelemetry import logs
-except ImportError:
-    from opentelemetry import _logs as logs  # type: ignore[no-redef]
-
-from opentelemetry import metrics, trace
+from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
@@ -28,11 +25,12 @@ from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import SpanLimits, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
 
 from ._wrap_utils import _normalize_traces_endpoint
 from .core.logger import get_logger
 from .core.span_processor import CompletionMarkerSpanProcessor, NeatlogsSpanProcessor
+from .errors import NeatlogsConfigurationError
 from .instrumentation.manager import InstrumentationManager
 from .version import __version__
 
@@ -42,79 +40,11 @@ logger = get_logger()
 _initialized = False
 _tracer_provider = None
 _owns_tracer_provider = False  # True only when neatlogs created the provider (safe to shut down)
-_isolated_provider = False  # True when isolated (explicit tracer_provider= OR auto-detected)
-
-# Foreign LLM-observability instrumentors that own the global OTel pipeline and
-# resolve their span parent from the GLOBAL current-span. If one is active while
-# neatlogs would otherwise reuse the global provider, spans cross-contaminate both
-# ways. Their presence is the auto-detect signal to isolate onto a private provider.
-#
-# NOTE: `openinference` is deliberately NOT listed. The bare
-# `openinference-instrumentation-*` packages are neatlogs' OWN instrumentation
-# backend (hard dependency) — neatlogs imports them itself the moment it
-# instruments anything, and they are always importable. So their presence in
-# sys.modules / on disk carries no information about a co-tenant and would cause
-# a false-positive isolation (spurious for every standalone user, and — because
-# the modules stay resident after shutdown — for every re-init in one process).
-# Genuine OpenInference-based co-tenants (Arize Phoenix, Arize) import `phoenix`/
-# `arize` and are detected via those entries below.
-_FOREIGN_LLM_INSTRUMENTORS = (
-    "openlit",
-    "langfuse",
-    "traceloop",  # traceloop-sdk / openllmetry
-    "phoenix",  # arize-phoenix (uses OpenInference under the hood)
-    "arize",
-    "logfire",
-)
-
-
-def _foreign_llm_instrumentor_active():
-    """Return the name of a loaded foreign LLM-observability instrumentor, or None.
-
-    Import presence in ``sys.modules`` is the signal: these packages install their
-    instrumentation onto the global provider at import/init time, so being loaded
-    in-process means their spans are (or will be) flowing through the global
-    pipeline neatlogs would otherwise share.
-    """
-    for name in _FOREIGN_LLM_INSTRUMENTORS:
-        if name in sys.modules:
-            return name
-    return None
-
-
-def _foreign_llm_instrumentor_installed():
-    """Return the name of an INSTALLED (importable) foreign LLM instrumentor, or None.
-
-    Unlike ``_foreign_llm_instrumentor_active`` (which requires the package to be
-    imported already), this only checks that it is importable. That is the signal
-    we need when neatlogs is the FIRST tracing SDK to init: the foreign tool
-    (openlit/langfuse/…) frequently loads LATER — e.g. in a FastAPI startup event
-    that runs after an import-time ``neatlogs.init()``. If neatlogs claimed the
-    global provider now, that later instrumentor would bind to OUR provider and
-    both pipelines would cross-contaminate. Detecting the package on-disk lets us
-    pre-emptively stay private and leave the global slot free for the co-tenant,
-    WITHOUT requiring the customer to pass ``isolate=True``.
-
-    A user who has a foreign package installed but genuinely wants neatlogs to own
-    the global provider (e.g. to capture their own raw-OTel spans) can force the
-    legacy behaviour with ``isolate=False``.
-    """
-    import importlib.util
-
-    for name in _FOREIGN_LLM_INSTRUMENTORS:
-        try:
-            if importlib.util.find_spec(name) is not None:
-                return name
-        except (ImportError, ValueError):
-            # find_spec can raise for namespace-package edge cases; treat as absent.
-            continue
-    return None
-
-
 _meter_provider = None
 _log_provider = None
 _span_processor = None
 _transport_span_processors = []
+_export_health = []
 _completion_span_processor = None
 _instrumentation_manager = None
 _debug_mode = False
@@ -137,6 +67,17 @@ _session_config = {
 def is_debug_enabled() -> bool:
     """Return True if neatlogs was initialized with debug=True."""
     return _debug_mode
+
+
+def _trace_sampler(sample_rate: float) -> ParentBased:
+    """Validate one finite trace-level rate and preserve parent sampling decisions."""
+
+    if isinstance(sample_rate, bool) or not isinstance(sample_rate, (int, float)):
+        raise NeatlogsConfigurationError("sample_rate must be a finite number from 0.0 to 1.0")
+    rate = float(sample_rate)
+    if not math.isfinite(rate) or rate < 0.0 or rate > 1.0:
+        raise NeatlogsConfigurationError("sample_rate must be a finite number from 0.0 to 1.0")
+    return ParentBased(root=TraceIdRatioBased(rate))
 
 
 def _restore_shutdown_signal_handlers() -> None:
@@ -319,37 +260,17 @@ def init(
               Pass a list of span kind strings, e.g. ["LLM", "TOOL"]. This selection
               is persisted so the dashboard reflects it. When None (default), the
               project setting is preserved.
-        tracer_provider: Opt-in FULL ISOLATION. Pass a private ``TracerProvider`` (one you
+        tracer_provider: Pass a private ``TracerProvider`` (one you
               created but did NOT install as the OTel global) and neatlogs will emit ALL of
               its spans — auto-instrumented, wrap()/trace()/@span, and the internal
               completion marker — into that provider ONLY. Use this when another tool
               already owns the global provider (e.g. your own OpenTelemetry setup exporting
               to Langfuse) and you need neatlogs and that tool to share NO pipeline: no
               neatlogs span reaches the other backend and no foreign span reaches neatlogs.
-              neatlogs never shuts this provider down and never claims the global
-              meter/logger providers. When None (default), behaviour is auto-detected
-              (see ``isolate``): neatlogs isolates automatically when a foreign LLM
-              instrumentor owns the global provider, and otherwise owns-or-reuses it.
-        isolate: Override the auto-isolation decision. When None (default), neatlogs
-              AUTO-DETECTS and isolates onto a private provider — with NO customer
-              code change — in either of these cases:
-                * a foreign LLM-observability instrumentor
-                  (openlit/langfuse/traceloop/openinference/…) already owns the
-                  global tracer provider (it loaded first), OR
-                * neatlogs is the first tracing SDK to load but a foreign
-                  instrumentor is INSTALLED (importable) and may attach to the
-                  global provider later (the common FastAPI-startup ordering, where
-                  neatlogs.init runs at import time and openlit.init runs in a
-                  startup event).
-              In both cases neatlogs routes ALL its spans through a private provider
-              so the two pipelines share nothing — no neatlogs span reaches the
-              foreign backend, no foreign span reaches neatlogs, and no foreign span
-              inherits a neatlogs parent. When NO foreign instrumentor is installed,
-              neatlogs owns-or-reuses the global provider exactly as before (standalone
-              behaviour is unchanged). Pass True to force isolation unconditionally, or
-              False to force the legacy own-or-reuse behaviour even when a foreign
-              instrumentor is present. Passing ``tracer_provider=`` implies isolation
-              regardless of this flag.
+              tracer provider. When omitted, Neatlogs creates and owns an SDK-private
+              provider and never claims or reuses the process-global provider.
+        isolate: Deprecated compatibility option. Neatlogs is always isolated and
+              never installs or reuses the process-global tracer provider.
         register_shutdown_handlers: Register SIGINT and SIGTERM handlers that end
               active Neatlogs spans child-first and flush before preserving normal
               signal termination. Defaults to True. Set False only when the host
@@ -361,6 +282,17 @@ def init(
         if debug:
             logger.warning("Neatlogs already initialized, skipping re-initialization")
         return
+
+    sampler = _trace_sampler(sample_rate)
+    if tracer_provider is not None and float(sample_rate) != 1.0:
+        raise NeatlogsConfigurationError(
+            "sample_rate cannot configure a caller-owned tracer_provider; "
+            "configure its sampler directly or omit tracer_provider"
+        )
+    if tracer_provider is not None and tracer_provider is trace.get_tracer_provider():
+        raise NeatlogsConfigurationError(
+            "tracer_provider must be private and must not be the process-global provider"
+        )
 
     disable_export_resolved = bool(disable_export) or (
         os.getenv("NEATLOGS_DISABLE_EXPORT", "").lower() in ("true", "1", "yes")
@@ -453,8 +385,7 @@ def init(
         resource_attrs["neatlogs.pii.span_types"] = ",".join(pii_span_types)
     resource = Resource.create(resource_attrs)
 
-    global _tracer_provider, _owns_tracer_provider, _isolated_provider
-    existing_provider = trace.get_tracer_provider()
+    global _tracer_provider, _owns_tracer_provider
 
     if tracer_provider is not None:
         # ISOLATED MODE. The caller handed us a PRIVATE provider (never installed
@@ -467,7 +398,6 @@ def init(
         # meter/logger providers below. This is what makes isolation total.
         provider = tracer_provider
         _owns_tracer_provider = False
-        _isolated_provider = True
         # Merge neatlogs' resource (service.name + neatlogs.workflow_name + tags/pii)
         # onto the caller's provider so exported spans carry workflow_name — the
         # branches that build their OWN provider pass resource= at construction,
@@ -481,87 +411,15 @@ def init(
                 logger.debug("Could not merge neatlogs resource onto provided provider")
         if debug:
             logger.debug("Using explicitly provided tracer provider (isolated mode)")
-    elif existing_provider and hasattr(existing_provider, "add_span_processor"):
-        # A real provider already owns the global pipeline. Two sub-cases:
-        _foreign = None if isolate is False else _foreign_llm_instrumentor_active()
-        if isolate is True or _foreign is not None:
-            # AUTO-DETECT ISOLATION. A foreign LLM-observability instrumentor
-            # (openlit/langfuse/traceloop/…) owns the global provider AND resolves
-            # its parent from the global current-span. Reusing that provider would
-            # cross-contaminate both pipelines: neatlogs spans export to the foreign
-            # backend, and foreign spans (a) export to neatlogs and (b) inherit a
-            # neatlogs parent. So we build a PRIVATE provider neatlogs never installs
-            # globally — identical semantics to an explicit tracer_provider=.
-            provider = TracerProvider(
-                resource=resource,
-                span_limits=_span_limits_for_capture_everything(),
-            )
-            _owns_tracer_provider = True  # we made it; safe to shut down
-            _isolated_provider = True
-            if debug:
-                _why = (
-                    f"detected foreign LLM instrumentor '{_foreign}'"
-                    if _foreign is not None
-                    else "isolate=True was requested"
-                )
-                logger.info(
-                    f"Auto-isolation engaged: {_why} owning the global tracer "
-                    f"provider — routing all neatlogs spans through a private "
-                    f"provider so the two pipelines share nothing."
-                )
-        else:
-            # Reuse a provider set by the host app / another SDK (plain OpenTelemetry
-            # with no foreign LLM instrumentor). We do NOT own it — shutdown() must
-            # never tear it down, or it would kill the co-tenant's exporter too.
-            provider = existing_provider
-            _owns_tracer_provider = False
-            _isolated_provider = False
-            if debug:
-                logger.debug("Using existing tracer provider (not owned by neatlogs)")
     else:
-        sampler = None
-        if sample_rate < 1.0:
-            sampler = TraceIdRatioBased(sample_rate)
-            if debug:
-                logger.debug(f"Using TraceIdRatioBased sampler with rate {sample_rate}")
-
         provider = TracerProvider(
             resource=resource,
             sampler=sampler,
             span_limits=_span_limits_for_capture_everything(),
         )
         _owns_tracer_provider = True
-
-        # neatlogs is the first tracing SDK to load (no real global provider yet).
-        # We must still decide whether to claim the global slot or stay private. A
-        # foreign LLM instrumentor (openlit/langfuse/…) frequently attaches to the
-        # global provider LATER — e.g. in a FastAPI startup event that runs after an
-        # import-time neatlogs.init(). If we claimed the global now, that later
-        # instrumentor would bind to OUR provider and both pipelines would
-        # cross-contaminate. So when isolation is requested OR a foreign instrumentor
-        # is merely INSTALLED (importable), we pre-emptively keep a private provider
-        # and leave the global slot free for the co-tenant to own — no isolate=True
-        # required from the customer.
-        _foreign_installed = None if isolate is False else _foreign_llm_instrumentor_installed()
-        if isolate is True or _foreign_installed is not None:
-            _isolated_provider = True
-            if debug:
-                _why = (
-                    "isolate=True was requested"
-                    if isolate is True
-                    else f"foreign LLM instrumentor '{_foreign_installed}' is installed "
-                    f"(may attach to the global provider later)"
-                )
-                logger.info(
-                    f"Pre-emptive isolation: {_why} — neatlogs loaded first but keeps "
-                    f"a PRIVATE tracer provider and leaves the global slot free for the "
-                    f"co-tenant so the two pipelines share nothing."
-                )
-        else:
-            trace.set_tracer_provider(provider)
-            _isolated_provider = False
-            if debug:
-                logger.debug("Created new tracer provider (owned by neatlogs)")
+        if debug:
+            logger.debug("Created SDK-private tracer provider (owned by neatlogs)")
 
     _tracer_provider = provider
 
@@ -575,13 +433,12 @@ def init(
     # NeatlogsSpanProcessor: pure pre-processing (attribute normalization + file logging)
     global _span_processor
     _span_processor = NeatlogsSpanProcessor(
-        sample_rate=sample_rate,
         debug=debug,
         mask=mask,
         emit_completion_markers=False,
         # A private/isolated pipeline contains only Neatlogs execution spans,
         # even when the caller retains provider shutdown ownership.
-        own_all_spans=_owns_tracer_provider or _isolated_provider,
+        own_all_spans=_owns_tracer_provider,
     )
     provider.add_span_processor(_span_processor)
 
@@ -597,6 +454,7 @@ def init(
         # warmups, outbound fetches outside any traced request) are never sent — on
         # their own they're junk rootless traces the backend can't simplify. Nested
         # HTTP spans (with a parent) still export normally.
+        from .core.masking_exporter import MaskingSpanExporter
         from .core.span_processor import is_rootless_infra_http
 
         class _FilteredOTLPExporter:
@@ -617,8 +475,9 @@ def init(
             def force_flush(self, timeout_millis: int = 30000):
                 return self._inner.force_flush(timeout_millis)
 
+        masking_exporter = MaskingSpanExporter(otlp_exporter, mask)
         batch_processor = BatchSpanProcessor(
-            _FilteredOTLPExporter(otlp_exporter),
+            _FilteredOTLPExporter(masking_exporter),
             max_export_batch_size=batch_size,
             schedule_delay_millis=int(flush_interval * 1000),
         )
@@ -632,6 +491,8 @@ def init(
         provider.add_span_processor(completion_processor)
         global _transport_span_processors
         _transport_span_processors = [batch_processor, completion_processor]
+        global _export_health
+        _export_health = [masking_exporter]
         global _completion_span_processor
         _completion_span_processor = completion_processor
         if debug:
@@ -644,15 +505,10 @@ def init(
 
     global _meter_provider
     _meter_provider = MeterProvider(resource=resource)
-    # In isolated mode, never claim the GLOBAL meter provider — that would clobber
-    # a co-tenant's (e.g. their OpenTelemetry/Langfuse) meter pipeline. neatlogs
-    # currently emits no metrics of its own, so a non-global provider is harmless.
-    if not _isolated_provider:
-        metrics.set_meter_provider(_meter_provider)
-        if debug:
-            logger.debug("Neatlogs meter provider initialized")
-    elif debug:
-        logger.debug("Isolated mode: skipping global meter provider registration")
+    # Keep the currently-unused meter pipeline private as well; never clobber a
+    # host application's process-global OpenTelemetry providers.
+    if debug:
+        logger.debug("Created SDK-private meter provider")
 
     # --- Logs signal (opt-in) ---
     # neatlogs.log(), capture_stdout=True, and logging.* auto-capture all require
@@ -662,6 +518,7 @@ def init(
         from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 
         from .core.log_exporter import NeatlogsLogFilter
+        from .core.masking_exporter import MaskingLogExporter
 
         logs_endpoint = f"{_base_url}/v1/logs"
         _otlp_log_exporter = OTLPLogExporter(
@@ -671,15 +528,11 @@ def init(
         _log_provider = LoggerProvider(resource=resource)
         # NeatlogsLogFilter drops external-module and no-trace records before
         # BatchLogRecordProcessor batches and sends them via OTLPLogExporter.
+        masking_log_exporter = MaskingLogExporter(_otlp_log_exporter, mask)
         _log_provider.add_log_record_processor(
-            NeatlogsLogFilter(BatchLogRecordProcessor(_otlp_log_exporter))
+            NeatlogsLogFilter(BatchLogRecordProcessor(masking_log_exporter))
         )
-        # Isolated mode: don't claim the GLOBAL logger provider (would clobber a
-        # co-tenant's log pipeline). LoggingInstrumentor below is still bound to
-        # our _log_provider explicitly via logger_provider=, so capture still works.
-        if not _isolated_provider:
-            logs.set_logger_provider(_log_provider)
-
+        _export_health.append(masking_log_exporter)
         try:
             import logging as _stdlib_logging
 
@@ -753,12 +606,10 @@ def flush(timeout_millis: int = 30000) -> bool:
             logger.error(f"Error flushing logs: {e}", exc_info=True)
             success = False
 
-    if _tracer_provider:
+    for processor in _transport_span_processors:
         try:
-            logger.debug("Flushing tracer provider...")
-            ok = _tracer_provider.force_flush(timeout_millis=timeout_millis)
-            success = bool(ok) and success
-            logger.debug("Tracer provider flushed successfully")
+            ok = processor.force_flush(timeout_millis=timeout_millis)
+            success = (ok is None or bool(ok)) and success
         except Exception as e:
             logger.error(f"Error flushing spans: {e}", exc_info=True)
             success = False
@@ -773,7 +624,36 @@ def flush(timeout_millis: int = 30000) -> bool:
             logger.error(f"Error flushing metrics: {e}", exc_info=True)
             success = False
 
+    success = all(exporter.health.healthy for exporter in _export_health) and success
+
     return success
+
+
+def flush_all(timeout_millis: int = 30000) -> Dict[str, bool]:
+    """Flush all live Neatlogs-owned pipelines within one bounded deadline."""
+    from .core.client_registry import snapshot_clients
+
+    operations = [("default", flush)] if _initialized else []
+    operations.extend(
+        (f"client:{client.workflow_name}:{id(client):x}", client.flush)
+        for client in snapshot_clients()
+    )
+    if not operations:
+        return {}
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=len(operations))
+    futures = {executor.submit(operation, timeout_millis): name for name, operation in operations}
+    done, pending = concurrent.futures.wait(futures, timeout=max(0, timeout_millis) / 1000)
+    results = {}
+    for future in done:
+        try:
+            results[futures[future]] = bool(future.result())
+        except Exception:
+            results[futures[future]] = False
+    for future in pending:
+        results[futures[future]] = False
+        future.cancel()
+    executor.shutdown(wait=False, cancel_futures=True)
+    return results
 
 
 def get_session_config():
@@ -819,6 +699,7 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
     """End active Neatlogs spans, then flush and shut down SDK providers."""
     global _tracer_provider, _owns_tracer_provider, _meter_provider, _log_provider, _span_processor, _initialized
     global _instrumentation_manager, _transport_span_processors, _completion_span_processor
+    global _export_health
 
     try:
         atexit.unregister(shutdown)
@@ -932,14 +813,13 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
     except Exception:
         pass
 
-    global _isolated_provider
-    _isolated_provider = False
     _initialized = False
     _tracer_provider = None
     _meter_provider = None
     _log_provider = None
     _span_processor = None
     _transport_span_processors = []
+    _export_health = []
     _completion_span_processor = None
     _debug_mode = False
     _session_config["session_id"] = None

--- a/neatlogs/openai.py
+++ b/neatlogs/openai.py
@@ -986,9 +986,15 @@ def _patch_openai_module() -> None:
     global _PATCHED, _ORIG_INIT, _ORIG_ASYNC_INIT
     if _PATCHED:
         return
-    _PATCHED = True
+    try:
+        import openai as _openai
+    except ImportError:
+        # ``neatlogs.wrap()`` also supports OpenAI-compatible/duck-typed
+        # clients.  Importing this wrapper must therefore not make the
+        # optional upstream package mandatory.
+        return
 
-    import openai as _openai
+    _PATCHED = True
 
     _ORIG_INIT = _openai.OpenAI.__init__
     _ORIG_ASYNC_INIT = _openai.AsyncOpenAI.__init__
@@ -1025,4 +1031,7 @@ def _unpatch_openai_module() -> None:
 
 _patch_openai_module()
 
-import openai  # noqa: E402
+try:
+    import openai  # noqa: E402
+except ImportError:  # pragma: no cover - covered through neatlogs.wrap()
+    openai = None  # type: ignore[assignment]

--- a/neatlogs/schema_v2.py
+++ b/neatlogs/schema_v2.py
@@ -1,0 +1,90 @@
+"""Access to the canonical, language-neutral NeatLogs telemetry contract v2."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from importlib import resources
+from typing import Any
+
+TELEMETRY_CONTRACT_VERSION = "2.0.0"
+TELEMETRY_SCHEMA_VERSION = 2
+TELEMETRY_SCHEMA_SHA256 = "1ce32734138c2ffc316c4299f5ae3eebec2f94381a538a383af49ba93eec9f9d"
+
+
+def _contract_resource(name: str):
+    return resources.files("neatlogs").joinpath(f"contracts/v2/{name}")
+
+
+def telemetry_schema_bytes() -> bytes:
+    """Return the exact public schema bytes shipped with this SDK."""
+
+    return _contract_resource("neatlogs-telemetry.schema.json").read_bytes()
+
+
+def telemetry_schema() -> dict[str, Any]:
+    """Return the parsed canonical telemetry schema."""
+
+    return json.loads(telemetry_schema_bytes())
+
+
+def telemetry_manifest() -> dict[str, Any]:
+    """Return the packaged contract manifest used by fixture generators."""
+
+    return json.loads(_contract_resource("manifest.json").read_bytes())
+
+
+def verify_telemetry_schema() -> None:
+    """Fail when the packaged schema, digest, and manifest disagree."""
+
+    actual = hashlib.sha256(telemetry_schema_bytes()).hexdigest()
+    if actual != TELEMETRY_SCHEMA_SHA256:
+        raise RuntimeError(
+            "NeatLogs telemetry schema v2 digest mismatch: "
+            f"expected {TELEMETRY_SCHEMA_SHA256}, received {actual}"
+        )
+    manifest = telemetry_manifest()
+    schema = telemetry_schema()
+    expected = {
+        "contract_version": TELEMETRY_CONTRACT_VERSION,
+        "schema_version": TELEMETRY_SCHEMA_VERSION,
+        "schema_sha256": TELEMETRY_SCHEMA_SHA256,
+        "schema_id": schema.get("$id"),
+        "schema_file": "neatlogs-telemetry.schema.json",
+    }
+    mismatches = {
+        key: (manifest.get(key), value)
+        for key, value in expected.items()
+        if manifest.get(key) != value
+    }
+    if mismatches:
+        raise RuntimeError(f"NeatLogs telemetry manifest mismatch: {mismatches}")
+
+
+def validate_telemetry_fixture(fixture: Mapping[str, Any] | Sequence[Mapping[str, Any]]) -> None:
+    """Validate one generated span envelope, or a sequence of envelopes, against v2.
+
+    Validation support is intentionally optional so importing the SDK does not add
+    a JSON Schema dependency. Install ``neatlogs[schema-validation]`` in fixture
+    generators and conformance jobs.
+    """
+
+    try:
+        from jsonschema.validators import validator_for
+    except ImportError as exc:  # pragma: no cover - exercised in a clean consumer test
+        raise RuntimeError(
+            "Telemetry fixture validation requires neatlogs[schema-validation]"
+        ) from exc
+
+    schema = telemetry_schema()
+    validator_class = validator_for(schema)
+    validator_class.check_schema(schema)
+    validator = validator_class(schema)
+    fixtures = [fixture] if isinstance(fixture, Mapping) else fixture
+    if isinstance(fixtures, (str, bytes)) or not isinstance(fixtures, Sequence):
+        raise TypeError("fixture must be a mapping or a sequence of mappings")
+    for index, item in enumerate(fixtures):
+        if not isinstance(item, Mapping):
+            raise TypeError(f"fixture[{index}] must be a mapping")
+        validator.validate(dict(item))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+schema-validation = [
+    "jsonschema>=4.18.0,<5.0.0",
+]
 # Each extra installs only the heavy underlying library.
 # All openinference-instrumentation-* adapters are in base deps — no need to list them here.
 azure-ai-inference = [
@@ -194,6 +197,9 @@ Repository = "https://github.com/NeatLogs/neatlogs.git"
 Issues = "https://github.com/NeatLogs/neatlogs/issues"
 Documentation = "https://docs.neatlogs.com/"
 
+[project.scripts]
+neatlogs-doctor = "neatlogs.__main__:doctor_main"
+
 [tool.setuptools]
 include-package-data = false
 
@@ -208,6 +214,7 @@ exclude = [
 [tool.setuptools.package-data]
 neatlogs = [
     "config/*.json",
+    "contracts/v2/*.json",
 ]
 
 [tool.setuptools.exclude-package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,7 @@ Issues = "https://github.com/NeatLogs/neatlogs/issues"
 Documentation = "https://docs.neatlogs.com/"
 
 [project.scripts]
+neatlogs = "neatlogs.__main__:main"
 neatlogs-doctor = "neatlogs.__main__:doctor_main"
 
 [tool.setuptools]

--- a/scripts/smoke_dist.sh
+++ b/scripts/smoke_dist.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 path/to/neatlogs.whl" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+smoke_dir="$(mktemp -d)"
+trap 'rm -rf "$smoke_dir"' EXIT
+
+python_bin="${PYTHON:-python3}"
+"$python_bin" -m venv "$smoke_dir/venv"
+"$smoke_dir/venv/bin/python" -m pip install "$1"
+cd "$smoke_dir"
+"$smoke_dir/venv/bin/python" "$repo_root/scripts/smoke_readme.py"
+"$smoke_dir/venv/bin/neatlogs-doctor" --disable-export --json > "$smoke_dir/doctor.json"
+"$smoke_dir/venv/bin/python" -c \
+  'import json, pathlib, sys; result=json.loads(pathlib.Path(sys.argv[1]).read_text()); assert result["format_version"] == "neatlogs.doctor/v1" and result["ready"]' \
+  "$smoke_dir/doctor.json"

--- a/scripts/smoke_readme.py
+++ b/scripts/smoke_readme.py
@@ -1,0 +1,26 @@
+"""Offline smoke of the README's install/init/decorate/flush lifecycle."""
+
+import neatlogs
+from neatlogs import span
+
+doctor = neatlogs.doctor(disable_export=True)
+assert doctor.ready
+assert doctor.format_version == "neatlogs.doctor/v1"
+assert neatlogs.init.__module__ == "neatlogs.init"
+
+neatlogs.init(
+    api_key="readme-smoke-key",
+    workflow_name="readme-smoke",
+    instrumentations=[],
+    disable_export=True,
+)
+
+
+@span(kind="WORKFLOW", name="quickstart")
+def main():
+    return "smoke-ok"
+
+
+assert main() == "smoke-ok"
+assert neatlogs.flush()
+assert neatlogs.shutdown()

--- a/tests/integration/test_gemini_instrumentation.py
+++ b/tests/integration/test_gemini_instrumentation.py
@@ -14,7 +14,6 @@ import respx
 # Import the new SDK
 from google import genai
 from google.genai import types
-from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
@@ -49,8 +48,15 @@ class TestGoogleGenAIInstrumentation:
         # The SDK accesses .token or calls refresh. We make sure it behaves strings.
         mock_creds.token = "fake-oauth-token-string"
         mock_creds.valid = True
+        mock_creds.quota_project_id = None
 
-        with patch("google.auth.default", return_value=(mock_creds, "test-project")):
+        with (
+            patch("google.auth.default", return_value=(mock_creds, "test-project")),
+            patch(
+                "google.genai._api_client.get_token_from_credentials",
+                return_value="fake-oauth-token-string",
+            ),
+        ):
             yield mock_creds
 
     @respx.mock
@@ -66,11 +72,14 @@ class TestGoogleGenAIInstrumentation:
         # Setup Clean OTEL
         provider = TracerProvider()
         provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
-        trace.set_tracer_provider(provider)
 
         import neatlogs
 
-        neatlogs.init(api_key="test-key", instrumentations=["google-genai"])
+        neatlogs.init(
+            api_key="test-key",
+            instrumentations=["google_genai"],
+            tracer_provider=provider,
+        )
 
         # 2. ACT
         client = genai.Client(api_key="fake-google-key")
@@ -82,16 +91,14 @@ class TestGoogleGenAIInstrumentation:
         time.sleep(0.1)
         spans = in_memory_span_exporter.get_finished_spans()
 
-        llm_spans = [s for s in spans if s.attributes.get("openinference.span.kind") == "LLM"]
+        llm_spans = [s for s in spans if s.attributes.get("neatlogs.span.kind") == "llm"]
 
         assert len(llm_spans) >= 1
         span = llm_spans[0]
 
-        # FIXED: Based on your error log, the attribute is 'llm.provider' = 'google'
-        # The specific key might vary by instrumentor version, checking what exists.
-        assert span.attributes.get("llm.provider") == "google"
+        assert span.attributes.get("neatlogs.llm.provider") == "google_genai"
         assert "gemini" in str(span.attributes)
-        assert span.attributes.get("llm.token_count.total") == 20
+        assert span.attributes.get("neatlogs.llm.token_count.total") == 20
 
     @respx.mock
     def test_gemini_vertex_mode_creates_span(
@@ -110,11 +117,14 @@ class TestGoogleGenAIInstrumentation:
 
         provider = TracerProvider()
         provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
-        trace.set_tracer_provider(provider)
 
         import neatlogs
 
-        neatlogs.init(api_key="test-key", instrumentations=["google-genai"])
+        neatlogs.init(
+            api_key="test-key",
+            instrumentations=["google_genai"],
+            tracer_provider=provider,
+        )
 
         # 2. ACT
         # The client will use our mocked google.auth.default credentials
@@ -127,10 +137,9 @@ class TestGoogleGenAIInstrumentation:
 
         time.sleep(0.1)
         spans = in_memory_span_exporter.get_finished_spans()
-        llm_span = next(s for s in spans if s.attributes.get("openinference.span.kind") == "LLM")
+        llm_span = next(s for s in spans if s.attributes.get("neatlogs.span.kind") == "llm")
 
-        # In Vertex mode, provider might still be google or vertexai
-        assert llm_span.attributes.get("llm.provider") == "google"
+        assert llm_span.attributes.get("neatlogs.llm.provider") == "google_genai"
 
     @respx.mock
     def test_gemini_streaming_capture(self, in_memory_span_exporter):
@@ -150,11 +159,14 @@ class TestGoogleGenAIInstrumentation:
 
         provider = TracerProvider()
         provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
-        trace.set_tracer_provider(provider)
 
         import neatlogs
 
-        neatlogs.init(api_key="test-key", instrumentations=["google-genai"])
+        neatlogs.init(
+            api_key="test-key",
+            instrumentations=["google_genai"],
+            tracer_provider=provider,
+        )
 
         client = genai.Client(api_key="fake")
 

--- a/tests/unit/test_crewai_prompt_fidelity.py
+++ b/tests/unit/test_crewai_prompt_fidelity.py
@@ -4,7 +4,6 @@ import json
 import sys
 from pathlib import Path
 
-from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
@@ -84,9 +83,12 @@ def test_example_uses_automatic_crewai_instrumentation() -> None:
 def _install_test_tracer(in_memory_span_exporter) -> None:
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
-    trace.set_tracer_provider(provider)
-    # isolate=False pins neatlogs to the provider set above — see test_crewai_tool_fidelity.
-    neatlogs.init(api_key="test-key", disable_export=True, instrumentations=[], isolate=False)
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=[],
+        tracer_provider=provider,
+    )
 
 
 def test_crewai_string_input_preserves_content_after_10000_characters(

--- a/tests/unit/test_crewai_tool_fidelity.py
+++ b/tests/unit/test_crewai_tool_fidelity.py
@@ -5,7 +5,6 @@ import types
 from datetime import datetime, timezone
 
 import pytest
-from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import StatusCode
@@ -16,11 +15,12 @@ import neatlogs
 def _install_test_tracer(in_memory_span_exporter) -> None:
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
-    trace.set_tracer_provider(provider)
-    # isolate=False pins neatlogs to the provider set above. Without it, auto-isolation engages
-    # whenever a foreign instrumentor (logfire, traceloop, …) is merely importable in the venv and
-    # spans go to a private provider this exporter never sees.
-    neatlogs.init(api_key="test-key", disable_export=True, instrumentations=[], isolate=False)
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=[],
+        tracer_provider=provider,
+    )
 
 
 def _crewai_module():

--- a/tests/unit/test_decorator_capture_policy.py
+++ b/tests/unit/test_decorator_capture_policy.py
@@ -1,0 +1,33 @@
+import neatlogs
+from neatlogs._wrap_utils import set_neatlogs_provider
+
+
+def test_legacy_trace_content_environment_variable_is_ignored(
+    monkeypatch, tracer_provider, in_memory_span_exporter
+):
+    monkeypatch.setenv("NEATLOGS_TRACE_CONTENT", "false")
+    set_neatlogs_provider(tracer_provider)
+
+    @neatlogs.span(kind="TOOL")
+    def echo(value):
+        return value
+
+    assert echo("visible") == "visible"
+    span = in_memory_span_exporter.get_finished_spans()[0]
+    assert "visible" in span.attributes["input.value"]
+    assert span.attributes["output.value"] == '"visible"'
+
+
+def test_explicit_per_span_capture_controls_remain_supported(
+    tracer_provider, in_memory_span_exporter
+):
+    set_neatlogs_provider(tracer_provider)
+
+    @neatlogs.span(kind="TOOL", capture_input=False, capture_output=False)
+    def echo(value):
+        return value
+
+    assert echo("private") == "private"
+    span = in_memory_span_exporter.get_finished_spans()[0]
+    assert "input.value" not in span.attributes
+    assert "output.value" not in span.attributes

--- a/tests/unit/test_decorator_streaming.py
+++ b/tests/unit/test_decorator_streaming.py
@@ -1,0 +1,170 @@
+import asyncio
+import gc
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+import neatlogs
+from neatlogs._wrap_utils import set_neatlogs_provider
+
+
+def _install(provider):
+    set_neatlogs_provider(provider)
+
+
+def test_sync_generator_exhaustion_and_exactly_once_close(tracer_provider, in_memory_span_exporter):
+    _install(tracer_provider)
+
+    @neatlogs.span(kind="CHAIN")
+    def stream():
+        yield "a"
+        yield "b"
+
+    result = stream()
+    assert list(result) == ["a", "b"]
+    result.close()
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes["neatlogs.stream.completion_state"] == "complete"
+    assert spans[0].attributes["neatlogs.stream.chunk_count"] == 2
+
+
+def test_sync_early_close_partial_and_never_consumed(tracer_provider, in_memory_span_exporter):
+    _install(tracer_provider)
+
+    @neatlogs.span(kind="CHAIN")
+    def stream():
+        yield "first"
+        yield "second"
+
+    never = stream()
+    del never
+    gc.collect()
+    assert in_memory_span_exporter.get_finished_spans() == ()
+
+    result = stream()
+    assert next(result) == "first"
+    result.close()
+    span = in_memory_span_exporter.get_finished_spans()[0]
+    assert span.attributes["neatlogs.stream.completion_state"] == "consumer_cancelled"
+    assert span.attributes["output.value"] == '["first"]'
+
+
+def test_sync_midstream_error_and_gc_finalization(tracer_provider, in_memory_span_exporter):
+    _install(tracer_provider)
+
+    @neatlogs.span(kind="CHAIN")
+    def broken():
+        yield "partial"
+        raise RuntimeError("boom")
+
+    result = broken()
+    assert next(result) == "partial"
+    with pytest.raises(RuntimeError):
+        next(result)
+    assert (
+        in_memory_span_exporter.get_finished_spans()[0].attributes[
+            "neatlogs.stream.completion_state"
+        ]
+        == "provider_error"
+    )
+
+    @neatlogs.span(kind="CHAIN")
+    def abandoned():
+        yield "partial"
+        yield "later"
+
+    result = abandoned()
+    next(result)
+    del result
+    gc.collect()
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 2
+    assert spans[-1].attributes["neatlogs.stream.completion_state"] == "consumer_cancelled"
+
+
+@pytest.mark.asyncio
+async def test_async_exhaust_close_error_and_cancellation(tracer_provider, in_memory_span_exporter):
+    _install(tracer_provider)
+
+    @neatlogs.span(kind="CHAIN")
+    async def complete():
+        yield "a"
+        yield "b"
+
+    assert [item async for item in complete()] == ["a", "b"]
+
+    @neatlogs.span(kind="CHAIN")
+    async def partial():
+        yield "first"
+        await asyncio.sleep(10)
+
+    result = partial()
+    assert await anext(result) == "first"
+    await result.aclose()
+
+    result = partial()
+    assert await anext(result) == "first"
+    pending = asyncio.create_task(anext(result))
+    await asyncio.sleep(0)
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+
+    @neatlogs.span(kind="CHAIN")
+    async def broken():
+        yield "first"
+        raise RuntimeError("boom")
+
+    result = broken()
+    await anext(result)
+    with pytest.raises(RuntimeError):
+        await anext(result)
+
+    states = [
+        s.attributes["neatlogs.stream.completion_state"]
+        for s in in_memory_span_exporter.get_finished_spans()
+    ]
+    assert states == [
+        "complete",
+        "consumer_cancelled",
+        "consumer_cancelled",
+        "provider_error",
+    ]
+
+
+def test_stream_output_is_bounded(tracer_provider, in_memory_span_exporter):
+    _install(tracer_provider)
+
+    @neatlogs.span(kind="CHAIN")
+    def stream():
+        yield "x" * 120_000
+        yield "small"
+
+    list(stream())
+    span = in_memory_span_exporter.get_finished_spans()[0]
+    assert len(span.attributes["output.value"]) <= 100_000
+    assert span.attributes["neatlogs.stream.output_truncated"] is True
+    assert span.attributes["neatlogs.stream.chunk_count"] == 2
+
+
+def test_never_started_generator_binds_to_current_reinit_generation():
+    first, second = TracerProvider(), TracerProvider()
+    first_export, second_export = InMemorySpanExporter(), InMemorySpanExporter()
+    first.add_span_processor(SimpleSpanProcessor(first_export))
+    second.add_span_processor(SimpleSpanProcessor(second_export))
+
+    @neatlogs.span(kind="CHAIN")
+    def stream():
+        yield "value"
+
+    set_neatlogs_provider(first)
+    pending = stream()  # generator body and span have not started
+    set_neatlogs_provider(second)
+    assert list(pending) == ["value"]
+    assert first_export.get_finished_spans() == ()
+    assert len(second_export.get_finished_spans()) == 1
+    first.shutdown()
+    second.shutdown()

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -1,0 +1,123 @@
+import importlib
+import json
+import math
+import subprocess
+import sys
+
+import neatlogs
+
+init_module = importlib.import_module("neatlogs.init")
+
+
+def check(result, name):
+    return next(item for item in result.checks if item.name == name)
+
+
+def test_doctor_is_stable_read_only_and_network_free(monkeypatch):
+    def forbidden(*args, **kwargs):
+        raise AssertionError("doctor attempted a network request")
+
+    monkeypatch.setattr("requests.sessions.Session.request", forbidden)
+    before = (
+        init_module._initialized,
+        init_module._tracer_provider,
+        tuple(init_module._export_health),
+        init_module.get_session_config(),
+    )
+
+    result = neatlogs.doctor(disable_export=True)
+
+    after = (
+        init_module._initialized,
+        init_module._tracer_provider,
+        tuple(init_module._export_health),
+        init_module.get_session_config(),
+    )
+    assert after == before
+    assert result.format_version == "neatlogs.doctor/v1"
+    assert result.sdk_version == neatlogs.__version__
+    assert result.ready
+    assert [item.name for item in result.checks] == [
+        "runtime",
+        "package",
+        "schema",
+        "transport",
+        "endpoint",
+        "sampler",
+        "ownership",
+        "queue",
+        "export_health",
+        "root",
+    ]
+    assert check(result, "queue").reason_code == "EXPORT_QUEUE_DISABLED"
+    assert check(result, "export_health").status == "unknown"
+    assert check(result, "root").status == "unknown"
+
+
+def test_doctor_rejects_endpoint_and_sampler_without_leaking_secret(monkeypatch):
+    secret = "doctor-super-secret"
+    monkeypatch.setenv(
+        "NEATLOGS_ENDPOINT", f"https://user:{secret}@ingest.neatlogs.com/path?token={secret}"
+    )
+
+    result = neatlogs.doctor(sample_rate=math.nan)
+    encoded = result.to_json()
+
+    assert not result.ready
+    assert check(result, "endpoint").reason_code == "ENDPOINT_INVALID"
+    assert check(result, "sampler").reason_code == "SAMPLER_INVALID"
+    assert secret not in encoded
+
+
+def test_doctor_observes_private_runtime_health_and_active_root():
+    neatlogs.init(
+        workflow_name="doctor-test",
+        disable_export=True,
+        register_shutdown_handlers=False,
+    )
+    try:
+        with neatlogs.trace(name="doctor.root"):
+            result = neatlogs.doctor(disable_export=True)
+            root = check(result, "root")
+            assert root.status == "pass"
+            assert root.reason_code == "ROOT_IDS_VALID"
+            assert len(root.details["trace_id"]) == 32
+            assert len(root.details["span_id"]) == 16
+            assert check(result, "ownership").reason_code == "OTEL_PROVIDER_PRIVATE"
+            assert check(result, "export_health").reason_code == "EXPORT_HEALTHY"
+    finally:
+        neatlogs.shutdown()
+
+
+def test_doctor_reports_existing_export_health_failure():
+    class Health:
+        failures = 2
+        drops = 1
+
+    class Exporter:
+        health = Health()
+
+    class Runtime:
+        tracer_provider = object()
+        _span_processor = None
+        _exporters = [Exporter()]
+        _log_exporters = []
+
+    result = neatlogs.doctor(client=Runtime())
+    health = check(result, "export_health")
+    assert not result.ready
+    assert health.reason_code == "EXPORT_HEALTH_UNHEALTHY"
+    assert health.details == {"dropped_spans": "1", "export_failures": "2"}
+
+
+def test_doctor_cli_emits_common_json_contract():
+    process = subprocess.run(
+        [sys.executable, "-m", "neatlogs", "doctor", "--disable-export", "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result = json.loads(process.stdout)
+    assert result["format_version"] == "neatlogs.doctor/v1"
+    assert result["ready"] is True
+    assert process.stderr == ""

--- a/tests/unit/test_doctor_v2.py
+++ b/tests/unit/test_doctor_v2.py
@@ -1,0 +1,324 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.trace import SpanContext, SpanKind, Status, StatusCode, TraceFlags, TraceState
+
+from neatlogs.core.masking_exporter import MaskingSpanExporter
+from neatlogs.doctor_v2 import (
+    clear_doctor_capture,
+    doctor_captured_local_v2,
+    doctor_local_v2,
+    doctor_probe_v2,
+    doctor_semantic_digest,
+    get_captured_envelope,
+)
+from neatlogs.__main__ import main
+
+FIXTURES = Path("/Users/shyam-neatlogs/neatlogs-chotu/contracts/doctor/v2/fixtures")
+
+
+def envelope():
+    return json.loads((FIXTURES / "valid-envelope.json").read_text())
+
+
+def test_canonical_digest_matches_cross_language_golden_value():
+    assert doctor_semantic_digest(envelope()) == (
+        "sha256:76d8726734664dacaa4e6da4ffc547cc" "5b7c8edde4721a485b5875378c233381"
+    )
+
+
+def test_valid_envelope_conforms_to_doctor_v2_shape():
+    result = doctor_local_v2(envelope(), flush_duration_ms=12)
+    assert result["format_version"] == "neatlogs.doctor/v2"
+    assert result["mode"] == "local"
+    assert result["status"] == "pass"
+    assert result["first_failure"] is None
+    assert result["runtime"]["language"] == "python"
+    assert result["checks"][0]["reason_code"] == "LOCAL_ENVELOPE_VALID"
+
+
+def test_validation_reports_first_contract_order_failure():
+    invalid = envelope()
+    invalid["trace_id"] = "bad"
+    invalid["spans"][1]["parent_span_id"] = "missing"
+    result = doctor_local_v2(invalid)
+    assert result["status"] == "fail"
+    assert result["first_failure"] == "TRACE_ID_INVALID"
+    assert "capture" not in result
+
+
+def _span(attributes, *, trace_id=1, span_id=2, parent_id=0):
+    context = SpanContext(
+        trace_id=trace_id,
+        span_id=span_id,
+        is_remote=False,
+        trace_flags=TraceFlags.SAMPLED,
+        trace_state=TraceState(),
+    )
+    parent = (
+        None
+        if not parent_id
+        else SpanContext(
+            trace_id=trace_id,
+            span_id=parent_id,
+            is_remote=False,
+            trace_flags=TraceFlags.SAMPLED,
+            trace_state=TraceState(),
+        )
+    )
+    return ReadableSpan(
+        name="root",
+        context=context,
+        parent=parent,
+        resource=Resource.create({}),
+        attributes=attributes,
+        events=[],
+        links=[],
+        kind=SpanKind.INTERNAL,
+        status=Status(StatusCode.OK),
+        start_time=1,
+        end_time=2,
+        instrumentation_scope=None,
+    )
+
+
+class Exporter:
+    def __init__(self):
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def force_flush(self, timeout_millis=30000):
+        return True
+
+    def shutdown(self):
+        pass
+
+
+def test_real_exporter_path_captures_only_post_mask_data():
+    clear_doctor_capture()
+    inner = Exporter()
+
+    def mask(snapshot):
+        snapshot["attributes"]["input.value"] = '{"email":"[masked]"}'
+        return snapshot
+
+    exporter = MaskingSpanExporter(inner, mask)
+    assert (
+        exporter.export(
+            [
+                _span(
+                    {
+                        "neatlogs.span.kind": "WORKFLOW",
+                        "input.value": '{"email":"secret@example.com"}',
+                    }
+                )
+            ]
+        )
+        is SpanExportResult.SUCCESS
+    )
+    captured = get_captured_envelope("00000000000000000000000000000001")
+    assert captured["spans"][0]["input"] == {"email": "[masked]"}
+    serialized = json.dumps(captured)
+    assert "secret@example.com" not in serialized
+    assert doctor_captured_local_v2("00000000000000000000000000000001")["status"] == "pass"
+
+
+def test_capture_store_is_bounded_to_sixteen_traces():
+    clear_doctor_capture()
+    from neatlogs.doctor_v2 import capture_prepared_spans
+
+    for trace_id in range(1, 18):
+        capture_prepared_spans([_span({"neatlogs.span.kind": "WORKFLOW"}, trace_id=trace_id)])
+    assert get_captured_envelope("00000000000000000000000000000001") is None
+    assert get_captured_envelope("00000000000000000000000000000011") is not None
+
+
+def test_probe_polling_never_passes_on_auth_receipt_only(monkeypatch):
+    created = {
+        "diagnostic_id": "diag_0123456789abcdef",
+        "probe_token": "x" * 32,
+        "expires_at": "2030-01-01T00:05:00Z",
+    }
+    receipt = {
+        "status": "pending",
+        "diagnostic_id": created["diagnostic_id"],
+        "created_at": "2030-01-01T00:00:00Z",
+        "expires_at": created["expires_at"],
+        "stages": [
+            {
+                "stage": "auth",
+                "status": "accepted",
+                "reason_code": "AUTH_ACCEPTED",
+                "at": "2030-01-01T00:00:01Z",
+            }
+        ],
+    }
+    response = lambda value, ok=True: SimpleNamespace(
+        ok=ok, json=lambda: value, raise_for_status=lambda: None
+    )
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.post", lambda *a, **k: response(created))
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.get", lambda *a, **k: response(receipt))
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.delete", lambda *a, **k: response({}))
+    monkeypatch.setattr("neatlogs.doctor_v2.time.sleep", lambda *_: None)
+    ticks = iter([0.0, 1.0, 2.0])
+    monkeypatch.setattr("neatlogs.doctor_v2.time.monotonic", lambda: next(ticks, 2.0))
+    result = doctor_probe_v2(
+        api_key="local-key", endpoint="http://localhost:4100", timeout_seconds=1
+    )
+    assert result["status"] == "fail"
+    assert result["first_failure"] == "STAGE_PENDING"
+    assert result["probe"]["receipt_status"] == "pending"
+    assert result["checks"][0]["remediation_code"] == "WAIT_FOR_RECEIPT"
+    assert "probe_token" not in json.dumps(result)
+
+
+def test_probe_missing_credential_never_echoes_environment(monkeypatch):
+    monkeypatch.delenv("NEATLOGS_API_KEY", raising=False)
+    result = doctor_probe_v2()
+    assert result["first_failure"] == "CREDENTIAL_MISSING"
+    assert "api_key" not in json.dumps(result).lower()
+
+
+def test_standalone_local_runs_real_isolated_exporter_pipeline(monkeypatch, capsys):
+    clear_doctor_capture()
+    monkeypatch.delenv("NEATLOGS_API_KEY", raising=False)
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("local Doctor attempted backend access")
+
+    monkeypatch.setattr("requests.sessions.Session.request", forbidden)
+    assert main(["doctor", "--local", "--json"]) == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "pass"
+    assert result["first_failure"] is None
+    assert result["capture"]["span_count"] == 2
+    assert result["capture"]["semantic_digest"].startswith("sha256:")
+    assert result["checks"] == [
+        {
+            "name": "local_envelope",
+            "status": "pass",
+            "reason_code": "LOCAL_ENVELOPE_VALID",
+            "message": "The final normalized local envelope is valid",
+            "remediation_code": "NONE",
+        }
+    ]
+    assert result["runtime"]["language"] == "python"
+    assert result["sampling"]["sampled"] is True
+    assert result["ownership"]["provider"] == "private"
+    assert result["queue"]["mode"] == "diagnostic_capture"
+    assert result["flush"]["outcome"] == "success"
+
+
+def test_probe_digest_mismatch_prevents_success(monkeypatch):
+    created = {
+        "diagnostic_id": "diag_0123456789abcdef",
+        "probe_token": "x" * 32,
+        "expires_at": "2030-01-01T00:05:00Z",
+    }
+    stages = [
+        {
+            "stage": stage,
+            "status": "accepted",
+            "reason_code": code,
+            "at": "2030-01-01T00:00:01Z",
+        }
+        for stage, code in (
+            ("auth", "AUTH_ACCEPTED"),
+            ("schema_decode", "SCHEMA_DECODED"),
+            ("pii", "PII_PROCESSED"),
+            ("kafka", "KAFKA_PUBLISHED"),
+            ("raw_durable", "RAW_DURABLE"),
+            ("root_resolution", "ROOT_RESOLVED"),
+            ("simplified_durable", "SIMPLIFIED_DURABLE"),
+            ("visibility", "DIAGNOSTIC_VISIBLE"),
+        )
+    ]
+    receipt = {
+        "status": "pass",
+        "expires_at": created["expires_at"],
+        "backend_semantic_digest": "sha256:" + "f" * 64,
+        "stages": stages,
+    }
+    response = lambda value: SimpleNamespace(
+        ok=True, json=lambda: value, raise_for_status=lambda: None
+    )
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.post", lambda *a, **k: response(created))
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.get", lambda *a, **k: response(receipt))
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.delete", lambda *a, **k: response({}))
+    result = doctor_probe_v2(
+        api_key="local-key", endpoint="http://localhost:4100", timeout_seconds=1
+    )
+    assert result["status"] == "fail"
+    assert result["first_failure"] == "DIGEST_MISMATCH"
+
+
+@pytest.mark.parametrize(
+    ("receipt", "expected"),
+    [
+        (
+            {
+                "status": "expired",
+                "expires_at": "2030-01-01T00:05:00Z",
+                "stages": [
+                    {
+                        "stage": "auth",
+                        "status": "accepted",
+                        "reason_code": "AUTH_ACCEPTED",
+                        "at": "2030-01-01T00:00:01Z",
+                    }
+                ],
+            },
+            "DIAGNOSTIC_EXPIRED",
+        ),
+        (
+            {
+                "status": "fail",
+                "first_failure": "RAW_DURABILITY_FAILED",
+                "expires_at": "2030-01-01T00:05:00Z",
+                "stages": [
+                    {
+                        "stage": "raw_durable",
+                        "status": "failed",
+                        "reason_code": "RAW_DURABILITY_FAILED",
+                        "at": "2030-01-01T00:00:01Z",
+                    }
+                ],
+            },
+            "RAW_DURABILITY_FAILED",
+        ),
+    ],
+)
+def test_probe_preserves_expiry_and_first_backend_failure(monkeypatch, receipt, expected):
+    created = {
+        "diagnostic_id": "diag_0123456789abcdef",
+        "probe_token": "x" * 32,
+        "expires_at": "2030-01-01T00:05:00Z",
+    }
+    response = lambda value: SimpleNamespace(
+        ok=True, json=lambda: value, raise_for_status=lambda: None
+    )
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.post", lambda *a, **k: response(created))
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.get", lambda *a, **k: response(receipt))
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.delete", lambda *a, **k: response({}))
+    result = doctor_probe_v2(
+        api_key="local-key", endpoint="http://localhost:4100", timeout_seconds=1
+    )
+    assert result["status"] == "fail"
+    assert result["first_failure"] == expected
+
+
+def test_standalone_local_reports_missing_configuration(monkeypatch, capsys):
+    clear_doctor_capture()
+    monkeypatch.delenv("NEATLOGS_API_KEY", raising=False)
+    assert main(["doctor", "--local", "--json"]) == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["first_failure"] is None
+    assert all(check["reason_code"] != "CREDENTIAL_MISSING" for check in result["checks"])

--- a/tests/unit/test_doctor_v2.py
+++ b/tests/unit/test_doctor_v2.py
@@ -164,7 +164,11 @@ def test_probe_polling_never_passes_on_auth_receipt_only(monkeypatch):
     response = lambda value, ok=True: SimpleNamespace(
         ok=ok, json=lambda: value, raise_for_status=lambda: None
     )
-    monkeypatch.setattr("neatlogs.doctor_v2.requests.post", lambda *a, **k: response(created))
+    posted = {}
+    def post(*args, **kwargs):
+        posted.update(kwargs.get("json") or {})
+        return response(created)
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.post", post)
     monkeypatch.setattr("neatlogs.doctor_v2.requests.get", lambda *a, **k: response(receipt))
     monkeypatch.setattr("neatlogs.doctor_v2.requests.delete", lambda *a, **k: response({}))
     monkeypatch.setattr("neatlogs.doctor_v2.time.sleep", lambda *_: None)
@@ -177,6 +181,9 @@ def test_probe_polling_never_passes_on_auth_receipt_only(monkeypatch):
     assert result["first_failure"] == "STAGE_PENDING"
     assert result["probe"]["receipt_status"] == "pending"
     assert result["checks"][0]["remediation_code"] == "WAIT_FOR_RECEIPT"
+    assert posted["trace_id"] == result["capture"]["trace_id"]
+    assert posted["envelope_digest"] == result["capture"]["semantic_digest"]
+    assert posted["fixture_version"] == "doctor-v2"
     assert "probe_token" not in json.dumps(result)
 
 

--- a/tests/unit/test_google_genai_stream_lifecycle.py
+++ b/tests/unit/test_google_genai_stream_lifecycle.py
@@ -1,0 +1,112 @@
+import gc
+from types import SimpleNamespace
+
+import pytest
+
+import neatlogs.google_genai as google_genai
+
+
+class _Models:
+    def __init__(self, factory):
+        self._factory = factory
+
+    def generate_content(self, *args, **kwargs):
+        return SimpleNamespace(candidates=[], usage_metadata=None)
+
+    def generate_content_stream(self, *args, **kwargs):
+        return self._factory()
+
+
+class _AsyncModels:
+    def __init__(self, factory):
+        self._factory = factory
+
+    async def generate_content(self, *args, **kwargs):
+        return SimpleNamespace(candidates=[], usage_metadata=None)
+
+    async def generate_content_stream(self, *args, **kwargs):
+        return self._factory()
+
+
+def _chunk(text):
+    part = SimpleNamespace(text=text, thought=False, function_call=None)
+    content = SimpleNamespace(parts=[part])
+    return SimpleNamespace(
+        candidates=[SimpleNamespace(content=content, finish_reason=None)], usage_metadata=None
+    )
+
+
+def test_google_sync_iterator_ownership_all_terminal_paths(
+    monkeypatch, tracer_provider, in_memory_span_exporter
+):
+    monkeypatch.setattr(
+        google_genai, "get_provider_tracer", lambda: tracer_provider.get_tracer("google.test")
+    )
+
+    models = _Models(lambda: iter([_chunk("a"), _chunk("b")]))
+    google_genai._patch_models(models)
+    assert len(list(models.generate_content_stream(model="m", contents="q"))) == 2
+
+    models = _Models(lambda: iter([_chunk("partial"), _chunk("later")]))
+    google_genai._patch_models(models)
+    stream = models.generate_content_stream(model="m", contents="q")
+    next(stream)
+    stream.close()
+    stream.close()
+
+    models = _Models(lambda: iter([_chunk("unused")]))
+    google_genai._patch_models(models)
+    stream = models.generate_content_stream(model="m", contents="q")
+    del stream
+    gc.collect()
+
+    def failing():
+        yield _chunk("partial")
+        raise RuntimeError("provider boom")
+
+    models = _Models(failing)
+    google_genai._patch_models(models)
+    stream = models.generate_content_stream(model="m", contents="q")
+    next(stream)
+    with pytest.raises(RuntimeError):
+        next(stream)
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert [span.attributes["neatlogs.stream.completion_state"] for span in spans] == [
+        "complete",
+        "consumer_cancelled",
+        "consumer_cancelled",
+        "provider_error",
+    ]
+    assert len(spans) == 4
+
+
+@pytest.mark.asyncio
+async def test_google_async_iterator_preserves_awaitable_contract_and_close_ownership(
+    monkeypatch, tracer_provider, in_memory_span_exporter
+):
+    monkeypatch.setattr(
+        google_genai, "get_provider_tracer", lambda: tracer_provider.get_tracer("google.test")
+    )
+
+    async def chunks():
+        yield _chunk("a")
+        yield _chunk("b")
+
+    models = _AsyncModels(chunks)
+    google_genai._patch_async_models(models)
+    stream = await models.generate_content_stream(model="m", contents="q")
+    assert [item async for item in stream]
+
+    models = _AsyncModels(chunks)
+    google_genai._patch_async_models(models)
+    stream = await models.generate_content_stream(model="m", contents="q")
+    await anext(stream)
+    await stream.aclose()
+    await stream.aclose()
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert [span.attributes["neatlogs.stream.completion_state"] for span in spans] == [
+        "complete",
+        "consumer_cancelled",
+    ]

--- a/tests/unit/test_mask_application.py
+++ b/tests/unit/test_mask_application.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import importlib
+import json
 import time
 
 from opentelemetry.sdk._logs import LoggerProvider
@@ -74,6 +75,69 @@ def test_events_exceptions_and_status_are_maskable_without_source_mutation():
     assert all(SENTINEL not in str(dict(event.attributes)) for event in exported.events)
     assert exported.status.description == "***"
     assert any(SENTINEL in str(dict(event.attributes)) for event in span.events)
+
+
+def test_serialized_json_attributes_are_materialized_and_restored():
+    encoded = json.dumps({"request": {"api_key": SENTINEL, "safe": True}})
+
+    def mask(snapshot):
+        snapshot["attributes"]["input.value"]["request"]["api_key"] = "***"
+        return snapshot
+
+    provider, inner, _ = _pipeline(mask)
+    span = _span(provider)
+    span.set_attribute("input.value", encoded)
+    span.end()
+    provider.shutdown()
+
+    exported = inner.get_finished_spans()[0]
+    assert json.loads(exported.attributes["input.value"]) == {
+        "request": {"api_key": "***", "safe": True}
+    }
+    assert span.attributes["input.value"] == encoded
+
+
+def test_serialized_json_attribute_can_be_replaced_as_a_whole_string():
+    replacement = '{"email":"[REDACTED]"}'
+
+    def mask(snapshot):
+        snapshot["attributes"]["input.value"] = replacement
+        return snapshot
+
+    provider, inner, _ = _pipeline(mask)
+    span = _span(provider)
+    span.set_attribute("input.value", '{"email":"secret@example.com"}')
+    span.end()
+    provider.shutdown()
+
+    assert inner.get_finished_spans()[0].attributes["input.value"] == replacement
+
+
+def test_mask_does_not_receive_source_references_beyond_depth_limit():
+    source = {"next": {}}
+    current = source["next"]
+    for _ in range(40):
+        current["next"] = {}
+        current = current["next"]
+    current["secret"] = SENTINEL
+
+    def mask(snapshot):
+        candidate = snapshot["attributes"]["deep"]
+        while "next" in candidate:
+            candidate = candidate["next"]
+        candidate["secret"] = "***"
+        return snapshot
+
+    # Exercise the boundary helper directly because OTel attributes reject
+    # arbitrary nested mappings before they reach an exporter.
+    from neatlogs.core.masking_exporter import _MaskRunner
+
+    runner = _MaskRunner(5.0)
+    try:
+        assert runner.apply(mask, {"attributes": {"deep": source}}) is not None
+    finally:
+        runner.shutdown()
+    assert current["secret"] == SENTINEL
 
 
 def test_per_span_precedence_and_internal_id_removal():

--- a/tests/unit/test_mask_application.py
+++ b/tests/unit/test_mask_application.py
@@ -1,140 +1,184 @@
-"""
-Regression tests for client-side mask application in NeatlogsSpanProcessor.
+"""Final-boundary masking contracts using real OTel providers/exporters."""
 
-Guards two bugs fixed in span_processor.on_end (§7b/§7c/§8):
-  1. A per-span mask (@span(mask=)/trace(mask=), stamped as neatlogs.mask_id)
-     must reach the EXPORTED span, not just the file log. Previously the mask
-     sites gated on self.mask (global only), so a per-span-only mask was a no-op
-     on export.
-  2. The mask must be applied EXACTLY ONCE per span. Previously §7b + §7c (+ §8)
-     applied it 2-3x, which silently double-transforms non-idempotent masks
-     (e.g. translation).
+import asyncio
+import importlib
+import time
 
-These tests drive the processor directly with a fake ReadableSpan so they run
-with no exporter/backend and no LLM calls.
-"""
-
-from types import SimpleNamespace
-
-import pytest
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter, SimpleLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import Status, StatusCode
 
 from neatlogs.core.mask import register_mask
+from neatlogs.core.masking_exporter import MaskingLogExporter, MaskingSpanExporter
 from neatlogs.core.span_processor import NeatlogsSpanProcessor
 
-
-class _MutableAttrs(dict):
-    """Stand-in for OTel BoundedAttributes: a mutable mapping."""
-
-    _immutable = False
+SENTINEL = "privacy-sentinel-never-export"
 
 
-def _make_span(attrs, name="child", trace_id=0x1, span_id=0x2, parent_id=None):
-    """Minimal ReadableSpan-like object the processor's on_end reads from."""
-    ctx = SimpleNamespace(trace_id=trace_id, span_id=span_id)
-    parent = SimpleNamespace(span_id=parent_id) if parent_id is not None else None
-    status = SimpleNamespace(status_code=SimpleNamespace(name="OK"), description=None)
-    scope = SimpleNamespace(name="neatlogs.test")
-    a = _MutableAttrs(attrs)
-    return SimpleNamespace(
-        name=name,
-        attributes=a,
-        _attributes=a,
-        context=ctx,
-        parent=parent,
-        start_time=1,
-        end_time=2,
-        status=status,
-        events=[],
-        resource=SimpleNamespace(attributes={}),
-        instrumentation_scope=scope,
-        kind=None,
-    )
+def _pipeline(mask=None, exporter=None, timeout=5.0):
+    provider = TracerProvider(resource=Resource.create({"secret.resource": SENTINEL}))
+    inner = exporter or InMemorySpanExporter()
+    wrapper = MaskingSpanExporter(inner, mask, timeout_seconds=timeout)
+    provider.add_span_processor(NeatlogsSpanProcessor(mask=mask, own_all_spans=True))
+    provider.add_span_processor(SimpleSpanProcessor(wrapper))
+    return provider, inner, wrapper
 
 
-def _counting_mask(counter, tag):
-    def mask(span):
-        counter["n"] += 1
-        attrs = span.get("attributes", {}) or {}
-        for k in list(attrs):
-            v = attrs[k]
-            if isinstance(v, str) and any(h in k.lower() for h in ("input", "output", "value")):
-                attrs[k] = f"[{tag}#{counter['n']}]" + v
-        return span
-
-    return mask
+def _span(provider, name="call"):
+    span = provider.get_tracer("neatlogs.test").start_span(name)
+    span.set_attribute("openinference.span.kind", "LLM")
+    span.set_attribute("input.value", SENTINEL)
+    return span
 
 
-def test_global_mask_applied_once_and_exported():
-    counter = {"n": 0}
-    proc = NeatlogsSpanProcessor(mask=_counting_mask(counter, "G"))
-    span = _make_span(
-        {
-            "openinference.span.kind": "CHAIN",
-            "input.value": "IN",
-            "output.value": "OUT",
-        }
-    )
-    proc.on_end(span)
+def test_canonicalize_then_mask_clone_without_mutating_source():
+    def mask(snapshot):
+        # The processor has completed before the exporter takes its canonical
+        # snapshot; typed input is therefore present at the mask boundary.
+        assert snapshot["attributes"]["input.value"] == SENTINEL
+        snapshot["attributes"]["input.value"] = "***"
+        snapshot["resource"]["attributes"]["secret.resource"] = "***"
+        return snapshot
 
-    assert counter["n"] == 1, f"global mask applied {counter['n']}x, expected 1"
-    # Value on the EXPORTED span (span._attributes) is masked exactly once.
-    assert span._attributes["input.value"] == "[G#1]IN"
-    assert span._attributes["output.value"] == "[G#1]OUT"
-
-
-def test_per_span_mask_without_global_reaches_export():
-    """The bug that mattered most: per-span mask, NO global mask."""
-    counter = {"n": 0}
-    proc = NeatlogsSpanProcessor(mask=None)  # no global mask
-    mask_id = register_mask(_counting_mask(counter, "S"))
-    span = _make_span(
-        {
-            "openinference.span.kind": "CHAIN",
-            "neatlogs.mask_id": mask_id,
-            "input.value": "IN",
-            "output.value": "OUT",
-        }
-    )
-    proc.on_end(span)
-
-    assert counter["n"] == 1, f"per-span mask applied {counter['n']}x, expected 1"
-    assert (
-        span._attributes["input.value"] == "[S#1]IN"
-    ), "per-span mask did not reach the exported span"
-    assert span._attributes["output.value"] == "[S#1]OUT"
+    provider, inner, _ = _pipeline(mask)
+    span = _span(provider)
+    span.end()
+    provider.shutdown()
+    exported = inner.get_finished_spans()[0]
+    assert exported.attributes["input.value"] == "***"
+    assert exported.resource.attributes["secret.resource"] == "***"
+    assert span.attributes["input.value"] == SENTINEL
 
 
-def test_per_span_mask_takes_precedence_over_global():
-    gcount, scount = {"n": 0}, {"n": 0}
-    proc = NeatlogsSpanProcessor(mask=_counting_mask(gcount, "G"))
-    mask_id = register_mask(_counting_mask(scount, "S"))
-    span = _make_span(
-        {
-            "openinference.span.kind": "CHAIN",
-            "neatlogs.mask_id": mask_id,
-            "input.value": "IN",
-        }
-    )
-    proc.on_end(span)
+def test_events_exceptions_and_status_are_maskable_without_source_mutation():
+    def mask(snapshot):
+        for event in snapshot["events"]:
+            event["attributes"] = {key: "***" for key in event["attributes"]}
+        snapshot["status"]["description"] = "***"
+        return snapshot
 
-    assert scount["n"] == 1, "per-span mask should run exactly once"
-    assert gcount["n"] == 0, "global mask must NOT run when a per-span mask exists"
-    assert span._attributes["input.value"] == "[S#1]IN"
-
-
-def test_no_mask_leaves_values_untouched():
-    proc = NeatlogsSpanProcessor(mask=None)
-    span = _make_span(
-        {
-            "openinference.span.kind": "CHAIN",
-            "input.value": "IN",
-        }
-    )
-    proc.on_end(span)
-    assert span._attributes["input.value"] == "IN"
+    provider, inner, _ = _pipeline(mask)
+    span = _span(provider, "failure")
+    try:
+        raise RuntimeError(SENTINEL)
+    except RuntimeError as exc:
+        span.record_exception(exc)
+        span.set_status(Status(StatusCode.ERROR, SENTINEL))
+    span.end()
+    provider.shutdown()
+    exported = inner.get_finished_spans()[0]
+    assert all(SENTINEL not in str(dict(event.attributes)) for event in exported.events)
+    assert exported.status.description == "***"
+    assert any(SENTINEL in str(dict(event.attributes)) for event in span.events)
 
 
-if __name__ == "__main__":
-    import sys
+def test_per_span_precedence_and_internal_id_removal():
+    calls = []
 
-    sys.exit(pytest.main([__file__, "-v", "-p", "no:logfire"]))
+    def global_mask(snapshot):
+        calls.append("global")
+        return snapshot
+
+    def local_mask(snapshot):
+        calls.append("local")
+        snapshot["attributes"]["input.value"] = "***"
+        return snapshot
+
+    provider, inner, _ = _pipeline(global_mask)
+    span = _span(provider)
+    span.set_attribute("neatlogs.mask_id", register_mask(local_mask))
+    span.end()
+    provider.shutdown()
+    exported = inner.get_finished_spans()[0]
+    assert calls == ["local"]
+    assert exported.attributes["input.value"] == "***"
+    assert "neatlogs.mask_id" not in exported.attributes
+
+
+def test_async_mask_and_null_drop():
+    async def mask(snapshot):
+        await asyncio.sleep(0)
+        snapshot["attributes"]["input.value"] = "***"
+        return snapshot
+
+    provider, inner, wrapper = _pipeline(mask)
+    _span(provider).end()
+    provider.shutdown()
+    assert inner.get_finished_spans()[0].attributes["input.value"] == "***"
+    assert wrapper.health.healthy
+
+    provider, inner, wrapper = _pipeline(lambda _: None)
+    _span(provider).end()
+    provider.shutdown()
+    assert inner.get_finished_spans() == ()
+    assert not wrapper.health.healthy
+    assert wrapper.health.drops == 1
+
+
+def test_exception_and_timeout_fail_closed():
+    def broken(_):
+        raise RuntimeError(SENTINEL)
+
+    provider, inner, wrapper = _pipeline(broken)
+    _span(provider).end()
+    provider.shutdown()
+    assert inner.get_finished_spans() == ()
+    assert not wrapper.health.healthy
+
+    def slow(snapshot):
+        time.sleep(0.1)
+        return snapshot
+
+    provider, inner, wrapper = _pipeline(slow, timeout=0.01)
+    _span(provider).end()
+    provider.shutdown()
+    assert inner.get_finished_spans() == ()
+    assert not wrapper.health.healthy
+
+
+class _FailingExporter(InMemorySpanExporter):
+    def export(self, spans):
+        return SpanExportResult.FAILURE
+
+
+def test_transport_failure_exposed_by_health_and_flush():
+    provider, _, wrapper = _pipeline(lambda snapshot: snapshot, _FailingExporter())
+    _span(provider).end()
+    assert not wrapper.health.healthy
+    assert wrapper.force_flush() is False
+    provider.shutdown()
+
+
+def test_public_flush_reports_mask_drop_health(monkeypatch):
+    init_module = importlib.import_module("neatlogs.init")
+    provider, _, wrapper = _pipeline(lambda _: None)
+    _span(provider).end()
+    monkeypatch.setattr(init_module, "_tracer_provider", None)
+    monkeypatch.setattr(init_module, "_meter_provider", None)
+    monkeypatch.setattr(init_module, "_log_provider", None)
+    monkeypatch.setattr(init_module, "_export_health", [wrapper])
+    assert init_module.flush() is False
+    provider.shutdown()
+
+
+def test_log_body_attributes_and_resource_are_masked():
+    def mask(snapshot):
+        snapshot["body"] = "***"
+        snapshot["attributes"]["secret"] = "***"
+        snapshot["resource"]["attributes"]["secret.resource"] = "***"
+        return snapshot
+
+    provider = LoggerProvider(resource=Resource.create({"secret.resource": SENTINEL}))
+    inner = InMemoryLogRecordExporter()
+    wrapper = MaskingLogExporter(inner, mask)
+    provider.add_log_record_processor(SimpleLogRecordProcessor(wrapper))
+    provider.get_logger("test").emit(body=SENTINEL, attributes={"secret": SENTINEL})
+    provider.shutdown()
+    exported = inner.get_finished_logs()[0]
+    assert exported.log_record.body == "***"
+    assert exported.log_record.attributes["secret"] == "***"
+    assert exported.resource.attributes["secret.resource"] == "***"

--- a/tests/unit/test_secondary_client.py
+++ b/tests/unit/test_secondary_client.py
@@ -128,10 +128,32 @@ def test_flushing_one_client_does_not_flush_another(monkeypatch):
 
     first.flush()
 
-    assert first_flushes == [1]
+    # Client.flush touches only processors installed by Neatlogs, never every
+    # processor on a caller-owned provider.
+    assert first_flushes == []
     assert second_flushes == []
 
     first.shutdown()
+    second.shutdown()
+
+
+def test_flush_all_discovers_live_clients_and_unregisters_closed(monkeypatch):
+    first, _, _ = _client("first")
+    second, _, _ = _client("second")
+    calls = []
+    monkeypatch.setattr(first, "flush", lambda timeout_millis=30000: calls.append("first") or True)
+    monkeypatch.setattr(
+        second, "flush", lambda timeout_millis=30000: calls.append("second") or True
+    )
+    results = neatlogs.flush_all(1000)
+    assert set(calls) == {"first", "second"}
+    assert len(results) == 2 and all(results.values())
+
+    first.shutdown()
+    calls.clear()
+    results = neatlogs.flush_all(1000)
+    assert calls == ["second"]
+    assert len(results) == 1
     second.shutdown()
 
 

--- a/tests/unit/test_telemetry_schema_v2.py
+++ b/tests/unit/test_telemetry_schema_v2.py
@@ -1,0 +1,176 @@
+import hashlib
+import json
+
+import pytest
+from jsonschema import ValidationError
+
+import neatlogs
+
+EXPECTED_PRECEDENCE = [
+    "native-v2",
+    "neatlogs-direct",
+    "otel-genai",
+    "openinference",
+    "provider-specific",
+    "external-legacy",
+    "unknown-raw",
+]
+
+
+def test_canonical_telemetry_schema_is_packaged_verbatim():
+    schema_bytes = neatlogs.telemetry_schema_bytes()
+
+    assert hashlib.sha256(schema_bytes).hexdigest() == neatlogs.TELEMETRY_SCHEMA_SHA256
+    assert json.loads(schema_bytes) == neatlogs.telemetry_schema()
+    neatlogs.verify_telemetry_schema()
+    manifest = neatlogs.telemetry_manifest()
+    assert manifest["schema_sha256"] == neatlogs.TELEMETRY_SCHEMA_SHA256
+    assert manifest["schema_id"] == json.loads(schema_bytes)["$id"]
+
+
+def test_canonical_telemetry_policy_is_consumed_by_the_sdk():
+    schema = neatlogs.telemetry_schema()
+    policy = schema["x-neatlogs-policy"]
+
+    assert neatlogs.TELEMETRY_SCHEMA_VERSION == 2
+    assert policy["contract_version"] == neatlogs.TELEMETRY_CONTRACT_VERSION
+    assert policy["conflict_precedence"] == EXPECTED_PRECEDENCE
+    assert policy["tool_calls"]["execution_is_separate_tool_span"] is True
+    assert policy["root_finalization"]["launch_sdk_auto_workflow_roots"] is True
+
+
+def test_stream_contract_requires_an_explicit_terminal_completion_state():
+    stream = neatlogs.telemetry_schema()["$defs"]["llmStream"]
+
+    assert "completion_state" in stream["required"]
+    assert stream["properties"]["completion_state"]["enum"] == [
+        "not_streamed",
+        "complete",
+        "consumer_cancelled",
+        "provider_error",
+    ]
+
+
+def _generated_workflow_fixture():
+    """Smallest useful output shape shared fixture generators can emit."""
+
+    return {
+        "schema_version": 2,
+        "trace_id": "1" * 32,
+        "span_id": "2" * 16,
+        "parent_span_id": None,
+        "name": "generated-workflow",
+        "kind": "WORKFLOW",
+        "ownership": {
+            "owner": "neatlogs-sdk",
+            "provider_generation": 1,
+            "project_key_id": None,
+            "propagation": "local-private-context",
+        },
+        "wrapper": {
+            "captured": False,
+            "integration": None,
+            "integration_version": None,
+            "capture_fidelity": "native",
+        },
+        "input": {"type": "json", "value": {"question": "fixed"}, "media": []},
+        "output": {"type": "text", "value": "FIXTURE_OK", "media": []},
+        "status": {"code": "OK", "message": None, "source": "application"},
+        "error": None,
+        "code": None,
+        "provenance": [],
+        "conflicts": [],
+        "semantic": {
+            "kind": "WORKFLOW",
+            "operation": "fixture-generation",
+            "role": None,
+            "metadata": {},
+            "recovery": None,
+        },
+        "attributes": {},
+    }
+
+
+def _generated_streaming_fixture(completion_state):
+    fixture = _generated_workflow_fixture()
+    fixture["name"] = "generated-stream"
+    fixture["kind"] = "LLM"
+    fixture["semantic"] = {
+        "kind": "LLM",
+        "request": {
+            "provider": "fixture",
+            "model": "fixture-model",
+            "operation": "generate",
+            "messages": [],
+            "tools": [],
+            "parameters": {
+                "temperature": None,
+                "top_p": None,
+                "top_k": None,
+                "max_output_tokens": None,
+                "stop": [],
+                "seed": None,
+                "frequency_penalty": None,
+                "presence_penalty": None,
+                "response_format": None,
+                "reasoning": None,
+                "service_tier": None,
+                "provider_options": {},
+            },
+        },
+        "response": {
+            "id": None,
+            "model": "fixture-model",
+            "choices": [],
+            "finish_reasons": [],
+        },
+        "usage": {
+            "input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+            "reasoning_tokens": None,
+            "cache_read_tokens": None,
+            "cache_write_tokens": None,
+            "cost_usd": None,
+        },
+        "stream": {
+            "completion_state": completion_state,
+            "time_to_first_token_ms": None,
+            "chunk_count": 1,
+            "choice_count": 0,
+            "events": [],
+            "raw_chunks": None,
+        },
+    }
+    return fixture
+
+
+def test_generated_fixture_validation_hook_accepts_one_or_many_envelopes():
+    fixture = _generated_workflow_fixture()
+
+    assert neatlogs.validate_telemetry_fixture(fixture) is None
+    assert neatlogs.validate_telemetry_fixture([fixture, fixture]) is None
+
+
+@pytest.mark.parametrize(
+    "completion_state",
+    ["not_streamed", "complete", "consumer_cancelled", "provider_error"],
+)
+def test_generated_stream_fixture_requires_a_terminal_completion_state(completion_state):
+    assert (
+        neatlogs.validate_telemetry_fixture(_generated_streaming_fixture(completion_state)) is None
+    )
+
+
+def test_generated_fixture_validation_hook_rejects_contract_drift():
+    fixture = _generated_workflow_fixture()
+    fixture["trace_id"] = "not-a-trace-id"
+
+    with pytest.raises(ValidationError):
+        neatlogs.validate_telemetry_fixture(fixture)
+
+
+@pytest.mark.parametrize("fixture", ["invalid", [None]])
+def test_generated_fixture_validation_hook_rejects_non_mapping_items(fixture):
+    with pytest.raises(TypeError):
+        neatlogs.validate_telemetry_fixture(fixture)

--- a/tests/unit/test_trace_sampling_and_provider_ownership.py
+++ b/tests/unit/test_trace_sampling_and_provider_ownership.py
@@ -1,0 +1,198 @@
+import math
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.sampling import ParentBased
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
+
+import neatlogs
+from neatlogs._wrap_utils import get_neatlogs_provider
+
+
+def _export_from(provider: TracerProvider) -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return exporter
+
+
+def _remote_parent(*, sampled: bool):
+    flags = TraceFlags(TraceFlags.SAMPLED if sampled else TraceFlags.DEFAULT)
+    span = NonRecordingSpan(
+        SpanContext(
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            span_id=0x1234567890ABCDEF,
+            is_remote=True,
+            trace_flags=flags,
+            trace_state=TraceState(),
+        )
+    )
+    return otel_trace.set_span_in_context(span)
+
+
+def test_init_never_claims_or_reuses_the_global_provider():
+    global_provider = TracerProvider()
+    global_exporter = _export_from(global_provider)
+    otel_trace.set_tracer_provider(global_provider)
+
+    neatlogs.init(api_key="unused", disable_export=True, instrumentations=[])
+    private_provider = get_neatlogs_provider()
+    assert private_provider is not None
+    assert private_provider is not global_provider
+    private_exporter = _export_from(private_provider)
+
+    with neatlogs.trace("private-root", kind="WORKFLOW"):
+        pass
+    global_provider.get_tracer("foreign.host").start_span("foreign-root").end()
+
+    assert {span.name for span in private_exporter.get_finished_spans()} == {"private-root"}
+    assert {span.name for span in global_exporter.get_finished_spans()} == {"foreign-root"}
+
+
+def test_deprecated_isolate_false_cannot_disable_private_provider_isolation():
+    global_provider = TracerProvider()
+    otel_trace.set_tracer_provider(global_provider)
+
+    neatlogs.init(
+        api_key="unused",
+        disable_export=True,
+        instrumentations=[],
+        isolate=False,
+    )
+
+    assert get_neatlogs_provider() is not global_provider
+
+
+@pytest.mark.parametrize("value", [0.0, 1e-12, 0.5, 1.0 - 1e-12, 1.0])
+def test_finite_sampling_boundaries_are_accepted_and_parent_based(value):
+    neatlogs.init(
+        api_key="unused",
+        disable_export=True,
+        instrumentations=[],
+        sample_rate=value,
+    )
+
+    assert isinstance(get_neatlogs_provider().sampler, ParentBased)
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1, math.nan, math.inf, -math.inf, True, "1", None])
+def test_invalid_sample_rate_is_a_typed_configuration_error(value):
+    with pytest.raises(neatlogs.NeatlogsConfigurationError, match="sample_rate"):
+        neatlogs.init(
+            api_key="unused",
+            disable_export=True,
+            instrumentations=[],
+            sample_rate=value,
+        )
+
+
+def test_zero_sample_rate_drops_the_whole_local_trace():
+    neatlogs.init(
+        api_key="unused",
+        disable_export=True,
+        instrumentations=[],
+        sample_rate=0.0,
+    )
+    exporter = _export_from(get_neatlogs_provider())
+
+    with neatlogs.trace("root", kind="WORKFLOW"):
+        with neatlogs.trace("child", kind="CHAIN"):
+            pass
+
+    assert exporter.get_finished_spans() == ()
+
+
+@pytest.mark.parametrize(
+    ("sample_rate", "remote_sampled", "expected_names"),
+    [(0.0, True, {"remote-child"}), (1.0, False, set())],
+)
+def test_remote_parent_sampling_decision_is_preserved(sample_rate, remote_sampled, expected_names):
+    neatlogs.init(
+        api_key="unused",
+        disable_export=True,
+        instrumentations=[],
+        sample_rate=sample_rate,
+    )
+    provider = get_neatlogs_provider()
+    exporter = _export_from(provider)
+
+    span = provider.get_tracer("neatlogs.remote-test").start_span(
+        "remote-child",
+        context=_remote_parent(sampled=remote_sampled),
+    )
+    span.end()
+
+    assert {span.name for span in exporter.get_finished_spans()} == expected_names
+
+
+@pytest.mark.parametrize("factory", ["init", "client"])
+def test_caller_owned_provider_rejects_an_unenforceable_sample_rate(factory):
+    provider = TracerProvider()
+    with pytest.raises(neatlogs.NeatlogsConfigurationError, match="caller-owned"):
+        if factory == "init":
+            neatlogs.init(
+                api_key="unused",
+                disable_export=True,
+                instrumentations=[],
+                tracer_provider=provider,
+                sample_rate=0.5,
+            )
+        else:
+            neatlogs.Client(
+                api_key="unused",
+                workflow_name="test",
+                disable_export=True,
+                tracer_provider=provider,
+                sample_rate=0.5,
+            )
+
+
+@pytest.mark.parametrize("factory", ["init", "client"])
+def test_explicit_process_global_provider_is_rejected(factory):
+    provider = TracerProvider()
+    otel_trace.set_tracer_provider(provider)
+
+    with pytest.raises(neatlogs.NeatlogsConfigurationError, match="process-global"):
+        if factory == "init":
+            neatlogs.init(
+                api_key="unused",
+                disable_export=True,
+                instrumentations=[],
+                tracer_provider=provider,
+            )
+        else:
+            neatlogs.Client(
+                api_key="unused",
+                workflow_name="test",
+                disable_export=True,
+                tracer_provider=provider,
+            )
+
+
+def test_clients_with_different_sample_rates_remain_isolated():
+    dropped = neatlogs.Client(
+        api_key="unused",
+        workflow_name="dropped",
+        disable_export=True,
+        sample_rate=0.0,
+    )
+    kept = neatlogs.Client(
+        api_key="unused",
+        workflow_name="kept",
+        disable_export=True,
+        sample_rate=1.0,
+    )
+    dropped_exporter = _export_from(dropped.tracer_provider)
+    kept_exporter = _export_from(kept.tracer_provider)
+
+    dropped.get_tracer("client.dropped").start_span("dropped-root").end()
+    kept.get_tracer("client.kept").start_span("kept-root").end()
+
+    assert dropped_exporter.get_finished_spans() == ()
+    assert {span.name for span in kept_exporter.get_finished_spans()} == {"kept-root"}
+    assert dropped.tracer_provider is not kept.tracer_provider
+
+    dropped.shutdown()
+    kept.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -4408,6 +4408,9 @@ portkey = [
 pydantic-ai = [
     { name = "pydantic-ai" },
 ]
+schema-validation = [
+    { name = "jsonschema" },
+]
 smolagents = [
     { name = "smolagents" },
 ]
@@ -4457,6 +4460,7 @@ requires-dist = [
     { name = "hermes-agent", marker = "python_full_version >= '3.11' and extra == 'hermes'", specifier = ">=0.15.1" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "instructor", marker = "extra == 'instructor'", specifier = ">=1.0.0" },
+    { name = "jsonschema", marker = "extra == 'schema-validation'", specifier = ">=4.18.0,<5.0.0" },
     { name = "langchain", marker = "extra == 'langchain'", specifier = ">=1.1.2" },
     { name = "langchain-classic", marker = "extra == 'langchain'", specifier = ">=1.0.0" },
     { name = "langchain-community", marker = "extra == 'langchain'", specifier = ">=0.4.1" },
@@ -4519,7 +4523,7 @@ requires-dist = [
     { name = "smolagents", marker = "extra == 'smolagents'", specifier = ">=1.0.0" },
     { name = "wrapt", specifier = ">=1.0.0" },
 ]
-provides-extras = ["azure-ai-inference", "openai", "azure-openai", "anthropic", "langchain", "langgraph", "crewai", "llama-index", "google-adk", "groq", "agno", "bedrock", "dspy", "litellm", "google-genai", "openai-agents", "guardrails", "haystack", "instructor", "mcp", "mistralai", "portkey", "pydantic-ai", "smolagents", "hermes", "vertexai", "vertex-ai", "autogen-agentchat", "milvus"]
+provides-extras = ["schema-validation", "azure-ai-inference", "openai", "azure-openai", "anthropic", "langchain", "langgraph", "crewai", "llama-index", "google-adk", "groq", "agno", "bedrock", "dspy", "litellm", "google-genai", "openai-agents", "guardrails", "haystack", "instructor", "mcp", "mistralai", "portkey", "pydantic-ai", "smolagents", "hermes", "vertexai", "vertex-ai", "autogen-agentchat", "milvus"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Scope

Python SDK implementation required by **Phase 9 — cross-SDK Doctor v2**. The primary launch focus remains Phase 4 (TypeScript), Phase 5 (Go), and Phase 9 (Doctor across all SDKs).

**Branch:** `feature/doctor-v2-python` → `main`

## Phase 9 — Doctor v2 (Python)

### Implemented

- [x] Embed canonical telemetry schema v2.
- [x] Run `doctor --local --json` through a real isolated synthetic workflow.
- [x] Capture the same final normalized and fail-closed masked envelope used by production export, including serialized/nested JSON.
- [x] Report identity, hierarchy, content, choice/tool/stream, sampling, provider ownership, queue/drop/retry, payload, and bounded flush evidence.
- [x] Correlate backend probes using the exact local trace ID, semantic digest, and fixture version.
- [x] Reject incomplete, auth-only, or digest-mismatched receipts.
- [x] Provide stable safe remediation codes for auth and endpoint failures.
- [x] Keep optional OpenAI and Google GenAI wrappers import-safe.
- [x] Keep credentials, probe tokens, and private backend details out of results.

### Cross-repository Phase 9 dependencies

- Contract: `neatlogs-chotu / feature/doctor-v2-contract`
- Backend receipts: `neatlogs-app / feature/sdk-launchreadiness-plan`
- TypeScript Phase 4: neatlogs/neatlogs-typescript#13
- Go Phase 5: neatlogs/neatlogs-go#7
- Wizard consumer: `neatlogs-wizard / feature/launch-readiness-v2`

### Final Phase 9 gates

- [ ] Fix CI dependency wiring: the current matrix cannot import `jsonschema`; lint/test checks are red.
- [ ] Re-run the complete Python 3.10–3.13 CI matrix.
- [ ] Commit/review remaining Doctor contract work and open its PR.
- [ ] Open/review backend and Wizard PRs.
- [ ] Run all three SDK local Doctors and live backend probes simultaneously.
- [ ] Validate every backend stage through visibility and compare backend/local digests.
- [ ] Verify TTL cleanup plus diagnostic exclusion from normal UI, billing, and analytics.
- [ ] Review and merge after all required checks are green.
- [ ] Bump/publish the Python package and verify a clean installation from the published artifact.

## Validation already completed

- [x] Local Python unit suite: 263 passed, 1 skipped.
- [x] Doctor-focused suite: 17/17.
- [x] Manual local Doctor passed with a normalized captured envelope.
- [x] Simultaneous live local backend probe with TypeScript and Go reported successful stages.
- [x] `git diff --check`.

## Merge readiness

Implementation is substantially complete, but this PR is **not merge-ready while CI is red**. The current failure is explicit: `tests/unit/test_telemetry_schema_v2.py` cannot import `jsonschema` in the GitHub Actions test environment.