### PR TITLE
Launch readiness Phase 2: harden shared Python telemetry kernel

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -92,11 +92,13 @@ and telemetry items to a 1 MB capture budget. A truncated value contains its ori
 SHA-256 digest, and `backend_upload_contract_unavailable`; spans/logs also carry
 `neatlogs.capture.*` diagnostics, exposed through `get_delivery_diagnostics()`.
 
-Typed-media metadata is detected without fetching remote content. Generic overflow and large
-typed-media upload remain disabled until the backend provides the authenticated, project-scoped
-upload-session contract. The SDK contains an internal injectable authority seam for contract tests,
-but does not guess an endpoint, issue cloud credentials, retain a permanent object URL, or silently
-send an oversized item through ordinary ingest.
+Typed-media metadata is detected without fetching remote content. Credential-bearing remote
+locators are reduced to scheme/host/path, and large inline media is replaced in captured bodies by
+typed unavailable metadata rather than a base64 prefix. Generic overflow and large typed-media
+upload remain disabled until the backend provides the authenticated, project-scoped upload-session
+contract. The internal test seam accepts success only with a project-scoped, validated `ready`
+receipt whose small reference was exported; it does not make the backend contract complete, guess
+an endpoint, issue cloud credentials, or silently send an oversized item through ordinary ingest.
 
 ---
 

--- a/README.MD
+++ b/README.MD
@@ -84,6 +84,20 @@ For long-running servers (FastAPI, Celery workers), call `init()` once at startu
 
 Full walkthrough: [Your First Trace](https://docs.neatlogs.com/quickstart/your-first-trace).
 
+### Payload delivery status
+
+Normal OTLP batches are byte-limited and gzip-compressed. Deploy and verify gzip-aware trace
+intake before releasing this SDK version. Captured text values are bounded to 100,000 UTF-8 bytes
+and telemetry items to a 1 MB capture budget. A truncated value contains its original byte length,
+SHA-256 digest, and `backend_upload_contract_unavailable`; spans/logs also carry
+`neatlogs.capture.*` diagnostics, exposed through `get_delivery_diagnostics()`.
+
+Typed-media metadata is detected without fetching remote content. Generic overflow and large
+typed-media upload remain disabled until the backend provides the authenticated, project-scoped
+upload-session contract. The SDK contains an internal injectable authority seam for contract tests,
+but does not guess an endpoint, issue cloud credentials, retain a permanent object URL, or silently
+send an oversized item through ordinary ingest.
+
 ---
 
 ## Integrate into your codebase (recommended)

--- a/neatlogs/__init__.py
+++ b/neatlogs/__init__.py
@@ -32,10 +32,11 @@ from .core.crewai_task_registry import register_crewai_task
 from .core.identity import identify
 from .core.llm_binder import bind_templates
 from .core.log import log
+from .core.masking_exporter import MaskContext
 from .core.propagation import extract_trace_context, inject_trace_context
 from .decorators import span
 from .errors import NeatlogsConfigurationError, NeatlogsError
-from .init import flush, flush_all, init, shutdown
+from .init import flush, flush_all, get_delivery_diagnostics, init, shutdown
 from .prompt.client import (
     AsyncPromptClient,
     CachedPrompt,

--- a/neatlogs/_wrap_utils.py
+++ b/neatlogs/_wrap_utils.py
@@ -21,9 +21,15 @@ from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
 
 from .constants import DEFAULT_INGEST_ENDPOINT
+from .core.capture import (
+    DEFAULT_MAX_CAPTURE_VALUE_BYTES,
+    UPLOAD_UNAVAILABLE_REASON,
+    bound_text,
+)
 from .core.logger import get_logger
 
 logger = get_logger()
+_MAX_LEGACY_STREAM_CHUNKS = 1024
 
 _wrapper_tracer: Optional[otel_trace.Tracer] = None
 _wrapper_bootstrapped = False
@@ -869,15 +875,48 @@ def get_provider_tracer() -> "_AutoRootTracer":
     return _AutoRootTracer(get_tracer())
 
 
-def serialize(obj: Any, max_length: Optional[int] = None) -> str:
-    """Safe JSON serialization; truncation is only applied when explicitly requested."""
+def serialize(obj: Any, max_length: Optional[int] = DEFAULT_MAX_CAPTURE_VALUE_BYTES) -> str:
+    """Safe JSON serialization with explicit, byte-aware overflow diagnostics."""
     try:
         s = json.dumps(obj, default=str, ensure_ascii=False)
     except (TypeError, ValueError):
         s = str(obj)
-    if max_length is not None and len(s) > max_length:
-        return s[:max_length] + "...[truncated]"
-    return s
+    return s if max_length is None else bound_text(s, max_length)
+
+
+def _accepts_keyword(callback: Callable, name: str) -> bool:
+    try:
+        parameters = inspect.signature(callback).parameters
+    except (TypeError, ValueError):
+        return False
+    parameter = parameters.get(name)
+    return bool(
+        parameter
+        and parameter.kind
+        in {inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY}
+    ) or any(item.kind is inspect.Parameter.VAR_KEYWORD for item in parameters.values())
+
+
+class _InterruptedSpanProxy:
+    """Keep legacy finalizers from turning an interrupted stream into success."""
+
+    def __init__(self, span: otel_trace.Span) -> None:
+        self._span = span
+
+    def set_status(self, status_or_status_code, *args: Any, **kwargs: Any) -> None:
+        from opentelemetry.trace import Status, StatusCode
+
+        code = (
+            status_or_status_code.status_code
+            if isinstance(status_or_status_code, Status)
+            else status_or_status_code
+        )
+        if code is StatusCode.OK:
+            return
+        self._span.set_status(status_or_status_code, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._span, name)
 
 
 class SyncStreamWrapper:
@@ -894,6 +933,7 @@ class SyncStreamWrapper:
         self._first_chunk_time: Optional[float] = None
         self._incremental = hasattr(finalizer, "on_chunk") and hasattr(finalizer, "finish")
         self._chunks: List[Any] = []
+        self._dropped_chunks = 0
         self._finalized = False
         self._exhausted = False
 
@@ -907,7 +947,9 @@ class SyncStreamWrapper:
                         return
             finally:
                 if not self._finalized:
-                    self.close()
+                    # A loop break abandons this iterator, not the provider-owned
+                    # stream. Finalize telemetry but leave the source resumable.
+                    self._finalize(interrupted=True)
 
         return consume()
 
@@ -924,11 +966,26 @@ class SyncStreamWrapper:
 
         if self._first_chunk_time is None:
             self._first_chunk_time = time.perf_counter()
+        if self._finalized:
+            return chunk
         if self._incremental:
             self._finalizer.on_chunk(self._span, chunk)
-        else:
+        elif len(self._chunks) < _MAX_LEGACY_STREAM_CHUNKS:
             self._chunks.append(chunk)
+        else:
+            self._dropped_chunks += 1
+            self._mark_chunk_overflow()
         return chunk
+
+    def _mark_chunk_overflow(self) -> None:
+        self._span.set_attribute("neatlogs.capture.truncated", True)
+        self._span.set_attribute("neatlogs.capture.truncated_count", self._dropped_chunks)
+        self._span.set_attribute("neatlogs.stream.chunks_dropped", self._dropped_chunks)
+        self._span.set_attribute("neatlogs.capture.overflow.state", "disabled")
+        self._span.set_attribute(
+            "neatlogs.capture.overflow.reason",
+            UPLOAD_UNAVAILABLE_REASON,
+        )
 
     def __enter__(self):
         if hasattr(self._stream, "__enter__"):
@@ -974,7 +1031,21 @@ class SyncStreamWrapper:
         else:
             if interrupted:
                 self._span.set_attribute("neatlogs.stream.cancelled", True)
-            self._finalizer(self._span, self._chunks, elapsed_ms, ttft_ms)
+            if _accepts_keyword(self._finalizer, "interrupted"):
+                self._finalizer(
+                    self._span,
+                    self._chunks,
+                    elapsed_ms,
+                    ttft_ms,
+                    interrupted=interrupted,
+                )
+            else:
+                self._finalizer(
+                    _InterruptedSpanProxy(self._span) if interrupted else self._span,
+                    self._chunks,
+                    elapsed_ms,
+                    ttft_ms,
+                )
 
     def _finalize_error(self, error: BaseException):
         if self._finalized:
@@ -1011,6 +1082,7 @@ class AsyncStreamWrapper:
         self._first_chunk_time: Optional[float] = None
         self._incremental = hasattr(finalizer, "on_chunk") and hasattr(finalizer, "finish")
         self._chunks: List[Any] = []
+        self._dropped_chunks = 0
         self._finalized = False
         self._exhausted = False
 
@@ -1024,7 +1096,9 @@ class AsyncStreamWrapper:
                         return
             finally:
                 if not self._finalized:
-                    await self.aclose()
+                    # Do not transfer ownership of the provider stream to the
+                    # temporary async iterator created for ``async for``.
+                    self._finalize(interrupted=True)
 
         return consume()
 
@@ -1041,11 +1115,26 @@ class AsyncStreamWrapper:
 
         if self._first_chunk_time is None:
             self._first_chunk_time = time.perf_counter()
+        if self._finalized:
+            return chunk
         if self._incremental:
             self._finalizer.on_chunk(self._span, chunk)
-        else:
+        elif len(self._chunks) < _MAX_LEGACY_STREAM_CHUNKS:
             self._chunks.append(chunk)
+        else:
+            self._dropped_chunks += 1
+            self._mark_chunk_overflow()
         return chunk
+
+    def _mark_chunk_overflow(self) -> None:
+        self._span.set_attribute("neatlogs.capture.truncated", True)
+        self._span.set_attribute("neatlogs.capture.truncated_count", self._dropped_chunks)
+        self._span.set_attribute("neatlogs.stream.chunks_dropped", self._dropped_chunks)
+        self._span.set_attribute("neatlogs.capture.overflow.state", "disabled")
+        self._span.set_attribute(
+            "neatlogs.capture.overflow.reason",
+            UPLOAD_UNAVAILABLE_REASON,
+        )
 
     async def __aenter__(self):
         if hasattr(self._stream, "__aenter__"):
@@ -1091,7 +1180,21 @@ class AsyncStreamWrapper:
         else:
             if interrupted:
                 self._span.set_attribute("neatlogs.stream.cancelled", True)
-            self._finalizer(self._span, self._chunks, elapsed_ms, ttft_ms)
+            if _accepts_keyword(self._finalizer, "interrupted"):
+                self._finalizer(
+                    self._span,
+                    self._chunks,
+                    elapsed_ms,
+                    ttft_ms,
+                    interrupted=interrupted,
+                )
+            else:
+                self._finalizer(
+                    _InterruptedSpanProxy(self._span) if interrupted else self._span,
+                    self._chunks,
+                    elapsed_ms,
+                    ttft_ms,
+                )
 
     def _finalize_error(self, error: BaseException):
         if self._finalized:

--- a/neatlogs/_wrap_utils.py
+++ b/neatlogs/_wrap_utils.py
@@ -16,12 +16,11 @@ from contextvars import ContextVar
 from typing import Any, Callable, Dict, List, Mapping, Optional
 from urllib.parse import urlparse
 
-from .constants import DEFAULT_INGEST_ENDPOINT
-
 from opentelemetry import context as context_api
 from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
 
+from .constants import DEFAULT_INGEST_ENDPOINT
 from .core.logger import get_logger
 
 logger = get_logger()
@@ -434,6 +433,7 @@ def _bootstrap_from_env(api_key: str) -> None:
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
     from opentelemetry.sdk.resources import SERVICE_NAME, Resource
     from opentelemetry.sdk.trace import SpanLimits
+
     from .core.byte_limited_exporter import ByteLimitedSpanExporter
     from .core.delivery import DeliveryDiagnostics, ObservableBatchSpanProcessor
     from .core.transport import build_otlp_session

--- a/neatlogs/_wrap_utils.py
+++ b/neatlogs/_wrap_utils.py
@@ -11,6 +11,7 @@ Only contains truly shared concerns:
 import inspect
 import json
 import os
+import sys
 import time
 from contextvars import ContextVar
 from typing import Any, Callable, Dict, List, Mapping, Optional
@@ -29,7 +30,7 @@ from .core.capture import (
 from .core.logger import get_logger
 
 logger = get_logger()
-_MAX_LEGACY_STREAM_CHUNKS = 1024
+_MAX_LEGACY_STREAM_BYTES = 1_000_000
 
 _wrapper_tracer: Optional[otel_trace.Tracer] = None
 _wrapper_bootstrapped = False
@@ -877,8 +878,10 @@ def get_provider_tracer() -> "_AutoRootTracer":
 
 def serialize(obj: Any, max_length: Optional[int] = DEFAULT_MAX_CAPTURE_VALUE_BYTES) -> str:
     """Safe JSON serialization with explicit, byte-aware overflow diagnostics."""
+    from .core.media import sanitize_media_payload
+
     try:
-        s = json.dumps(obj, default=str, ensure_ascii=False)
+        s = json.dumps(sanitize_media_payload(obj), default=str, ensure_ascii=False)
     except (TypeError, ValueError):
         s = str(obj)
     return s if max_length is None else bound_text(s, max_length)
@@ -919,6 +922,56 @@ class _InterruptedSpanProxy:
         return getattr(self._span, name)
 
 
+def _bounded_object_size(value: Any, limit: int, seen: Optional[set[int]] = None) -> int:
+    """Estimate retained chunk bytes without materializing an unbounded serialization."""
+
+    if limit < 0:
+        return 0
+    if seen is None:
+        seen = set()
+    if isinstance(value, str):
+        total = 0
+        for offset in range(0, len(value), 4096):
+            total += len(value[offset : offset + 4096].encode("utf-8"))
+            if total > limit:
+                return limit + 1
+        return total
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return min(len(value), limit + 1)
+    if value is None or isinstance(value, (bool, int, float)):
+        return min(sys.getsizeof(value), limit + 1)
+
+    identity = id(value)
+    if identity in seen:
+        return 0
+    seen.add(identity)
+    total = min(sys.getsizeof(value), limit + 1)
+    if total > limit:
+        return total
+
+    if isinstance(value, Mapping):
+        children = value.items()
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        children = ((None, item) for item in value)
+    elif hasattr(value, "__dict__"):
+        children = vars(value).items()
+    else:
+        slots = getattr(type(value), "__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        children = ((slot, getattr(value, slot)) for slot in slots if hasattr(value, slot))
+
+    for key, item in children:
+        if key is not None:
+            total += _bounded_object_size(key, limit - total, seen)
+        if total > limit:
+            return limit + 1
+        total += _bounded_object_size(item, limit - total, seen)
+        if total > limit:
+            return limit + 1
+    return total
+
+
 class SyncStreamWrapper:
     """
     Wraps a sync streaming response. Transparently passes through chunks
@@ -933,6 +986,7 @@ class SyncStreamWrapper:
         self._first_chunk_time: Optional[float] = None
         self._incremental = hasattr(finalizer, "on_chunk") and hasattr(finalizer, "finish")
         self._chunks: List[Any] = []
+        self._chunk_bytes = 0
         self._dropped_chunks = 0
         self._finalized = False
         self._exhausted = False
@@ -970,17 +1024,25 @@ class SyncStreamWrapper:
             return chunk
         if self._incremental:
             self._finalizer.on_chunk(self._span, chunk)
-        elif len(self._chunks) < _MAX_LEGACY_STREAM_CHUNKS:
-            self._chunks.append(chunk)
         else:
-            self._dropped_chunks += 1
-            self._mark_chunk_overflow()
+            chunk_bytes = _bounded_object_size(
+                chunk,
+                _MAX_LEGACY_STREAM_BYTES - self._chunk_bytes,
+            )
+            if self._chunk_bytes + chunk_bytes <= _MAX_LEGACY_STREAM_BYTES:
+                self._chunks.append(chunk)
+                self._chunk_bytes += chunk_bytes
+            else:
+                self._dropped_chunks += 1
+                self._mark_chunk_overflow()
         return chunk
 
     def _mark_chunk_overflow(self) -> None:
         self._span.set_attribute("neatlogs.capture.truncated", True)
         self._span.set_attribute("neatlogs.capture.truncated_count", self._dropped_chunks)
         self._span.set_attribute("neatlogs.stream.chunks_dropped", self._dropped_chunks)
+        self._span.set_attribute("neatlogs.stream.capture_incomplete", True)
+        self._span.set_attribute("neatlogs.stream.bytes_retained", self._chunk_bytes)
         self._span.set_attribute("neatlogs.capture.overflow.state", "disabled")
         self._span.set_attribute(
             "neatlogs.capture.overflow.reason",
@@ -1031,9 +1093,14 @@ class SyncStreamWrapper:
         else:
             if interrupted:
                 self._span.set_attribute("neatlogs.stream.cancelled", True)
+            finalizer_span = (
+                _InterruptedSpanProxy(self._span)
+                if interrupted or self._dropped_chunks
+                else self._span
+            )
             if _accepts_keyword(self._finalizer, "interrupted"):
                 self._finalizer(
-                    self._span,
+                    finalizer_span,
                     self._chunks,
                     elapsed_ms,
                     ttft_ms,
@@ -1041,7 +1108,7 @@ class SyncStreamWrapper:
                 )
             else:
                 self._finalizer(
-                    _InterruptedSpanProxy(self._span) if interrupted else self._span,
+                    finalizer_span,
                     self._chunks,
                     elapsed_ms,
                     ttft_ms,
@@ -1082,6 +1149,7 @@ class AsyncStreamWrapper:
         self._first_chunk_time: Optional[float] = None
         self._incremental = hasattr(finalizer, "on_chunk") and hasattr(finalizer, "finish")
         self._chunks: List[Any] = []
+        self._chunk_bytes = 0
         self._dropped_chunks = 0
         self._finalized = False
         self._exhausted = False
@@ -1119,17 +1187,25 @@ class AsyncStreamWrapper:
             return chunk
         if self._incremental:
             self._finalizer.on_chunk(self._span, chunk)
-        elif len(self._chunks) < _MAX_LEGACY_STREAM_CHUNKS:
-            self._chunks.append(chunk)
         else:
-            self._dropped_chunks += 1
-            self._mark_chunk_overflow()
+            chunk_bytes = _bounded_object_size(
+                chunk,
+                _MAX_LEGACY_STREAM_BYTES - self._chunk_bytes,
+            )
+            if self._chunk_bytes + chunk_bytes <= _MAX_LEGACY_STREAM_BYTES:
+                self._chunks.append(chunk)
+                self._chunk_bytes += chunk_bytes
+            else:
+                self._dropped_chunks += 1
+                self._mark_chunk_overflow()
         return chunk
 
     def _mark_chunk_overflow(self) -> None:
         self._span.set_attribute("neatlogs.capture.truncated", True)
         self._span.set_attribute("neatlogs.capture.truncated_count", self._dropped_chunks)
         self._span.set_attribute("neatlogs.stream.chunks_dropped", self._dropped_chunks)
+        self._span.set_attribute("neatlogs.stream.capture_incomplete", True)
+        self._span.set_attribute("neatlogs.stream.bytes_retained", self._chunk_bytes)
         self._span.set_attribute("neatlogs.capture.overflow.state", "disabled")
         self._span.set_attribute(
             "neatlogs.capture.overflow.reason",
@@ -1180,9 +1256,14 @@ class AsyncStreamWrapper:
         else:
             if interrupted:
                 self._span.set_attribute("neatlogs.stream.cancelled", True)
+            finalizer_span = (
+                _InterruptedSpanProxy(self._span)
+                if interrupted or self._dropped_chunks
+                else self._span
+            )
             if _accepts_keyword(self._finalizer, "interrupted"):
                 self._finalizer(
-                    self._span,
+                    finalizer_span,
                     self._chunks,
                     elapsed_ms,
                     ttft_ms,
@@ -1190,7 +1271,7 @@ class AsyncStreamWrapper:
                 )
             else:
                 self._finalizer(
-                    _InterruptedSpanProxy(self._span) if interrupted else self._span,
+                    finalizer_span,
                     self._chunks,
                     elapsed_ms,
                     ttft_ms,

--- a/neatlogs/_wrap_utils.py
+++ b/neatlogs/_wrap_utils.py
@@ -16,6 +16,8 @@ from contextvars import ContextVar
 from typing import Any, Callable, Dict, List, Mapping, Optional
 from urllib.parse import urlparse
 
+from .constants import DEFAULT_INGEST_ENDPOINT
+
 from opentelemetry import context as context_api
 from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -103,7 +105,7 @@ def _normalize_traces_endpoint(endpoint: str) -> str:
     """Convert a Neatlogs base endpoint into the OTLP traces endpoint."""
     raw = (endpoint or "").strip().rstrip("/")
     if not raw:
-        raw = "https://ingest.neatlogs.com"
+        raw = DEFAULT_INGEST_ENDPOINT
 
     if raw.endswith("/v1/traces"):
         return raw
@@ -428,13 +430,16 @@ def neatlogs_span(scope: str, name: str, **start_kwargs: Any) -> "_NeatlogsSpanC
 
 
 def _bootstrap_from_env(api_key: str) -> None:
+    from opentelemetry.exporter.otlp.proto.http import Compression
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
     from opentelemetry.sdk.resources import SERVICE_NAME, Resource
     from opentelemetry.sdk.trace import SpanLimits
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from .core.byte_limited_exporter import ByteLimitedSpanExporter
+    from .core.delivery import DeliveryDiagnostics, ObservableBatchSpanProcessor
+    from .core.transport import build_otlp_session
 
     endpoint = _wrapper_config.get("endpoint") or os.environ.get(
-        "NEATLOGS_ENDPOINT", "https://ingest.neatlogs.com"
+        "NEATLOGS_ENDPOINT", DEFAULT_INGEST_ENDPOINT
     )
     endpoint = _normalize_traces_endpoint(endpoint)
 
@@ -456,8 +461,16 @@ def _bootstrap_from_env(api_key: str) -> None:
     exporter = OTLPSpanExporter(
         endpoint=endpoint,
         headers={"x-api-key": api_key},
+        compression=Compression.Gzip,
+        session=build_otlp_session(),
     )
-    provider.add_span_processor(BatchSpanProcessor(exporter))
+    diagnostics = DeliveryDiagnostics()
+    provider.add_span_processor(
+        ObservableBatchSpanProcessor(
+            ByteLimitedSpanExporter(exporter, diagnostics=diagnostics),
+            diagnostics=diagnostics,
+        )
+    )
     set_neatlogs_provider(provider)
     logger.debug(f"neatlogs wrapper: auto-bootstrapped private TracerProvider → {endpoint}")
 
@@ -856,13 +869,13 @@ def get_provider_tracer() -> "_AutoRootTracer":
     return _AutoRootTracer(get_tracer())
 
 
-def serialize(obj: Any, max_length: int = 100_000) -> str:
-    """Safe JSON serialization with truncation."""
+def serialize(obj: Any, max_length: Optional[int] = None) -> str:
+    """Safe JSON serialization; truncation is only applied when explicitly requested."""
     try:
         s = json.dumps(obj, default=str, ensure_ascii=False)
     except (TypeError, ValueError):
         s = str(obj)
-    if len(s) > max_length:
+    if max_length is not None and len(s) > max_length:
         return s[:max_length] + "...[truncated]"
     return s
 
@@ -879,25 +892,42 @@ class SyncStreamWrapper:
         self._finalizer = finalizer
         self._start_time = time.perf_counter()
         self._first_chunk_time: Optional[float] = None
+        self._incremental = hasattr(finalizer, "on_chunk") and hasattr(finalizer, "finish")
         self._chunks: List[Any] = []
         self._finalized = False
+        self._exhausted = False
 
     def __iter__(self):
-        return self
+        def consume():
+            try:
+                while True:
+                    try:
+                        yield self.__next__()
+                    except StopIteration:
+                        return
+            finally:
+                if not self._finalized:
+                    self.close()
+
+        return consume()
 
     def __next__(self):
         try:
             chunk = next(self._stream)
         except StopIteration:
-            self._finalize()
+            self._exhausted = True
+            self._finalize(interrupted=False)
             raise
-        except Exception as e:
+        except BaseException as e:
             self._finalize_error(e)
             raise
 
         if self._first_chunk_time is None:
             self._first_chunk_time = time.perf_counter()
-        self._chunks.append(chunk)
+        if self._incremental:
+            self._finalizer.on_chunk(self._span, chunk)
+        else:
+            self._chunks.append(chunk)
         return chunk
 
     def __enter__(self):
@@ -905,12 +935,28 @@ class SyncStreamWrapper:
             self._stream.__enter__()
         return self
 
-    def __exit__(self, *args):
-        if hasattr(self._stream, "__exit__"):
-            self._stream.__exit__(*args)
-        self._finalize()
+    def __exit__(self, exc_type, exc, tb):
+        try:
+            if hasattr(self._stream, "__exit__"):
+                self._stream.__exit__(exc_type, exc, tb)
+        except BaseException as close_error:
+            self._finalize_error(close_error)
+            raise
+        if exc is not None:
+            self._finalize_error(exc)
+        else:
+            self._finalize(interrupted=not self._exhausted)
 
-    def _finalize(self):
+    def close(self):
+        try:
+            if hasattr(self._stream, "close"):
+                self._stream.close()
+        except BaseException as close_error:
+            self._finalize_error(close_error)
+            raise
+        self._finalize(interrupted=not self._exhausted)
+
+    def _finalize(self, *, interrupted: bool):
         if self._finalized:
             return
         self._finalized = True
@@ -918,16 +964,34 @@ class SyncStreamWrapper:
         ttft_ms = None
         if self._first_chunk_time is not None:
             ttft_ms = (self._first_chunk_time - self._start_time) * 1000
-        self._finalizer(self._span, self._chunks, elapsed_ms, ttft_ms)
+        if self._incremental:
+            self._finalizer.finish(
+                self._span,
+                elapsed_ms,
+                ttft_ms,
+                interrupted=interrupted,
+            )
+        else:
+            if interrupted:
+                self._span.set_attribute("neatlogs.stream.cancelled", True)
+            self._finalizer(self._span, self._chunks, elapsed_ms, ttft_ms)
 
-    def _finalize_error(self, error: Exception):
+    def _finalize_error(self, error: BaseException):
         if self._finalized:
             return
         self._finalized = True
+        if self._incremental and hasattr(self._finalizer, "fail"):
+            self._finalizer.fail(self._span, error)
+            return
         from opentelemetry.trace import StatusCode
 
-        self._span.set_status(StatusCode.ERROR, str(error))
-        self._span.record_exception(error)
+        if error.__class__.__name__ in {"CancelledError", "GeneratorExit"}:
+            self._span.set_attribute("neatlogs.stream.cancelled", True)
+            self._span.set_status(StatusCode.UNSET)
+        else:
+            self._span.set_status(StatusCode.ERROR, str(error))
+            if isinstance(error, Exception):
+                self._span.record_exception(error)
         self._span.end()
 
     def __getattr__(self, name):
@@ -945,25 +1009,42 @@ class AsyncStreamWrapper:
         self._finalizer = finalizer
         self._start_time = time.perf_counter()
         self._first_chunk_time: Optional[float] = None
+        self._incremental = hasattr(finalizer, "on_chunk") and hasattr(finalizer, "finish")
         self._chunks: List[Any] = []
         self._finalized = False
+        self._exhausted = False
 
     def __aiter__(self):
-        return self
+        async def consume():
+            try:
+                while True:
+                    try:
+                        yield await self.__anext__()
+                    except StopAsyncIteration:
+                        return
+            finally:
+                if not self._finalized:
+                    await self.aclose()
+
+        return consume()
 
     async def __anext__(self):
         try:
             chunk = await self._stream.__anext__()
         except StopAsyncIteration:
-            self._finalize()
+            self._exhausted = True
+            self._finalize(interrupted=False)
             raise
-        except Exception as e:
+        except BaseException as e:
             self._finalize_error(e)
             raise
 
         if self._first_chunk_time is None:
             self._first_chunk_time = time.perf_counter()
-        self._chunks.append(chunk)
+        if self._incremental:
+            self._finalizer.on_chunk(self._span, chunk)
+        else:
+            self._chunks.append(chunk)
         return chunk
 
     async def __aenter__(self):
@@ -971,12 +1052,28 @@ class AsyncStreamWrapper:
             await self._stream.__aenter__()
         return self
 
-    async def __aexit__(self, *args):
-        if hasattr(self._stream, "__aexit__"):
-            await self._stream.__aexit__(*args)
-        self._finalize()
+    async def __aexit__(self, exc_type, exc, tb):
+        try:
+            if hasattr(self._stream, "__aexit__"):
+                await self._stream.__aexit__(exc_type, exc, tb)
+        except BaseException as close_error:
+            self._finalize_error(close_error)
+            raise
+        if exc is not None:
+            self._finalize_error(exc)
+        else:
+            self._finalize(interrupted=not self._exhausted)
 
-    def _finalize(self):
+    async def aclose(self):
+        try:
+            if hasattr(self._stream, "aclose"):
+                await self._stream.aclose()
+        except BaseException as close_error:
+            self._finalize_error(close_error)
+            raise
+        self._finalize(interrupted=not self._exhausted)
+
+    def _finalize(self, *, interrupted: bool):
         if self._finalized:
             return
         self._finalized = True
@@ -984,16 +1081,34 @@ class AsyncStreamWrapper:
         ttft_ms = None
         if self._first_chunk_time is not None:
             ttft_ms = (self._first_chunk_time - self._start_time) * 1000
-        self._finalizer(self._span, self._chunks, elapsed_ms, ttft_ms)
+        if self._incremental:
+            self._finalizer.finish(
+                self._span,
+                elapsed_ms,
+                ttft_ms,
+                interrupted=interrupted,
+            )
+        else:
+            if interrupted:
+                self._span.set_attribute("neatlogs.stream.cancelled", True)
+            self._finalizer(self._span, self._chunks, elapsed_ms, ttft_ms)
 
-    def _finalize_error(self, error: Exception):
+    def _finalize_error(self, error: BaseException):
         if self._finalized:
             return
         self._finalized = True
+        if self._incremental and hasattr(self._finalizer, "fail"):
+            self._finalizer.fail(self._span, error)
+            return
         from opentelemetry.trace import StatusCode
 
-        self._span.set_status(StatusCode.ERROR, str(error))
-        self._span.record_exception(error)
+        if error.__class__.__name__ in {"CancelledError", "GeneratorExit"}:
+            self._span.set_attribute("neatlogs.stream.cancelled", True)
+            self._span.set_status(StatusCode.UNSET)
+        else:
+            self._span.set_status(StatusCode.ERROR, str(error))
+            if isinstance(error, Exception):
+                self._span.record_exception(error)
         self._span.end()
 
     def __getattr__(self, name):

--- a/neatlogs/anthropic.py
+++ b/neatlogs/anthropic.py
@@ -344,7 +344,12 @@ def _set_usage_attributes(span: Any, usage: Any) -> None:
 
 
 def _finalize_stream(
-    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+    span: Any,
+    chunks: List[Any],
+    duration_ms: float,
+    ttft_ms: Optional[float],
+    *,
+    interrupted: bool = False,
 ) -> None:
     """Finalize a streaming response span from accumulated Anthropic stream events."""
     text_parts: List[str] = []
@@ -445,7 +450,7 @@ def _finalize_stream(
                 round(duration_ms - ttft_ms, 3),
             )
 
-    span.set_status(StatusCode.OK)
+    span.set_status(StatusCode.UNSET if interrupted else StatusCode.OK)
     span.end()
 
 

--- a/neatlogs/azure_openai.py
+++ b/neatlogs/azure_openai.py
@@ -415,7 +415,12 @@ def _finalize_response(span: Any, response: Any, duration_ms: float) -> None:
 
 
 def _finalize_stream(
-    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+    span: Any,
+    chunks: List[Any],
+    duration_ms: float,
+    ttft_ms: Optional[float],
+    *,
+    interrupted: bool = False,
 ) -> None:
     text_parts: List[str] = []
     tool_calls_acc: dict = {}
@@ -484,7 +489,7 @@ def _finalize_stream(
                 round(duration_ms - ttft_ms, 3),
             )
 
-    span.set_status(StatusCode.OK)
+    span.set_status(StatusCode.UNSET if interrupted else StatusCode.OK)
     span.end()
 
 
@@ -510,7 +515,12 @@ def _finalize_responses_response(span: Any, response: Any, duration_ms: float) -
 
 
 def _finalize_responses_stream(
-    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+    span: Any,
+    chunks: List[Any],
+    duration_ms: float,
+    ttft_ms: Optional[float],
+    *,
+    interrupted: bool = False,
 ) -> None:
     text_parts: List[str] = []
     model = None
@@ -542,7 +552,7 @@ def _finalize_responses_stream(
     span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
     if ttft_ms is not None:
         span.set_attribute("neatlogs.llm.metrics.ttft_ms", round(ttft_ms, 3))
-    span.set_status(StatusCode.OK)
+    span.set_status(StatusCode.UNSET if interrupted else StatusCode.OK)
     span.end()
 
 

--- a/neatlogs/client.py
+++ b/neatlogs/client.py
@@ -34,7 +34,7 @@ from .constants import DEFAULT_INGEST_ENDPOINT, export_queue_capacity
 from .core.byte_limited_exporter import ByteLimitedSpanExporter
 from .core.byte_limited_log_exporter import ByteLimitedLogExporter
 from .core.client_registry import register_client, unregister_client
-from .core.deadline import bounded_call
+from .core.deadline import DeadlineWorker, bounded_call
 from .core.delivery import (
     DeliveryDiagnostics,
     ObservableBatchLogRecordProcessor,
@@ -212,6 +212,10 @@ class Client:
                     )
                 )
 
+        # Start the shutdown worker only after construction succeeds, but before
+        # registering the atexit hook that depends on it. Python 3.12 forbids
+        # starting a new thread once interpreter finalization has begun.
+        self._shutdown_worker = DeadlineWorker(f"neatlogs-client-shutdown-{id(self):x}")
         atexit.register(self._atexit_shutdown)
         register_client(self)
 
@@ -277,7 +281,10 @@ class Client:
             if self._state == "closed":
                 return self._shutdown_result
             if self._state == "closing":
-                if self._shutdown_owner == threading.get_ident():
+                if (
+                    self._shutdown_owner == threading.get_ident()
+                    or self._shutdown_worker.is_current()
+                ):
                     return self._shutdown_result
                 completed = self._state_changed.wait_for(
                     lambda: self._state == "closed",
@@ -308,6 +315,7 @@ class Client:
                 atexit.unregister(self._atexit_shutdown)
             except Exception:
                 pass
+            self._shutdown_worker.close()
             unregister_client(self)
 
     def _atexit_shutdown(self) -> None:
@@ -330,25 +338,35 @@ class Client:
                 self.log_provider.shutdown,
                 deadline,
                 synchronous=synchronous,
+                worker=self._shutdown_worker,
             )
             success = completed and success
-        try:
-            self._span_processor.end_active_spans(termination_reason)
-        except Exception:
+        completed, _ = bounded_call(
+            lambda: self._span_processor.end_active_spans(termination_reason),
+            deadline,
+            synchronous=synchronous,
+            worker=self._shutdown_worker,
+        )
+        if not completed:
             success = False
         remaining_millis = max(0, int((deadline - time.monotonic()) * 1000))
         if not self._span_processor.wait_for_downstream(remaining_millis):
             success = False
         if self._completion_processor is not None:
-            try:
-                self._completion_processor.emit_deferred()
-            except Exception:
+            completed, _ = bounded_call(
+                self._completion_processor.emit_deferred,
+                deadline,
+                synchronous=synchronous,
+                worker=self._shutdown_worker,
+            )
+            if not completed:
                 success = False
         if self._owns_provider:
             completed, _ = bounded_call(
                 self.tracer_provider.shutdown,
                 deadline,
                 synchronous=synchronous,
+                worker=self._shutdown_worker,
             )
             success = completed and success
         else:
@@ -358,6 +376,7 @@ class Client:
                 ),
                 deadline,
                 synchronous=synchronous,
+                worker=self._shutdown_worker,
             )
             success = completed and (result is None or bool(result)) and success
             for processor in reversed(self._transport_processors):
@@ -365,12 +384,14 @@ class Client:
                     processor.shutdown,
                     deadline,
                     synchronous=synchronous,
+                    worker=self._shutdown_worker,
                 )
                 success = completed and success
             completed, _ = bounded_call(
                 self._span_processor.shutdown,
                 deadline,
                 synchronous=synchronous,
+                worker=self._shutdown_worker,
             )
             success = completed and success
 

--- a/neatlogs/client.py
+++ b/neatlogs/client.py
@@ -32,6 +32,7 @@ from ._wrap_utils import (
 )
 from .constants import DEFAULT_INGEST_ENDPOINT, export_queue_capacity
 from .core.byte_limited_exporter import ByteLimitedSpanExporter
+from .core.byte_limited_log_exporter import ByteLimitedLogExporter
 from .core.client_registry import register_client, unregister_client
 from .core.deadline import bounded_call
 from .core.delivery import (
@@ -196,7 +197,10 @@ class Client:
                     NeatlogsLogFilter(
                         ObservableBatchLogRecordProcessor(
                             MaskingLogExporter(
-                                log_exporter,
+                                ByteLimitedLogExporter(
+                                    log_exporter,
+                                    diagnostics=self._delivery_diagnostics,
+                                ),
                                 mask,
                                 diagnostics=self._delivery_diagnostics,
                             ),
@@ -208,7 +212,7 @@ class Client:
                     )
                 )
 
-        atexit.register(self.shutdown)
+        atexit.register(self._atexit_shutdown)
         register_client(self)
 
     def get_tracer(self, scope: str):
@@ -226,7 +230,7 @@ class Client:
         with self._state_changed:
             return self._state == "running"
 
-    def get_delivery_diagnostics(self) -> dict[str, int]:
+    def get_delivery_diagnostics(self) -> dict[str, Any]:
         return self._delivery_diagnostics.snapshot()
 
     @contextlib.contextmanager
@@ -266,6 +270,8 @@ class Client:
         self,
         timeout_millis: int = 30000,
         termination_reason: str = "shutdown",
+        *,
+        _synchronous: bool = False,
     ) -> bool:
         with self._state_changed:
             if self._state == "closed":
@@ -286,7 +292,11 @@ class Client:
         self._span_processor.begin_shutdown(termination_reason)
         success = False
         try:
-            success = self._perform_shutdown(timeout_millis, termination_reason)
+            success = self._perform_shutdown(
+                timeout_millis,
+                termination_reason,
+                synchronous=_synchronous,
+            )
             return success
         finally:
             with self._state_changed:
@@ -295,17 +305,32 @@ class Client:
                 self._shutdown_owner = None
                 self._state_changed.notify_all()
             try:
-                atexit.unregister(self.shutdown)
+                atexit.unregister(self._atexit_shutdown)
             except Exception:
                 pass
             unregister_client(self)
 
-    def _perform_shutdown(self, timeout_millis: int, termination_reason: str) -> bool:
+    def _atexit_shutdown(self) -> None:
+        """Synchronous interpreter-exit cleanup (Python 3.12 forbids new threads)."""
+
+        self.shutdown(_synchronous=True)
+
+    def _perform_shutdown(
+        self,
+        timeout_millis: int,
+        termination_reason: str,
+        *,
+        synchronous: bool = False,
+    ) -> bool:
         success = True
         deadline = time.monotonic() + max(0, timeout_millis) / 1000
         # Drain logs before ending roots: root end creates the completion marker.
         if self.log_provider is not None:
-            completed, _ = bounded_call(self.log_provider.shutdown, deadline)
+            completed, _ = bounded_call(
+                self.log_provider.shutdown,
+                deadline,
+                synchronous=synchronous,
+            )
             success = completed and success
         try:
             self._span_processor.end_active_spans(termination_reason)
@@ -320,7 +345,11 @@ class Client:
             except Exception:
                 success = False
         if self._owns_provider:
-            completed, _ = bounded_call(self.tracer_provider.shutdown, deadline)
+            completed, _ = bounded_call(
+                self.tracer_provider.shutdown,
+                deadline,
+                synchronous=synchronous,
+            )
             success = completed and success
         else:
             completed, result = bounded_call(
@@ -328,12 +357,21 @@ class Client:
                     timeout_millis=max(0, int((deadline - time.monotonic()) * 1000))
                 ),
                 deadline,
+                synchronous=synchronous,
             )
             success = completed and (result is None or bool(result)) and success
             for processor in reversed(self._transport_processors):
-                completed, _ = bounded_call(processor.shutdown, deadline)
+                completed, _ = bounded_call(
+                    processor.shutdown,
+                    deadline,
+                    synchronous=synchronous,
+                )
                 success = completed and success
-            completed, _ = bounded_call(self._span_processor.shutdown, deadline)
+            completed, _ = bounded_call(
+                self._span_processor.shutdown,
+                deadline,
+                synchronous=synchronous,
+            )
             success = completed and success
 
         return success

--- a/neatlogs/client.py
+++ b/neatlogs/client.py
@@ -11,17 +11,17 @@ import atexit
 import contextlib
 import math
 import threading
+import time
 from collections.abc import Iterator
 from typing import Any, Callable
 from urllib.parse import urlparse
 
 from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk._logs import LoggerProvider
-from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import SpanLimits, TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
 
 from ._wrap_utils import (
@@ -31,9 +31,18 @@ from ._wrap_utils import (
     reset_active_client,
 )
 from .core.client_registry import register_client, unregister_client
+from .core.deadline import bounded_call
 from .core.log_exporter import NeatlogsLogFilter
 from .core.masking_exporter import MaskingLogExporter, MaskingSpanExporter
+from .constants import DEFAULT_INGEST_ENDPOINT, export_queue_capacity
+from .core.byte_limited_exporter import ByteLimitedSpanExporter
+from .core.delivery import (
+    DeliveryDiagnostics,
+    ObservableBatchLogRecordProcessor,
+    ObservableBatchSpanProcessor,
+)
 from .core.span_processor import CompletionMarkerSpanProcessor, NeatlogsSpanProcessor
+from .core.transport import build_otlp_session
 from .errors import NeatlogsConfigurationError
 from .version import __version__
 
@@ -67,7 +76,7 @@ class Client:
         *,
         api_key: str,
         workflow_name: str,
-        endpoint: str = "https://ingest.neatlogs.com",
+        endpoint: str = DEFAULT_INGEST_ENDPOINT,
         tags: list[str] | None = None,
         capture_logs: bool = False,
         batch_size: int = 100,
@@ -107,6 +116,7 @@ class Client:
         self._state_changed = threading.Condition(threading.RLock())
         self._owns_provider = tracer_provider is None
         self._tracers: dict[str, Any] = {}
+        self._delivery_diagnostics = DeliveryDiagnostics()
 
         resource_attrs: dict[str, Any] = {
             SERVICE_NAME: name,
@@ -147,11 +157,19 @@ class Client:
             exporter = OTLPSpanExporter(
                 endpoint=traces_endpoint,
                 headers={"x-api-key": key},
+                compression=Compression.Gzip,
+                session=build_otlp_session(),
             )
-            batch_processor = BatchSpanProcessor(
-                MaskingSpanExporter(exporter, mask),
+            batch_processor = ObservableBatchSpanProcessor(
+                MaskingSpanExporter(
+                    ByteLimitedSpanExporter(exporter, diagnostics=self._delivery_diagnostics),
+                    mask,
+                    diagnostics=self._delivery_diagnostics,
+                ),
                 max_export_batch_size=batch_size,
+                max_queue_size=export_queue_capacity(batch_size),
                 schedule_delay_millis=int(flush_interval * 1000),
+                diagnostics=self._delivery_diagnostics,
             )
             completion_processor = CompletionMarkerSpanProcessor(
                 self._span_processor,
@@ -171,10 +189,22 @@ class Client:
                 log_exporter = OTLPLogExporter(
                     endpoint=f"{base_url}/v1/logs",
                     headers={"x-api-key": key},
+                    compression=Compression.Gzip,
+                    session=build_otlp_session(),
                 )
                 self.log_provider.add_log_record_processor(
                     NeatlogsLogFilter(
-                        BatchLogRecordProcessor(MaskingLogExporter(log_exporter, mask))
+                        ObservableBatchLogRecordProcessor(
+                            MaskingLogExporter(
+                                log_exporter,
+                                mask,
+                                diagnostics=self._delivery_diagnostics,
+                            ),
+                            max_export_batch_size=batch_size,
+                            max_queue_size=export_queue_capacity(batch_size),
+                            schedule_delay_millis=int(flush_interval * 1000),
+                            diagnostics=self._delivery_diagnostics,
+                        )
                     )
                 )
 
@@ -195,6 +225,9 @@ class Client:
     def _is_running(self) -> bool:
         with self._state_changed:
             return self._state == "running"
+
+    def get_delivery_diagnostics(self) -> dict[str, int]:
+        return self._delivery_diagnostics.snapshot()
 
     @contextlib.contextmanager
     def activate(self) -> Iterator[Client]:
@@ -240,8 +273,11 @@ class Client:
             if self._state == "closing":
                 if self._shutdown_owner == threading.get_ident():
                     return self._shutdown_result
-                self._state_changed.wait_for(lambda: self._state == "closed")
-                return self._shutdown_result
+                completed = self._state_changed.wait_for(
+                    lambda: self._state == "closed",
+                    timeout=max(0, timeout_millis) / 1000,
+                )
+                return self._shutdown_result if completed else False
             self._state = "closing"
             self._shutdown_owner = threading.get_ident()
 
@@ -266,17 +302,17 @@ class Client:
 
     def _perform_shutdown(self, timeout_millis: int, termination_reason: str) -> bool:
         success = True
+        deadline = time.monotonic() + max(0, timeout_millis) / 1000
         # Drain logs before ending roots: root end creates the completion marker.
         if self.log_provider is not None:
-            try:
-                self.log_provider.shutdown()
-            except Exception:
-                success = False
+            completed, _ = bounded_call(self.log_provider.shutdown, deadline)
+            success = completed and success
         try:
             self._span_processor.end_active_spans(termination_reason)
         except Exception:
             success = False
-        if not self._span_processor.wait_for_downstream(timeout_millis):
+        remaining_millis = max(0, int((deadline - time.monotonic()) * 1000))
+        if not self._span_processor.wait_for_downstream(remaining_millis):
             success = False
         if self._completion_processor is not None:
             try:
@@ -284,25 +320,21 @@ class Client:
             except Exception:
                 success = False
         if self._owns_provider:
-            try:
-                self.tracer_provider.shutdown()
-            except Exception:
-                success = False
+            completed, _ = bounded_call(self.tracer_provider.shutdown, deadline)
+            success = completed and success
         else:
-            try:
-                result = self.tracer_provider.force_flush(timeout_millis=timeout_millis)
-                success = bool(result) and success
-            except Exception:
-                success = False
+            completed, result = bounded_call(
+                lambda: self.tracer_provider.force_flush(
+                    timeout_millis=max(0, int((deadline - time.monotonic()) * 1000))
+                ),
+                deadline,
+            )
+            success = completed and (result is None or bool(result)) and success
             for processor in reversed(self._transport_processors):
-                try:
-                    processor.shutdown()
-                except Exception:
-                    success = False
-            try:
-                self._span_processor.shutdown()
-            except Exception:
-                success = False
+                completed, _ = bounded_call(processor.shutdown, deadline)
+                success = completed and success
+            completed, _ = bounded_call(self._span_processor.shutdown, deadline)
+            success = completed and success
 
         return success
 

--- a/neatlogs/client.py
+++ b/neatlogs/client.py
@@ -30,17 +30,17 @@ from ._wrap_utils import (
     activate_client,
     reset_active_client,
 )
-from .core.client_registry import register_client, unregister_client
-from .core.deadline import bounded_call
-from .core.log_exporter import NeatlogsLogFilter
-from .core.masking_exporter import MaskingLogExporter, MaskingSpanExporter
 from .constants import DEFAULT_INGEST_ENDPOINT, export_queue_capacity
 from .core.byte_limited_exporter import ByteLimitedSpanExporter
+from .core.client_registry import register_client, unregister_client
+from .core.deadline import bounded_call
 from .core.delivery import (
     DeliveryDiagnostics,
     ObservableBatchLogRecordProcessor,
     ObservableBatchSpanProcessor,
 )
+from .core.log_exporter import NeatlogsLogFilter
+from .core.masking_exporter import MaskingLogExporter, MaskingSpanExporter
 from .core.span_processor import CompletionMarkerSpanProcessor, NeatlogsSpanProcessor
 from .core.transport import build_otlp_session
 from .errors import NeatlogsConfigurationError

--- a/neatlogs/constants.py
+++ b/neatlogs/constants.py
@@ -1,0 +1,10 @@
+"""Stable SDK-wide defaults shared by every NeatLogs entry point."""
+
+DEFAULT_INGEST_ENDPOINT = "https://ingest.neatlogs.com"
+DEFAULT_MAX_QUEUE_ITEMS = 2048
+
+
+def export_queue_capacity(batch_size: int) -> int:
+    """Keep queues bounded while ensuring a configured batch always fits."""
+
+    return max(DEFAULT_MAX_QUEUE_ITEMS, batch_size * 4)

--- a/neatlogs/core/byte_limited_exporter.py
+++ b/neatlogs/core/byte_limited_exporter.py
@@ -12,7 +12,12 @@ from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
 from .capture import limit_span_capture
 from .delivery import DeliveryDiagnostics
-from .upload_authority import DisabledUploadAuthority, OverflowPayload, UploadAuthority
+from .upload_authority import (
+    DisabledUploadAuthority,
+    OverflowExportReceipt,
+    OverflowPayload,
+    UploadAuthority,
+)
 
 DEFAULT_MAX_EXPORT_BYTES = 4 * 1024 * 1024
 logger = logging.getLogger(__name__)
@@ -120,7 +125,7 @@ class ByteLimitedSpanExporter(SpanExporter):
                         type(exc).__name__,
                     )
                     result = SpanExportResult.FAILURE
-                if result is True:
+                if isinstance(result, OverflowExportReceipt) and result.complete:
                     if self._diagnostics is not None:
                         self._diagnostics.record_overflow("span", "exports")
                 else:
@@ -131,7 +136,15 @@ class ByteLimitedSpanExporter(SpanExporter):
                 continue
 
             batch = value
-            if self._inner.export(batch) is not SpanExportResult.SUCCESS:
+            try:
+                result = self._inner.export(batch)
+            except Exception as exc:
+                logger.error(
+                    "[neatlogs] span batch export raised (%s)",
+                    type(exc).__name__,
+                )
+                result = SpanExportResult.FAILURE
+            if result is not SpanExportResult.SUCCESS:
                 if self._diagnostics is not None:
                     self._diagnostics.record_export_failure(
                         "span",

--- a/neatlogs/core/byte_limited_exporter.py
+++ b/neatlogs/core/byte_limited_exporter.py
@@ -1,0 +1,71 @@
+"""Encoded-byte-aware batching for OTLP/protobuf span export."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+from .delivery import DeliveryDiagnostics
+
+DEFAULT_MAX_EXPORT_BYTES = 4 * 1024 * 1024
+
+
+class ByteLimitedSpanExporter(SpanExporter):
+    """Split a row batch by a conservative encoded protobuf byte bound.
+
+    Encoding each span as a one-span OTLP request repeats resource and scope
+    framing that a combined request deduplicates. Summing those sizes is
+    therefore a safe upper bound without repeatedly encoding every growing
+    candidate batch. A single oversized span is forwarded intact: Phase 8 owns
+    the overflow claim-check, and this layer never truncates or silently drops.
+    """
+
+    def __init__(
+        self,
+        inner: SpanExporter,
+        max_export_bytes: int = DEFAULT_MAX_EXPORT_BYTES,
+        diagnostics: DeliveryDiagnostics | None = None,
+    ) -> None:
+        if max_export_bytes <= 0:
+            raise ValueError("max_export_bytes must be greater than zero")
+        self._inner = inner
+        self._max_export_bytes = max_export_bytes
+        self._diagnostics = diagnostics
+
+    @staticmethod
+    def _encoded_upper_bound(span: ReadableSpan) -> int:
+        return encode_spans((span,)).ByteSize()
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        batches: list[list[ReadableSpan]] = []
+        current: list[ReadableSpan] = []
+        current_bytes = 0
+
+        for span in spans:
+            span_bytes = self._encoded_upper_bound(span)
+            if current and current_bytes + span_bytes > self._max_export_bytes:
+                batches.append(current)
+                current = []
+                current_bytes = 0
+            current.append(span)
+            current_bytes += span_bytes
+
+        if current:
+            batches.append(current)
+
+        for batch in batches:
+            if self._inner.export(batch) is not SpanExportResult.SUCCESS:
+                if self._diagnostics is not None:
+                    self._diagnostics.record_export_failure("span", len(batch))
+                return SpanExportResult.FAILURE
+        return SpanExportResult.SUCCESS
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        result = self._inner.force_flush(timeout_millis)
+        return True if result is None else bool(result)
+
+    def shutdown(self) -> None:
+        self._inner.shutdown()

--- a/neatlogs/core/byte_limited_log_exporter.py
+++ b/neatlogs/core/byte_limited_log_exporter.py
@@ -21,7 +21,12 @@ except ImportError:  # OpenTelemetry 1.35-1.38 compatibility
 from .byte_limited_exporter import DEFAULT_MAX_EXPORT_BYTES
 from .capture import limit_log_capture
 from .delivery import DeliveryDiagnostics
-from .upload_authority import DisabledUploadAuthority, OverflowPayload, UploadAuthority
+from .upload_authority import (
+    DisabledUploadAuthority,
+    OverflowExportReceipt,
+    OverflowPayload,
+    UploadAuthority,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +116,8 @@ class ByteLimitedLogExporter(LogRecordExporter):
                     )
                     continue
                 try:
-                    succeeded = self._upload_authority.export_overflow(candidate) is True
+                    result = self._upload_authority.export_overflow(candidate)
+                    succeeded = isinstance(result, OverflowExportReceipt) and result.complete
                 except Exception as exc:
                     logger.error(
                         "[neatlogs] oversized log upload failed (%s)",
@@ -129,7 +135,15 @@ class ByteLimitedLogExporter(LogRecordExporter):
                 continue
 
             records = value
-            if self._inner.export(records) is not LogRecordExportResult.SUCCESS:
+            try:
+                result = self._inner.export(records)
+            except Exception as exc:
+                logger.error(
+                    "[neatlogs] log batch export raised (%s)",
+                    type(exc).__name__,
+                )
+                result = LogRecordExportResult.FAILURE
+            if result is not LogRecordExportResult.SUCCESS:
                 if self._diagnostics is not None:
                     self._diagnostics.record_export_failure(
                         "log",

--- a/neatlogs/core/byte_limited_log_exporter.py
+++ b/neatlogs/core/byte_limited_log_exporter.py
@@ -1,4 +1,4 @@
-"""Encoded-byte-aware batching for OTLP/protobuf span export."""
+"""Encoded-byte-aware batching for OTLP/protobuf log export."""
 
 from __future__ import annotations
 
@@ -6,32 +6,32 @@ import hashlib
 import logging
 from collections.abc import Sequence
 
-from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
-from opentelemetry.sdk.trace import ReadableSpan
-from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
 
-from .capture import limit_span_capture
+try:
+    from opentelemetry.sdk._logs import ReadableLogRecord
+    from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
+except ImportError:  # OpenTelemetry 1.35-1.38 compatibility
+    from opentelemetry.sdk._logs import LogData as ReadableLogRecord
+    from opentelemetry.sdk._logs.export import (
+        LogExporter as LogRecordExporter,
+        LogExportResult as LogRecordExportResult,
+    )
+
+from .byte_limited_exporter import DEFAULT_MAX_EXPORT_BYTES
+from .capture import limit_log_capture
 from .delivery import DeliveryDiagnostics
 from .upload_authority import DisabledUploadAuthority, OverflowPayload, UploadAuthority
 
-DEFAULT_MAX_EXPORT_BYTES = 4 * 1024 * 1024
 logger = logging.getLogger(__name__)
 
 
-class ByteLimitedSpanExporter(SpanExporter):
-    """Split a row batch by a conservative encoded protobuf byte bound.
-
-    Encoding each span as a one-span OTLP request repeats resource and scope
-    framing that a combined request deduplicates. Summing those sizes is
-    therefore a safe upper bound without repeatedly encoding every growing
-    candidate batch. A single oversized span crosses an injectable upload
-    authority boundary; the production default rejects it explicitly until the
-    authenticated backend Phase 8 contract is deployed.
-    """
+class ByteLimitedLogExporter(LogRecordExporter):
+    """Split log batches and explicitly reject unsafe single-record overflow."""
 
     def __init__(
         self,
-        inner: SpanExporter,
+        inner: LogRecordExporter,
         max_export_bytes: int = DEFAULT_MAX_EXPORT_BYTES,
         diagnostics: DeliveryDiagnostics | None = None,
         upload_authority: UploadAuthority | None = None,
@@ -44,36 +44,35 @@ class ByteLimitedSpanExporter(SpanExporter):
         self._upload_authority = upload_authority or DisabledUploadAuthority()
         if diagnostics is not None:
             diagnostics.configure_upload_authority(
-                "span",
+                "log",
                 self._upload_authority.available,
                 self._upload_authority.unavailable_reason,
             )
 
     @staticmethod
-    def _encoded_upper_bound(span: ReadableSpan) -> int:
-        return encode_spans((span,)).ByteSize()
+    def _encoded_upper_bound(item: ReadableLogRecord) -> int:
+        return encode_logs((item,)).ByteSize()
 
-    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
-        bounded_spans: list[ReadableSpan] = []
-        for span in spans:
-            bounded, truncations = limit_span_capture(span)
-            bounded_spans.append(bounded)
+    def export(self, batch: Sequence[ReadableLogRecord]) -> LogRecordExportResult:
+        bounded = []
+        for item in batch:
+            clone, truncations = limit_log_capture(item)
+            bounded.append(clone)
             if truncations and self._diagnostics is not None:
-                self._diagnostics.record_capture_truncation("span", truncations)
+                self._diagnostics.record_capture_truncation("log", truncations)
 
         actions: list[tuple[str, object]] = []
-        current: list[ReadableSpan] = []
+        current = []
         current_bytes = 0
         overflow_failed = False
-
-        for span in bounded_spans:
-            span_bytes = self._encoded_upper_bound(span)
-            if span_bytes > self._max_export_bytes:
+        for item in bounded:
+            item_bytes = self._encoded_upper_bound(item)
+            if item_bytes > self._max_export_bytes:
                 if current:
                     actions.append(("batch", current))
                     current = []
                     current_bytes = 0
-                payload = encode_spans((span,)).SerializeToString()
+                payload = encode_logs((item,)).SerializeToString()
                 actions.append(
                     (
                         "overflow",
@@ -81,18 +80,17 @@ class ByteLimitedSpanExporter(SpanExporter):
                             content=payload,
                             sha256=hashlib.sha256(payload).hexdigest(),
                             byte_length=len(payload),
-                            signal="span",
+                            signal="log",
                         ),
                     )
                 )
                 continue
-            if current and current_bytes + span_bytes > self._max_export_bytes:
+            if current and current_bytes + item_bytes > self._max_export_bytes:
                 actions.append(("batch", current))
                 current = []
                 current_bytes = 0
-            current.append(span)
-            current_bytes += span_bytes
-
+            current.append(item)
+            current_bytes += item_bytes
         if current:
             actions.append(("batch", current))
 
@@ -102,49 +100,52 @@ class ByteLimitedSpanExporter(SpanExporter):
                 if not self._upload_authority.available:
                     overflow_failed = True
                     if self._diagnostics is not None:
-                        self._diagnostics.record_overflow("span", "unavailable")
-                        self._diagnostics.record_overflow("span", "failures")
-                        self._diagnostics.record_export_failure("span", 1)
+                        self._diagnostics.record_overflow("log", "unavailable")
+                        self._diagnostics.record_overflow("log", "failures")
+                        self._diagnostics.record_export_failure("log", 1)
                     logger.error(
-                        "[neatlogs] oversized span rejected: bytes=%d limit=%d reason=%s",
+                        "[neatlogs] oversized log rejected: bytes=%d limit=%d reason=%s",
                         candidate.byte_length,
                         self._max_export_bytes,
                         self._upload_authority.unavailable_reason,
                     )
                     continue
                 try:
-                    result = self._upload_authority.export_overflow(candidate)
+                    succeeded = self._upload_authority.export_overflow(candidate) is True
                 except Exception as exc:
                     logger.error(
-                        "[neatlogs] oversized span upload failed (%s)",
+                        "[neatlogs] oversized log upload failed (%s)",
                         type(exc).__name__,
                     )
-                    result = SpanExportResult.FAILURE
-                if result is True:
+                    succeeded = False
+                if succeeded:
                     if self._diagnostics is not None:
-                        self._diagnostics.record_overflow("span", "exports")
+                        self._diagnostics.record_overflow("log", "exports")
                 else:
                     overflow_failed = True
                     if self._diagnostics is not None:
-                        self._diagnostics.record_overflow("span", "failures")
-                        self._diagnostics.record_export_failure("span", 1)
+                        self._diagnostics.record_overflow("log", "failures")
+                        self._diagnostics.record_export_failure("log", 1)
                 continue
 
-            batch = value
-            if self._inner.export(batch) is not SpanExportResult.SUCCESS:
+            records = value
+            if self._inner.export(records) is not LogRecordExportResult.SUCCESS:
                 if self._diagnostics is not None:
                     self._diagnostics.record_export_failure(
-                        "span",
+                        "log",
                         sum(
                             len(unattempted) if kind == "batch" else 1
                             for kind, unattempted in actions[index:]
                         ),
                     )
-                return SpanExportResult.FAILURE
-        return SpanExportResult.FAILURE if overflow_failed else SpanExportResult.SUCCESS
+                return LogRecordExportResult.FAILURE
+        return LogRecordExportResult.FAILURE if overflow_failed else LogRecordExportResult.SUCCESS
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
-        result = self._inner.force_flush(timeout_millis)
+        force_flush = getattr(self._inner, "force_flush", None)
+        if force_flush is None:
+            return True
+        result = force_flush(timeout_millis)
         return True if result is None else bool(result)
 
     def shutdown(self) -> None:

--- a/neatlogs/core/capture.py
+++ b/neatlogs/core/capture.py
@@ -1,0 +1,195 @@
+"""Bound telemetry capture without hiding that content was truncated."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from opentelemetry.sdk.trace import Event, ReadableSpan
+from opentelemetry.trace import Link
+
+DEFAULT_MAX_CAPTURE_VALUE_BYTES = 100_000
+DEFAULT_MAX_CAPTURE_ITEM_BYTES = 1_000_000
+CAPTURE_TRUNCATION_MARKER = "...[neatlogs-truncated"
+UPLOAD_UNAVAILABLE_REASON = "backend_upload_contract_unavailable"
+
+
+def _truncation_marker(original_bytes: int, digest: str) -> bytes:
+    return (
+        f"{CAPTURE_TRUNCATION_MARKER} original_bytes={original_bytes} "
+        f"sha256={digest} overflow={UPLOAD_UNAVAILABLE_REASON}]"
+    ).encode("utf-8")
+
+
+def _join_prefix_and_marker(prefix: bytes, marker: bytes, max_bytes: int) -> str:
+    if max_bytes <= len(marker):
+        return marker[:max_bytes].decode("utf-8", errors="ignore")
+    return prefix[: max_bytes - len(marker)].decode("utf-8", errors="ignore") + marker.decode(
+        "utf-8"
+    )
+
+
+def bound_text(value: str, max_bytes: int = DEFAULT_MAX_CAPTURE_VALUE_BYTES) -> str:
+    """Return UTF-8 text no larger than ``max_bytes`` with an explicit marker."""
+
+    max_bytes = max(0, max_bytes)
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    digest = hashlib.sha256(encoded).hexdigest()
+    return _join_prefix_and_marker(encoded, _truncation_marker(len(encoded), digest), max_bytes)
+
+
+class BoundedTextAccumulator:
+    """Hash a complete text stream while retaining only a bounded prefix."""
+
+    def __init__(self, max_bytes: int = DEFAULT_MAX_CAPTURE_VALUE_BYTES) -> None:
+        self._max_bytes = max_bytes
+        self._prefix = bytearray()
+        self._digest = hashlib.sha256()
+        self.original_bytes = 0
+
+    def append(self, value: str) -> None:
+        encoded = value.encode("utf-8")
+        self._digest.update(encoded)
+        self.original_bytes += len(encoded)
+        remaining = self._max_bytes - len(self._prefix)
+        if remaining > 0:
+            self._prefix.extend(encoded[:remaining])
+
+    @property
+    def truncated(self) -> bool:
+        return self.original_bytes > self._max_bytes
+
+    def value(self) -> str:
+        if not self.truncated:
+            return bytes(self._prefix).decode("utf-8", errors="ignore")
+        return _join_prefix_and_marker(
+            bytes(self._prefix),
+            _truncation_marker(self.original_bytes, self._digest.hexdigest()),
+            self._max_bytes,
+        )
+
+    def __bool__(self) -> bool:
+        return self.original_bytes > 0
+
+
+class _CaptureLimiter:
+    def __init__(self, max_item_bytes: int, max_value_bytes: int) -> None:
+        self.remaining = max_item_bytes
+        self.max_value_bytes = max_value_bytes
+        self.truncated = 0
+
+    def value(self, value: Any) -> Any:
+        if isinstance(value, str):
+            encoded_size = len(value.encode("utf-8"))
+            limit = max(0, min(self.max_value_bytes, self.remaining))
+            bounded = bound_text(value, limit)
+            retained_size = len(bounded.encode("utf-8"))
+            self.remaining = max(0, self.remaining - retained_size)
+            if encoded_size > limit or CAPTURE_TRUNCATION_MARKER in value:
+                self.truncated += 1
+            return bounded
+        if isinstance(value, Mapping):
+            return {key: self.value(item) for key, item in value.items()}
+        if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+            return tuple(self.value(item) for item in value)
+        return value
+
+
+def _reported_truncations(attributes: Mapping[str, Any]) -> int:
+    value = attributes.get("neatlogs.capture.truncated_count", 0)
+    return value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else 0
+
+
+def limit_span_capture(
+    span: ReadableSpan,
+    *,
+    max_item_bytes: int = DEFAULT_MAX_CAPTURE_ITEM_BYTES,
+    max_value_bytes: int = DEFAULT_MAX_CAPTURE_VALUE_BYTES,
+) -> tuple[ReadableSpan, int]:
+    """Clone a span with bounded post-mask attributes and events."""
+
+    limiter = _CaptureLimiter(max_item_bytes, max_value_bytes)
+    attributes = {key: limiter.value(value) for key, value in (span.attributes or {}).items()}
+    previously_reported = _reported_truncations(attributes)
+    events = [
+        Event(
+            event.name,
+            attributes={
+                key: limiter.value(value) for key, value in (event.attributes or {}).items()
+            },
+            timestamp=event.timestamp,
+        )
+        for event in span.events
+    ]
+    links = [
+        Link(
+            link.context,
+            attributes={
+                key: limiter.value(value) for key, value in (link.attributes or {}).items()
+            },
+        )
+        for link in span.links
+    ]
+    truncations = limiter.truncated + previously_reported
+    if not truncations:
+        return span, 0
+
+    attributes.update(
+        {
+            "neatlogs.capture.truncated": True,
+            "neatlogs.capture.truncated_count": truncations,
+            "neatlogs.capture.overflow.state": "disabled",
+            "neatlogs.capture.overflow.reason": UPLOAD_UNAVAILABLE_REASON,
+        }
+    )
+    return (
+        ReadableSpan(
+            name=span.name,
+            context=span.context,
+            parent=span.parent,
+            resource=span.resource,
+            attributes=attributes,
+            events=events,
+            links=links,
+            kind=span.kind,
+            status=span.status,
+            start_time=span.start_time,
+            end_time=span.end_time,
+            instrumentation_scope=span.instrumentation_scope,
+        ),
+        truncations,
+    )
+
+
+def limit_log_capture(
+    item: Any,
+    *,
+    max_item_bytes: int = DEFAULT_MAX_CAPTURE_ITEM_BYTES,
+    max_value_bytes: int = DEFAULT_MAX_CAPTURE_VALUE_BYTES,
+) -> tuple[Any, int]:
+    """Clone a readable log record with bounded post-mask body and attributes."""
+
+    limiter = _CaptureLimiter(max_item_bytes, max_value_bytes)
+    clone = copy.copy(item)
+    record = copy.copy(item.log_record)
+    record.body = limiter.value(record.body)
+    record.attributes = {
+        key: limiter.value(value) for key, value in (record.attributes or {}).items()
+    }
+    previously_reported = _reported_truncations(record.attributes)
+    truncations = limiter.truncated + previously_reported
+    if truncations:
+        record.attributes.update(
+            {
+                "neatlogs.capture.truncated": True,
+                "neatlogs.capture.truncated_count": truncations,
+                "neatlogs.capture.overflow.state": "disabled",
+                "neatlogs.capture.overflow.reason": UPLOAD_UNAVAILABLE_REASON,
+            }
+        )
+    object.__setattr__(clone, "log_record", record)
+    return clone, truncations

--- a/neatlogs/core/capture.py
+++ b/neatlogs/core/capture.py
@@ -7,8 +7,9 @@ import hashlib
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Event, ReadableSpan
-from opentelemetry.trace import Link
+from opentelemetry.trace import Link, Status
 
 DEFAULT_MAX_CAPTURE_VALUE_BYTES = 100_000
 DEFAULT_MAX_CAPTURE_ITEM_BYTES = 1_000_000
@@ -40,6 +41,18 @@ def bound_text(value: str, max_bytes: int = DEFAULT_MAX_CAPTURE_VALUE_BYTES) -> 
         return value
     digest = hashlib.sha256(encoded).hexdigest()
     return _join_prefix_and_marker(encoded, _truncation_marker(len(encoded), digest), max_bytes)
+
+
+def bound_bytes(value: bytes, max_bytes: int = DEFAULT_MAX_CAPTURE_VALUE_BYTES) -> bytes:
+    """Return bytes no larger than ``max_bytes`` with the same explicit marker."""
+
+    max_bytes = max(0, max_bytes)
+    if len(value) <= max_bytes:
+        return value
+    marker = _truncation_marker(len(value), hashlib.sha256(value).hexdigest())
+    if max_bytes <= len(marker):
+        return marker[:max_bytes]
+    return value[: max_bytes - len(marker)] + marker
 
 
 class BoundedTextAccumulator:
@@ -82,19 +95,72 @@ class _CaptureLimiter:
         self.max_value_bytes = max_value_bytes
         self.truncated = 0
 
+    def _string(self, value: str) -> str:
+        encoded_size = len(value.encode("utf-8"))
+        limit = max(0, min(self.max_value_bytes, self.remaining))
+        bounded = bound_text(value, limit)
+        retained_size = len(bounded.encode("utf-8"))
+        self.remaining = max(0, self.remaining - retained_size)
+        if encoded_size > limit or CAPTURE_TRUNCATION_MARKER in value:
+            self.truncated += 1
+        return bounded
+
+    def _bytes(self, value: bytes | bytearray) -> bytes:
+        raw = bytes(value)
+        limit = max(0, min(self.max_value_bytes, self.remaining))
+        bounded = bound_bytes(raw, limit)
+        self.remaining = max(0, self.remaining - len(bounded))
+        if len(raw) > limit or CAPTURE_TRUNCATION_MARKER.encode() in raw:
+            self.truncated += 1
+        return bounded
+
+    def _key(self, key: Any, used: set[str]) -> str | None:
+        original = key if isinstance(key, str) else str(key)
+        encoded = original.encode("utf-8")
+        limit = max(0, min(self.max_value_bytes, self.remaining))
+        if limit <= 0:
+            self.truncated += 1
+            return None
+        if len(encoded) <= limit:
+            candidate = original
+        else:
+            digest = hashlib.sha256(
+                f"{type(key).__module__}.{type(key).__qualname__}:{original}".encode("utf-8")
+            ).hexdigest()
+            suffix = f"~{digest}"
+            if limit <= len(suffix):
+                candidate = suffix[:limit]
+            else:
+                candidate = encoded[: limit - len(suffix)].decode("utf-8", errors="ignore") + suffix
+            self.truncated += 1
+        size = len(candidate.encode("utf-8"))
+        self.remaining = max(0, self.remaining - size)
+        if candidate in used:
+            # Never overwrite a previously retained entry. The item-level
+            # truncation diagnostics account for the omitted collision.
+            self.truncated += 1
+            return None
+        return candidate
+
+    def mapping(self, value: Mapping[Any, Any]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        used: set[str] = set()
+        for key, item in value.items():
+            bounded_key = self._key(key, used)
+            if bounded_key is None:
+                continue
+            used.add(bounded_key)
+            result[bounded_key] = self.value(item)
+        return result
+
     def value(self, value: Any) -> Any:
         if isinstance(value, str):
-            encoded_size = len(value.encode("utf-8"))
-            limit = max(0, min(self.max_value_bytes, self.remaining))
-            bounded = bound_text(value, limit)
-            retained_size = len(bounded.encode("utf-8"))
-            self.remaining = max(0, self.remaining - retained_size)
-            if encoded_size > limit or CAPTURE_TRUNCATION_MARKER in value:
-                self.truncated += 1
-            return bounded
+            return self._string(value)
+        if isinstance(value, (bytes, bytearray)):
+            return self._bytes(value)
         if isinstance(value, Mapping):
-            return {key: self.value(item) for key, item in value.items()}
-        if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+            return self.mapping(value)
+        if isinstance(value, Sequence):
             return tuple(self.value(item) for item in value)
         return value
 
@@ -113,14 +179,15 @@ def limit_span_capture(
     """Clone a span with bounded post-mask attributes and events."""
 
     limiter = _CaptureLimiter(max_item_bytes, max_value_bytes)
-    attributes = {key: limiter.value(value) for key, value in (span.attributes or {}).items()}
-    previously_reported = _reported_truncations(attributes)
+    previously_reported = _reported_truncations(span.attributes or {})
+    name = limiter.value(span.name)
+    resource_attributes = limiter.mapping(span.resource.attributes or {})
+    status_description = limiter.value(span.status.description)
+    attributes = limiter.mapping(span.attributes or {})
     events = [
         Event(
-            event.name,
-            attributes={
-                key: limiter.value(value) for key, value in (event.attributes or {}).items()
-            },
+            limiter.value(event.name),
+            attributes=limiter.mapping(event.attributes or {}),
             timestamp=event.timestamp,
         )
         for event in span.events
@@ -128,9 +195,7 @@ def limit_span_capture(
     links = [
         Link(
             link.context,
-            attributes={
-                key: limiter.value(value) for key, value in (link.attributes or {}).items()
-            },
+            attributes=limiter.mapping(link.attributes or {}),
         )
         for link in span.links
     ]
@@ -148,15 +213,15 @@ def limit_span_capture(
     )
     return (
         ReadableSpan(
-            name=span.name,
+            name=name,
             context=span.context,
             parent=span.parent,
-            resource=span.resource,
+            resource=Resource(resource_attributes, schema_url=span.resource.schema_url),
             attributes=attributes,
             events=events,
             links=links,
             kind=span.kind,
-            status=span.status,
+            status=Status(span.status.status_code, status_description),
             start_time=span.start_time,
             end_time=span.end_time,
             instrumentation_scope=span.instrumentation_scope,
@@ -176,11 +241,18 @@ def limit_log_capture(
     limiter = _CaptureLimiter(max_item_bytes, max_value_bytes)
     clone = copy.copy(item)
     record = copy.copy(item.log_record)
+    previously_reported = _reported_truncations(record.attributes or {})
     record.body = limiter.value(record.body)
-    record.attributes = {
-        key: limiter.value(value) for key, value in (record.attributes or {}).items()
-    }
-    previously_reported = _reported_truncations(record.attributes)
+    record.attributes = limiter.mapping(record.attributes or {})
+    record.severity_text = limiter.value(record.severity_text)
+    record.event_name = limiter.value(record.event_name)
+    original_resource = getattr(item, "resource", None) or getattr(record, "resource", None)
+    bounded_resource = None
+    if original_resource is not None:
+        bounded_resource = Resource(
+            limiter.mapping(original_resource.attributes or {}),
+            schema_url=original_resource.schema_url,
+        )
     truncations = limiter.truncated + previously_reported
     if truncations:
         record.attributes.update(
@@ -192,4 +264,9 @@ def limit_log_capture(
             }
         )
     object.__setattr__(clone, "log_record", record)
+    if bounded_resource is not None:
+        if hasattr(clone, "resource"):
+            object.__setattr__(clone, "resource", bounded_resource)
+        elif hasattr(record, "resource"):
+            object.__setattr__(record, "resource", bounded_resource)
     return clone, truncations

--- a/neatlogs/core/choice_accumulator.py
+++ b/neatlogs/core/choice_accumulator.py
@@ -1,0 +1,311 @@
+"""Incremental OpenAI-compatible multi-choice and tool-fragment capture."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from opentelemetry.trace import StatusCode
+
+from .media import set_media_attributes
+
+MAX_SEMANTIC_STREAM_EVENTS = 128
+
+
+def _get(value: Any, name: str, default=None):
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str, ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return str(value or "")
+
+
+@dataclass
+class _ToolCall:
+    id: str = ""
+    name: str = ""
+    arguments: str = ""
+    type: str = ""
+    details: str = ""
+    synthetic: bool = False
+
+
+@dataclass
+class _Choice:
+    role: str = "assistant"
+    content: list[str] = field(default_factory=list)
+    reasoning: list[str] = field(default_factory=list)
+    media_values: list[Any] = field(default_factory=list)
+    finish_reason: str | None = None
+    tool_calls: dict[int, _ToolCall] = field(default_factory=dict)
+
+
+class ChoiceAccumulator:
+    """Preserve every choice and key tool fragments by choice + tool index."""
+
+    def __init__(self, capture_fidelity: str = "native") -> None:
+        if capture_fidelity not in {"native", "normalized", "flattened", "unknown"}:
+            raise ValueError("unsupported capture fidelity")
+        self.capture_fidelity = capture_fidelity
+        self.choices: dict[int, _Choice] = {}
+        self.usage: Any = None
+        self.model = ""
+        self.response_id = ""
+        self.chunk_count = 0
+        self.finalized = False
+
+    def add_response(self, response: Any) -> None:
+        self._capture_envelope(response)
+        for position, value in enumerate(_get(response, "choices", None) or []):
+            index = _get(value, "index", position)
+            index = index if isinstance(index, int) else position
+            message = _get(value, "message", None)
+            if message is None:
+                continue
+            choice = self._choice(index)
+            choice.role = str(_get(message, "role", None) or "assistant")
+            content = _get(message, "content", None)
+            if content is not None:
+                choice.content.append(_string(content))
+                if not isinstance(content, str):
+                    choice.media_values.append(content)
+            reasoning = _get(message, "reasoning_content", None)
+            if reasoning is not None:
+                choice.reasoning.append(_string(reasoning))
+            self._add_tools(index, _get(message, "tool_calls", None))
+            finish_reason = _get(value, "finish_reason", None)
+            if finish_reason is not None:
+                choice.finish_reason = str(finish_reason)
+
+    def add_chunk(self, span: Any, chunk: Any) -> None:
+        chunk_index = self.chunk_count
+        self.chunk_count += 1
+        self._capture_envelope(chunk)
+        summary = []
+        for position, value in enumerate(_get(chunk, "choices", None) or []):
+            index = _get(value, "index", position)
+            index = index if isinstance(index, int) else position
+            delta = _get(value, "delta", None)
+            if delta is None:
+                continue
+            choice = self._choice(index)
+            role = _get(delta, "role", None)
+            if role:
+                choice.role = str(role)
+            content = (
+                _string(_get(delta, "content", ""))
+                if _get(delta, "content", None) is not None
+                else ""
+            )
+            reasoning = (
+                _string(_get(delta, "reasoning_content", ""))
+                if _get(delta, "reasoning_content", None) is not None
+                else ""
+            )
+            if content:
+                choice.content.append(content)
+            raw_content = _get(delta, "content", None)
+            if raw_content is not None and not isinstance(raw_content, str):
+                choice.media_values.append(raw_content)
+            if reasoning:
+                choice.reasoning.append(reasoning)
+            tools = _get(delta, "tool_calls", None) or []
+            self._add_tools(index, tools)
+            finish_reason = _get(value, "finish_reason", None)
+            if finish_reason is not None:
+                choice.finish_reason = str(finish_reason)
+            summary.append(
+                {
+                    "choice_index": index,
+                    "content_bytes": len(content.encode()),
+                    "reasoning_bytes": len(reasoning.encode()),
+                    "tool_fragments": len(tools),
+                    "finish_reason": finish_reason,
+                }
+            )
+        if chunk_index < MAX_SEMANTIC_STREAM_EVENTS and (summary or self.usage is not None):
+            span.add_event(
+                "neatlogs.stream.chunk",
+                {
+                    "neatlogs.stream.chunk.index": chunk_index,
+                    "neatlogs.stream.chunk.summary": _string(
+                        {"choices": summary, "usage": _get(chunk, "usage", None) is not None}
+                    ),
+                },
+            )
+
+    def apply(self, span: Any) -> None:
+        indexes = sorted(self.choices)
+        flattened_tool_index = 0
+        for choice_index in indexes:
+            choice = self.choices[choice_index]
+            prefix = f"neatlogs.llm.output_messages.{choice_index}"
+            span.set_attribute(f"{prefix}.role", choice.role)
+            content = "".join(choice.content)
+            if content:
+                span.set_attribute(f"{prefix}.content", content)
+            reasoning = "".join(choice.reasoning)
+            if reasoning:
+                span.set_attribute(f"{prefix}.reasoning", reasoning)
+            if choice.media_values:
+                set_media_attributes(span, prefix, choice.media_values, "output")
+            if choice.finish_reason is not None:
+                span.set_attribute(
+                    f"neatlogs.llm.choices.{choice_index}.finish_reason",
+                    choice.finish_reason,
+                )
+                if choice_index == indexes[0]:
+                    span.set_attribute("neatlogs.llm.finish_reason", choice.finish_reason)
+            for tool_index in sorted(choice.tool_calls):
+                tool = choice.tool_calls[tool_index]
+                if not tool.id:
+                    context = span.get_span_context()
+                    raw = (
+                        f"{context.trace_id:032x}:{context.span_id:016x}:{choice_index}:"
+                        f"{tool_index}:{tool.name}:{hashlib.sha256(tool.arguments.encode()).hexdigest()}"
+                    )
+                    tool.id = f"nl_{hashlib.sha256(raw.encode()).hexdigest()[:24]}"
+                    tool.synthetic = True
+                tool_prefix = f"neatlogs.llm.tool_calls.{flattened_tool_index}"
+                span.set_attribute(f"{tool_prefix}.id", tool.id)
+                if tool.type:
+                    span.set_attribute(f"{tool_prefix}.type", tool.type)
+                span.set_attribute(f"{tool_prefix}.name", tool.name)
+                span.set_attribute(f"{tool_prefix}.arguments", tool.arguments)
+                if tool.details:
+                    span.set_attribute(f"{tool_prefix}.details", tool.details)
+                span.set_attribute(f"{tool_prefix}.choice_index", choice_index)
+                span.set_attribute(f"{tool_prefix}.tool_call_index", tool_index)
+                if tool.synthetic:
+                    span.set_attribute(f"{tool_prefix}.id_synthetic", True)
+                flattened_tool_index += 1
+        if self.model:
+            span.set_attribute("neatlogs.llm.model_name", self.model)
+        if self.response_id:
+            span.set_attribute("neatlogs.llm.response_id", self.response_id)
+        self._apply_usage(span)
+        span.set_attribute("neatlogs.capture_fidelity", self.capture_fidelity)
+        if self.chunk_count:
+            span.set_attribute("neatlogs.stream.chunk_count", self.chunk_count)
+            if self.chunk_count > MAX_SEMANTIC_STREAM_EVENTS:
+                span.set_attribute(
+                    "neatlogs.stream.events_dropped",
+                    self.chunk_count - MAX_SEMANTIC_STREAM_EVENTS,
+                )
+
+    def _choice(self, index: int) -> _Choice:
+        return self.choices.setdefault(index, _Choice())
+
+    def _add_tools(self, choice_index: int, fragments: Any) -> None:
+        for position, fragment in enumerate(fragments or []):
+            index = _get(fragment, "index", position)
+            index = index if isinstance(index, int) else position
+            tool = self._choice(choice_index).tool_calls.setdefault(index, _ToolCall())
+            tool_id = _get(fragment, "id", None)
+            tool_type = _get(fragment, "type", None)
+            function = _get(fragment, "function", None)
+            if tool_id:
+                tool.id = str(tool_id)
+            if tool_type:
+                tool.type = str(tool_type)
+            name = _get(function, "name", None)
+            if name:
+                tool.name = str(name)
+            arguments = _get(function, "arguments", None)
+            if arguments is not None:
+                tool.arguments += _string(arguments)
+            if function is None:
+                tool.details = _string(fragment)
+
+    def _capture_envelope(self, value: Any) -> None:
+        usage = _get(value, "usage", None)
+        if usage is not None:
+            self.usage = usage
+        model = _get(value, "model", None)
+        if model:
+            self.model = str(model)
+        response_id = _get(value, "id", None)
+        if response_id:
+            self.response_id = str(response_id)
+
+    def _apply_usage(self, span: Any) -> None:
+        usage = self.usage
+        if usage is None:
+            return
+        span.set_attribute("neatlogs.llm.usage", _string(usage))
+        for source, target in (
+            ("prompt_tokens", "prompt"),
+            ("completion_tokens", "completion"),
+            ("total_tokens", "total"),
+        ):
+            value = _get(usage, source, None)
+            if value is not None:
+                span.set_attribute(f"neatlogs.llm.token_count.{target}", value)
+        prompt_details = _get(usage, "prompt_tokens_details", None)
+        cached = _get(prompt_details, "cached_tokens", None)
+        if cached is not None:
+            span.set_attribute("neatlogs.llm.token_count.cache_read", cached)
+        completion_details = _get(usage, "completion_tokens_details", None)
+        reasoning = _get(completion_details, "reasoning_tokens", None)
+        if reasoning is not None:
+            span.set_attribute("neatlogs.llm.token_count.reasoning", reasoning)
+
+
+class OpenAIStreamFinalizer:
+    """Incremental finalizer consumed by Sync/AsyncStreamWrapper."""
+
+    def __init__(self) -> None:
+        self.accumulator = ChoiceAccumulator()
+
+    def on_chunk(self, span: Any, chunk: Any) -> None:
+        self.accumulator.add_chunk(span, chunk)
+
+    def finish(
+        self,
+        span: Any,
+        duration_ms: float,
+        ttft_ms: float | None,
+        *,
+        interrupted: bool = False,
+    ) -> None:
+        if self.accumulator.finalized:
+            return
+        self.accumulator.finalized = True
+        self.accumulator.apply(span)
+        span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
+        if ttft_ms is not None:
+            span.set_attribute("neatlogs.llm.metrics.ttft_ms", round(ttft_ms, 3))
+            if duration_ms > ttft_ms:
+                span.set_attribute(
+                    "neatlogs.llm.metrics.streaming_time_to_generate_ms",
+                    round(duration_ms - ttft_ms, 3),
+                )
+        if interrupted:
+            span.set_attribute("neatlogs.stream.cancelled", True)
+            span.set_status(StatusCode.UNSET)
+        else:
+            span.set_status(StatusCode.OK)
+        span.end()
+
+    def fail(self, span: Any, error: BaseException) -> None:
+        if self.accumulator.finalized:
+            return
+        self.accumulator.finalized = True
+        self.accumulator.apply(span)
+        if error.__class__.__name__ in {"CancelledError", "GeneratorExit"}:
+            span.set_attribute("neatlogs.stream.cancelled", True)
+            span.set_status(StatusCode.UNSET)
+        else:
+            span.set_status(StatusCode.ERROR, str(error))
+            if isinstance(error, Exception):
+                span.record_exception(error)
+        span.end()

--- a/neatlogs/core/choice_accumulator.py
+++ b/neatlogs/core/choice_accumulator.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from opentelemetry.trace import StatusCode
 
+from .capture import BoundedTextAccumulator
 from .media import set_media_attributes
 
 MAX_SEMANTIC_STREAM_EVENTS = 128
@@ -33,7 +34,7 @@ def _string(value: Any) -> str:
 class _ToolCall:
     id: str = ""
     name: str = ""
-    arguments: str = ""
+    arguments: BoundedTextAccumulator = field(default_factory=BoundedTextAccumulator)
     type: str = ""
     details: str = ""
     synthetic: bool = False
@@ -42,8 +43,8 @@ class _ToolCall:
 @dataclass
 class _Choice:
     role: str = "assistant"
-    content: list[str] = field(default_factory=list)
-    reasoning: list[str] = field(default_factory=list)
+    content: BoundedTextAccumulator = field(default_factory=BoundedTextAccumulator)
+    reasoning: BoundedTextAccumulator = field(default_factory=BoundedTextAccumulator)
     media_values: list[Any] = field(default_factory=list)
     finish_reason: str | None = None
     tool_calls: dict[int, _ToolCall] = field(default_factory=dict)
@@ -150,12 +151,12 @@ class ChoiceAccumulator:
             choice = self.choices[choice_index]
             prefix = f"neatlogs.llm.output_messages.{choice_index}"
             span.set_attribute(f"{prefix}.role", choice.role)
-            content = "".join(choice.content)
+            content = choice.content.value()
             if content:
                 span.set_attribute(f"{prefix}.content", content)
-            reasoning = "".join(choice.reasoning)
+            reasoning = choice.reasoning.value()
             if reasoning:
-                span.set_attribute(f"{prefix}.reasoning", reasoning)
+                span.set_attribute(f"{prefix}.thinking", reasoning)
             if choice.media_values:
                 set_media_attributes(span, prefix, choice.media_values, "output")
             if choice.finish_reason is not None:
@@ -171,7 +172,8 @@ class ChoiceAccumulator:
                     context = span.get_span_context()
                     raw = (
                         f"{context.trace_id:032x}:{context.span_id:016x}:{choice_index}:"
-                        f"{tool_index}:{tool.name}:{hashlib.sha256(tool.arguments.encode()).hexdigest()}"
+                        f"{tool_index}:{tool.name}:"
+                        f"{hashlib.sha256(tool.arguments.value().encode()).hexdigest()}"
                     )
                     tool.id = f"nl_{hashlib.sha256(raw.encode()).hexdigest()[:24]}"
                     tool.synthetic = True
@@ -180,7 +182,7 @@ class ChoiceAccumulator:
                 if tool.type:
                     span.set_attribute(f"{tool_prefix}.type", tool.type)
                 span.set_attribute(f"{tool_prefix}.name", tool.name)
-                span.set_attribute(f"{tool_prefix}.arguments", tool.arguments)
+                span.set_attribute(f"{tool_prefix}.arguments", tool.arguments.value())
                 if tool.details:
                     span.set_attribute(f"{tool_prefix}.details", tool.details)
                 span.set_attribute(f"{tool_prefix}.choice_index", choice_index)
@@ -222,7 +224,7 @@ class ChoiceAccumulator:
                 tool.name = str(name)
             arguments = _get(function, "arguments", None)
             if arguments is not None:
-                tool.arguments += _string(arguments)
+                tool.arguments.append(_string(arguments))
             if function is None:
                 tool.details = _string(fragment)
 

--- a/neatlogs/core/choice_accumulator.py
+++ b/neatlogs/core/choice_accumulator.py
@@ -10,7 +10,7 @@ from typing import Any
 from opentelemetry.trace import StatusCode
 
 from .capture import BoundedTextAccumulator
-from .media import set_media_attributes
+from .media import media_references, sanitize_media_payload
 
 MAX_SEMANTIC_STREAM_EVENTS = 128
 
@@ -25,7 +25,12 @@ def _string(value: Any) -> str:
     if isinstance(value, str):
         return value
     try:
-        return json.dumps(value, default=str, ensure_ascii=False, separators=(",", ":"))
+        return json.dumps(
+            sanitize_media_payload(value, "output"),
+            default=str,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
     except (TypeError, ValueError):
         return str(value or "")
 
@@ -45,7 +50,7 @@ class _Choice:
     role: str = "assistant"
     content: BoundedTextAccumulator = field(default_factory=BoundedTextAccumulator)
     reasoning: BoundedTextAccumulator = field(default_factory=BoundedTextAccumulator)
-    media_values: list[Any] = field(default_factory=list)
+    media_records: list[dict[str, Any]] = field(default_factory=list)
     finish_reason: str | None = None
     tool_calls: dict[int, _ToolCall] = field(default_factory=dict)
 
@@ -78,7 +83,7 @@ class ChoiceAccumulator:
             if content is not None:
                 choice.content.append(_string(content))
                 if not isinstance(content, str):
-                    choice.media_values.append(content)
+                    choice.media_records.extend(media_references(content, "output"))
             reasoning = _get(message, "reasoning_content", None)
             if reasoning is not None:
                 choice.reasoning.append(_string(reasoning))
@@ -116,7 +121,7 @@ class ChoiceAccumulator:
                 choice.content.append(content)
             raw_content = _get(delta, "content", None)
             if raw_content is not None and not isinstance(raw_content, str):
-                choice.media_values.append(raw_content)
+                choice.media_records.extend(media_references(raw_content, "output"))
             if reasoning:
                 choice.reasoning.append(reasoning)
             tools = _get(delta, "tool_calls", None) or []
@@ -157,8 +162,13 @@ class ChoiceAccumulator:
             reasoning = choice.reasoning.value()
             if reasoning:
                 span.set_attribute(f"{prefix}.thinking", reasoning)
-            if choice.media_values:
-                set_media_attributes(span, prefix, choice.media_values, "output")
+            unique_media = {
+                (record.get("sha256"), record.get("reference"), record.get("type")): record
+                for record in choice.media_records
+            }
+            for media_index, record in enumerate(unique_media.values()):
+                for key, item in record.items():
+                    span.set_attribute(f"{prefix}.media.{media_index}.{key}", item)
             if choice.finish_reason is not None:
                 span.set_attribute(
                     f"neatlogs.llm.choices.{choice_index}.finish_reason",

--- a/neatlogs/core/deadline.py
+++ b/neatlogs/core/deadline.py
@@ -9,11 +9,57 @@ from collections.abc import Callable
 from typing import Any
 
 
+class DeadlineWorker:
+    """A daemon worker started before interpreter finalization.
+
+    Python 3.12 forbids starting a thread from an ``atexit`` callback. Pipelines
+    create this worker during initialization, so exit cleanup can still abandon
+    a blocking provider/exporter call at the configured deadline.
+    """
+
+    def __init__(self, name: str = "neatlogs-shutdown") -> None:
+        self._jobs: queue.Queue[tuple[Callable[[], Any], queue.Queue[tuple[bool, Any]]] | None]
+        self._jobs = queue.Queue()
+        self._thread = threading.Thread(target=self._run, name=name, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        while True:
+            job = self._jobs.get()
+            if job is None:
+                return
+            operation, completed = job
+            try:
+                result = operation()
+            except BaseException as exc:
+                completed.put_nowait((False, exc))
+            else:
+                completed.put_nowait((True, result))
+
+    def call(self, operation: Callable[[], Any], deadline: float) -> tuple[bool, Any]:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or not self._thread.is_alive():
+            return False, TimeoutError("Neatlogs shutdown deadline exceeded")
+        completed: queue.Queue[tuple[bool, Any]] = queue.Queue(maxsize=1)
+        self._jobs.put_nowait((operation, completed))
+        try:
+            return completed.get(timeout=remaining)
+        except queue.Empty:
+            return False, TimeoutError("Neatlogs shutdown deadline exceeded")
+
+    def is_current(self) -> bool:
+        return self._thread.ident == threading.get_ident()
+
+    def close(self) -> None:
+        self._jobs.put_nowait(None)
+
+
 def bounded_call(
     operation: Callable[[], Any],
     deadline: float,
     *,
     synchronous: bool = False,
+    worker: DeadlineWorker | None = None,
 ) -> tuple[bool, Any]:
     """Run one close operation by a monotonic deadline.
 
@@ -24,17 +70,10 @@ def bounded_call(
     remaining = deadline - time.monotonic()
     if remaining <= 0:
         return False, TimeoutError("Neatlogs shutdown deadline exceeded")
+    if worker is not None:
+        return worker.call(operation, deadline)
     if synchronous:
-        # Python 3.12+ prohibits starting threads from an atexit callback. The
-        # exporters already own their worker threads, so interpreter shutdown
-        # must join/flush those workers directly instead of creating another.
-        try:
-            result = operation()
-        except BaseException as exc:
-            return False, exc
-        if time.monotonic() > deadline:
-            return False, TimeoutError("Neatlogs shutdown deadline exceeded")
-        return True, result
+        return False, RuntimeError("synchronous shutdown requires a prestarted worker")
     completed: queue.Queue[tuple[bool, Any]] = queue.Queue(maxsize=1)
 
     def run() -> None:

--- a/neatlogs/core/deadline.py
+++ b/neatlogs/core/deadline.py
@@ -9,7 +9,12 @@ from collections.abc import Callable
 from typing import Any
 
 
-def bounded_call(operation: Callable[[], Any], deadline: float) -> tuple[bool, Any]:
+def bounded_call(
+    operation: Callable[[], Any],
+    deadline: float,
+    *,
+    synchronous: bool = False,
+) -> tuple[bool, Any]:
     """Run one close operation by a monotonic deadline.
 
     Python cannot forcibly cancel arbitrary exporter or user callback code, so
@@ -19,6 +24,17 @@ def bounded_call(operation: Callable[[], Any], deadline: float) -> tuple[bool, A
     remaining = deadline - time.monotonic()
     if remaining <= 0:
         return False, TimeoutError("Neatlogs shutdown deadline exceeded")
+    if synchronous:
+        # Python 3.12+ prohibits starting threads from an atexit callback. The
+        # exporters already own their worker threads, so interpreter shutdown
+        # must join/flush those workers directly instead of creating another.
+        try:
+            result = operation()
+        except BaseException as exc:
+            return False, exc
+        if time.monotonic() > deadline:
+            return False, TimeoutError("Neatlogs shutdown deadline exceeded")
+        return True, result
     completed: queue.Queue[tuple[bool, Any]] = queue.Queue(maxsize=1)
 
     def run() -> None:

--- a/neatlogs/core/deadline.py
+++ b/neatlogs/core/deadline.py
@@ -1,0 +1,34 @@
+"""Bound potentially blocking exporter/lifecycle calls without process hangs."""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+
+def bounded_call(operation: Callable[[], Any], deadline: float) -> tuple[bool, Any]:
+    """Run one close operation by a monotonic deadline.
+
+    Python cannot forcibly cancel arbitrary exporter or user callback code, so
+    the worker is daemonized. A timeout lets the SDK report loss and detach the
+    closed generation without keeping interpreter exit alive.
+    """
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return False, TimeoutError("Neatlogs shutdown deadline exceeded")
+    completed: queue.Queue[tuple[bool, Any]] = queue.Queue(maxsize=1)
+
+    def run() -> None:
+        try:
+            completed.put_nowait((True, operation()))
+        except BaseException as exc:
+            completed.put_nowait((False, exc))
+
+    threading.Thread(target=run, name="neatlogs-shutdown", daemon=True).start()
+    try:
+        return completed.get(timeout=remaining)
+    except queue.Empty:
+        return False, TimeoutError("Neatlogs shutdown deadline exceeded")

--- a/neatlogs/core/delivery.py
+++ b/neatlogs/core/delivery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 from dataclasses import asdict, dataclass
+from typing import Any
 
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -17,6 +18,18 @@ class DeliveryDiagnosticsSnapshot:
     log_export_failures: int = 0
     masked_span_drops: int = 0
     masked_log_drops: int = 0
+    span_capture_truncations: int = 0
+    log_capture_truncations: int = 0
+    span_overflow_exports: int = 0
+    span_overflow_failures: int = 0
+    span_overflow_unavailable: int = 0
+    log_overflow_exports: int = 0
+    log_overflow_failures: int = 0
+    log_overflow_unavailable: int = 0
+    span_upload_authority_available: bool = False
+    log_upload_authority_available: bool = False
+    span_upload_authority_reason: str = "backend_upload_contract_unavailable"
+    log_upload_authority_reason: str = "backend_upload_contract_unavailable"
 
 
 class DeliveryDiagnostics:
@@ -41,7 +54,24 @@ class DeliveryDiagnostics:
             field = "masked_span_drops" if signal == "span" else "masked_log_drops"
             setattr(self._values, field, getattr(self._values, field) + count)
 
-    def snapshot(self) -> dict[str, int]:
+    def record_capture_truncation(self, signal: str, count: int = 1) -> None:
+        with self._lock:
+            field = "span_capture_truncations" if signal == "span" else "log_capture_truncations"
+            setattr(self._values, field, getattr(self._values, field) + count)
+
+    def record_overflow(self, signal: str, outcome: str, count: int = 1) -> None:
+        if outcome not in {"exports", "failures", "unavailable"}:
+            raise ValueError(f"unknown overflow outcome: {outcome}")
+        with self._lock:
+            field = f"{signal}_overflow_{outcome}"
+            setattr(self._values, field, getattr(self._values, field) + count)
+
+    def configure_upload_authority(self, signal: str, available: bool, reason: str) -> None:
+        with self._lock:
+            setattr(self._values, f"{signal}_upload_authority_available", available)
+            setattr(self._values, f"{signal}_upload_authority_reason", reason)
+
+    def snapshot(self) -> dict[str, Any]:
         with self._lock:
             return asdict(self._values)
 

--- a/neatlogs/core/delivery.py
+++ b/neatlogs/core/delivery.py
@@ -1,0 +1,71 @@
+"""Bounded-queue and final-delivery loss counters for NeatLogs pipelines."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import asdict, dataclass
+
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+@dataclass
+class DeliveryDiagnosticsSnapshot:
+    span_queue_drops: int = 0
+    log_queue_drops: int = 0
+    span_export_failures: int = 0
+    log_export_failures: int = 0
+    masked_span_drops: int = 0
+    masked_log_drops: int = 0
+
+
+class DeliveryDiagnostics:
+    """Thread-safe per-pipeline counters retained for doctor diagnostics."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._values = DeliveryDiagnosticsSnapshot()
+
+    def record_queue_drop(self, signal: str, count: int = 1) -> None:
+        with self._lock:
+            field = "span_queue_drops" if signal == "span" else "log_queue_drops"
+            setattr(self._values, field, getattr(self._values, field) + count)
+
+    def record_export_failure(self, signal: str, count: int) -> None:
+        with self._lock:
+            field = "span_export_failures" if signal == "span" else "log_export_failures"
+            setattr(self._values, field, getattr(self._values, field) + count)
+
+    def record_masked_drop(self, signal: str, count: int = 1) -> None:
+        with self._lock:
+            field = "masked_span_drops" if signal == "span" else "masked_log_drops"
+            setattr(self._values, field, getattr(self._values, field) + count)
+
+    def snapshot(self) -> dict[str, int]:
+        with self._lock:
+            return asdict(self._values)
+
+
+class ObservableBatchSpanProcessor(BatchSpanProcessor):
+    def __init__(self, *args, diagnostics: DeliveryDiagnostics, **kwargs) -> None:
+        self._neatlogs_diagnostics = diagnostics
+        super().__init__(*args, **kwargs)
+
+    def on_end(self, span) -> None:
+        if span.context and span.context.trace_flags.sampled:
+            processor = self._batch_processor
+            if len(processor._queue) >= processor._max_queue_size:
+                self._neatlogs_diagnostics.record_queue_drop("span")
+        super().on_end(span)
+
+
+class ObservableBatchLogRecordProcessor(BatchLogRecordProcessor):
+    def __init__(self, *args, diagnostics: DeliveryDiagnostics, **kwargs) -> None:
+        self._neatlogs_diagnostics = diagnostics
+        super().__init__(*args, **kwargs)
+
+    def on_emit(self, log_record) -> None:
+        processor = self._batch_processor
+        if len(processor._queue) >= processor._max_queue_size:
+            self._neatlogs_diagnostics.record_queue_drop("log")
+        super().on_emit(log_record)

--- a/neatlogs/core/masking_exporter.py
+++ b/neatlogs/core/masking_exporter.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import copy
 import inspect
 import logging
+import queue
+import threading
+import time
+from dataclasses import dataclass
 from collections.abc import Mapping, Sequence
 from typing import Any, Callable
 
@@ -25,45 +28,142 @@ from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.trace import Link, Status, StatusCode
 
 from .mask import effective_mask
+from .delivery import DeliveryDiagnostics
 
 logger = logging.getLogger(__name__)
 
 
-def _mask_call(mask: Callable, snapshot: dict[str, Any], timeout_seconds: float):
-    result = mask(snapshot)
+@dataclass(frozen=True)
+class MaskContext:
+    """Deadline/cancellation information supplied to context-aware masks."""
+
+    signal_type: str
+    timeout_seconds: float
+    deadline_monotonic: float
+    cancelled: threading.Event
+
+
+def _accepts_context(mask: Callable, snapshot: dict[str, Any], context: MaskContext) -> bool:
+    try:
+        inspect.signature(mask).bind(snapshot, context)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _mask_call(
+    mask: Callable,
+    snapshot: dict[str, Any],
+    timeout_seconds: float,
+    context: MaskContext,
+):
+    result = (
+        mask(snapshot, context) if _accepts_context(mask, snapshot, context) else mask(snapshot)
+    )
     if inspect.isawaitable(result):
         return asyncio.run(asyncio.wait_for(result, timeout=timeout_seconds))
     return result
 
 
 class _MaskRunner:
-    def __init__(self, timeout_seconds: float = 5.0) -> None:
+    def __init__(self, timeout_seconds: float = 5.0, max_workers: int = 4) -> None:
         self._timeout_seconds = timeout_seconds
-        self._executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=4, thread_name_prefix="neatlogs-mask"
-        )
+        self._max_workers = max_workers
+        self._slots = threading.BoundedSemaphore(max_workers)
+        self._closed = threading.Event()
+        self._active_lock = threading.Lock()
+        self._active_cancellations: set[threading.Event] = set()
 
     def apply(self, mask: Callable, snapshot: dict[str, Any]) -> dict[str, Any] | None:
-        candidate = copy.deepcopy(snapshot)
-        future = self._executor.submit(_mask_call, mask, candidate, self._timeout_seconds)
-        try:
-            result = future.result(timeout=self._timeout_seconds)
-        except Exception as exc:
-            future.cancel()
-            logger.error(
-                "[neatlogs] mask failed; telemetry item dropped (%s)",
-                type(exc).__name__,
+        return self.apply_many(((mask, snapshot),))[0]
+
+    def apply_many(
+        self,
+        items: Sequence[tuple[Callable, dict[str, Any]]],
+    ) -> list[dict[str, Any] | None]:
+        """Mask a batch concurrently under one bounded export-worker deadline."""
+        if not items:
+            return []
+        results: list[dict[str, Any] | None] = [None] * len(items)
+        deadline = time.monotonic() + self._timeout_seconds
+        result_queue: queue.Queue[tuple[int, bool, Any, dict[str, Any]]] = queue.Queue()
+        pending = list(range(len(items)))
+        active: dict[int, threading.Event] = {}
+
+        def launch(index: int) -> bool:
+            if self._closed.is_set() or not self._slots.acquire(blocking=False):
+                return False
+            mask, snapshot = items[index]
+            candidate = copy.deepcopy(snapshot)
+            cancelled = threading.Event()
+            context = MaskContext(
+                signal_type=str(snapshot.get("signal") or "span"),
+                timeout_seconds=max(0.0, deadline - time.monotonic()),
+                deadline_monotonic=deadline,
+                cancelled=cancelled,
             )
-            return None
-        if result is None:
-            return candidate
-        if not isinstance(result, Mapping):
-            logger.error("[neatlogs] mask returned a non-mapping; telemetry item dropped")
-            return None
-        return dict(result)
+            active[index] = cancelled
+            with self._active_lock:
+                self._active_cancellations.add(cancelled)
+
+            def run() -> None:
+                try:
+                    remaining = max(0.001, deadline - time.monotonic())
+                    result = _mask_call(mask, candidate, remaining, context)
+                    result_queue.put((index, True, result, candidate))
+                except BaseException as exc:
+                    result_queue.put((index, False, exc, candidate))
+                finally:
+                    with self._active_lock:
+                        self._active_cancellations.discard(cancelled)
+                    self._slots.release()
+
+            threading.Thread(target=run, name="neatlogs-mask", daemon=True).start()
+            return True
+
+        while pending and len(active) < self._max_workers:
+            if not launch(pending[0]):
+                break
+            pending.pop(0)
+
+        while active and time.monotonic() < deadline:
+            try:
+                index, succeeded, result, candidate = result_queue.get(
+                    timeout=max(0.001, deadline - time.monotonic())
+                )
+            except queue.Empty:
+                break
+            active.pop(index, None)
+            if succeeded and result is None:
+                results[index] = candidate
+            elif succeeded and isinstance(result, Mapping):
+                results[index] = dict(result)
+            elif succeeded:
+                logger.error("[neatlogs] mask returned a non-mapping; telemetry item dropped")
+            else:
+                logger.error(
+                    "[neatlogs] mask failed; telemetry item dropped (%s)",
+                    type(result).__name__,
+                )
+            while pending and len(active) < self._max_workers:
+                if not launch(pending[0]):
+                    break
+                pending.pop(0)
+
+        if active or pending:
+            for cancelled in active.values():
+                cancelled.set()
+            logger.error(
+                "[neatlogs] mask deadline/capacity exhausted; %d telemetry item(s) dropped",
+                len(active) + len(pending),
+            )
+        return results
 
     def shutdown(self) -> None:
-        self._executor.shutdown(wait=False, cancel_futures=True)
+        self._closed.set()
+        with self._active_lock:
+            for cancelled in self._active_cancellations:
+                cancelled.set()
 
 
 def _attrs(value: Any) -> dict[str, Any]:
@@ -155,22 +255,36 @@ def _masked_span(span: ReadableSpan, snapshot: Mapping[str, Any]) -> ReadableSpa
 class MaskingSpanExporter(SpanExporter):
     """Clone, mask and export spans; callback failures drop only the affected span."""
 
-    def __init__(self, inner: SpanExporter, mask: Callable | None) -> None:
+    def __init__(
+        self,
+        inner: SpanExporter,
+        mask: Callable | None,
+        timeout_seconds: float = 5.0,
+        diagnostics: DeliveryDiagnostics | None = None,
+    ) -> None:
         self._inner = inner
         self._global_mask = mask
-        self._runner = _MaskRunner()
+        self._runner = _MaskRunner(timeout_seconds)
+        self._diagnostics = diagnostics
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
-        kept = []
-        for span in spans:
+        prepared: list[ReadableSpan | None] = [None] * len(spans)
+        masked_inputs: list[tuple[Callable, dict[str, Any]]] = []
+        masked_indexes: list[int] = []
+        for index, span in enumerate(spans):
             snapshot = _span_snapshot(span)
             mask = effective_mask(snapshot, self._global_mask)
             if mask is None:
-                kept.append(span)
+                prepared[index] = span
                 continue
-            masked = self._runner.apply(mask, snapshot)
+            masked_inputs.append((mask, snapshot))
+            masked_indexes.append(index)
+        for index, masked in zip(masked_indexes, self._runner.apply_many(masked_inputs)):
             if masked is not None:
-                kept.append(_masked_span(span, masked))
+                prepared[index] = _masked_span(spans[index], masked)
+            elif self._diagnostics is not None:
+                self._diagnostics.record_masked_drop("span")
+        kept = [span for span in prepared if span is not None]
         if not kept:
             return SpanExportResult.SUCCESS
         return self._inner.export(kept)
@@ -201,18 +315,30 @@ def _log_snapshot(item: ReadableLogRecord) -> dict[str, Any]:
 class MaskingLogExporter(LogRecordExporter):
     """Apply the same global fail-closed mask contract to correlated logs."""
 
-    def __init__(self, inner: LogRecordExporter, mask: Callable | None) -> None:
+    def __init__(
+        self,
+        inner: LogRecordExporter,
+        mask: Callable | None,
+        timeout_seconds: float = 5.0,
+        diagnostics: DeliveryDiagnostics | None = None,
+    ) -> None:
         self._inner = inner
         self._mask = mask
-        self._runner = _MaskRunner()
+        self._runner = _MaskRunner(timeout_seconds)
+        self._diagnostics = diagnostics
 
     def export(self, batch: Sequence[ReadableLogRecord]) -> LogRecordExportResult:
         if self._mask is None:
-            return self._inner.export(batch)
+            result = self._inner.export(batch)
+            if result is not LogRecordExportResult.SUCCESS and self._diagnostics is not None:
+                self._diagnostics.record_export_failure("log", len(batch))
+            return result
         kept = []
-        for item in batch:
-            masked = self._runner.apply(self._mask, _log_snapshot(item))
+        snapshots = [(self._mask, _log_snapshot(item)) for item in batch]
+        for item, masked in zip(batch, self._runner.apply_many(snapshots)):
             if masked is None:
+                if self._diagnostics is not None:
+                    self._diagnostics.record_masked_drop("log")
                 continue
             clone = copy.copy(item)
             clone_record = copy.copy(item.log_record)
@@ -241,7 +367,10 @@ class MaskingLogExporter(LogRecordExporter):
             kept.append(clone)
         if not kept:
             return LogRecordExportResult.SUCCESS
-        return self._inner.export(kept)
+        result = self._inner.export(kept)
+        if result is not LogRecordExportResult.SUCCESS and self._diagnostics is not None:
+            self._diagnostics.record_export_failure("log", len(kept))
+        return result
 
     def force_flush(self, timeout_millis: int = 10000) -> bool:
         # LogRecordExporter.force_flush became abstract in OpenTelemetry 1.44.

--- a/neatlogs/core/masking_exporter.py
+++ b/neatlogs/core/masking_exporter.py
@@ -44,12 +44,18 @@ class MaskContext:
     cancelled: threading.Event
 
 
-def _accepts_context(mask: Callable, snapshot: dict[str, Any], context: MaskContext) -> bool:
+def _accepts_context(mask: Callable) -> bool:
+    """Require an explicit keyword-only context opt-in.
+
+    The original public callback contract accepted one positional snapshot.
+    Binding a second positional argument breaks callbacks that happen to have
+    an unrelated optional positional parameter.
+    """
     try:
-        inspect.signature(mask).bind(snapshot, context)
+        parameter = inspect.signature(mask).parameters.get("context")
     except (TypeError, ValueError):
         return False
-    return True
+    return parameter is not None and parameter.kind is inspect.Parameter.KEYWORD_ONLY
 
 
 def _mask_call(
@@ -58,9 +64,7 @@ def _mask_call(
     timeout_seconds: float,
     context: MaskContext,
 ):
-    result = (
-        mask(snapshot, context) if _accepts_context(mask, snapshot, context) else mask(snapshot)
-    )
+    result = mask(snapshot, context=context) if _accepts_context(mask) else mask(snapshot)
     if inspect.isawaitable(result):
         return asyncio.run(asyncio.wait_for(result, timeout=timeout_seconds))
     return result
@@ -330,10 +334,7 @@ class MaskingLogExporter(LogRecordExporter):
 
     def export(self, batch: Sequence[ReadableLogRecord]) -> LogRecordExportResult:
         if self._mask is None:
-            result = self._inner.export(batch)
-            if result is not LogRecordExportResult.SUCCESS and self._diagnostics is not None:
-                self._diagnostics.record_export_failure("log", len(batch))
-            return result
+            return self._inner.export(batch)
         kept = []
         snapshots = [(self._mask, _log_snapshot(item)) for item in batch]
         for item, masked in zip(batch, self._runner.apply_many(snapshots)):
@@ -368,10 +369,7 @@ class MaskingLogExporter(LogRecordExporter):
             kept.append(clone)
         if not kept:
             return LogRecordExportResult.SUCCESS
-        result = self._inner.export(kept)
-        if result is not LogRecordExportResult.SUCCESS and self._diagnostics is not None:
-            self._diagnostics.record_export_failure("log", len(kept))
-        return result
+        return self._inner.export(kept)
 
     def force_flush(self, timeout_millis: int = 10000) -> bool:
         # LogRecordExporter.force_flush became abstract in OpenTelemetry 1.44.

--- a/neatlogs/core/masking_exporter.py
+++ b/neatlogs/core/masking_exporter.py
@@ -32,6 +32,7 @@ from .delivery import DeliveryDiagnostics
 from .mask import effective_mask
 
 logger = logging.getLogger(__name__)
+_MASK_POOL_SIZE = 4
 
 
 @dataclass(frozen=True)
@@ -70,11 +71,55 @@ def _mask_call(
     return result
 
 
+class _MaskWorkerPool:
+    """Fixed workers created before atexit; submissions never create threads."""
+
+    def __init__(self, max_workers: int = _MASK_POOL_SIZE) -> None:
+        self._tasks: queue.Queue[Callable[[], None]] = queue.Queue()
+        self._slots = threading.BoundedSemaphore(max_workers)
+        self._workers = [
+            threading.Thread(
+                target=self._run,
+                name=f"neatlogs-mask-{index}",
+                daemon=True,
+            )
+            for index in range(max_workers)
+        ]
+        for worker in self._workers:
+            worker.start()
+
+    def _run(self) -> None:
+        while True:
+            operation = self._tasks.get()
+            try:
+                operation()
+            finally:
+                self._slots.release()
+
+    def submit(self, operation: Callable[[], None]) -> bool:
+        if not self._slots.acquire(blocking=False):
+            return False
+        self._tasks.put_nowait(operation)
+        return True
+
+
+_mask_pool: _MaskWorkerPool | None = None
+_mask_pool_lock = threading.Lock()
+
+
+def _get_mask_pool() -> _MaskWorkerPool:
+    global _mask_pool
+    with _mask_pool_lock:
+        if _mask_pool is None:
+            _mask_pool = _MaskWorkerPool()
+        return _mask_pool
+
+
 class _MaskRunner:
     def __init__(self, timeout_seconds: float = 5.0, max_workers: int = 4) -> None:
         self._timeout_seconds = timeout_seconds
         self._max_workers = max_workers
-        self._slots = threading.BoundedSemaphore(max_workers)
+        self._pool = _get_mask_pool()
         self._closed = threading.Event()
         self._active_lock = threading.Lock()
         self._active_cancellations: set[threading.Event] = set()
@@ -96,7 +141,7 @@ class _MaskRunner:
         active: dict[int, threading.Event] = {}
 
         def launch(index: int) -> bool:
-            if self._closed.is_set() or not self._slots.acquire(blocking=False):
+            if self._closed.is_set():
                 return False
             mask, snapshot = items[index]
             candidate = copy.deepcopy(snapshot)
@@ -121,9 +166,12 @@ class _MaskRunner:
                 finally:
                     with self._active_lock:
                         self._active_cancellations.discard(cancelled)
-                    self._slots.release()
 
-            threading.Thread(target=run, name="neatlogs-mask", daemon=True).start()
+            if not self._pool.submit(run):
+                with self._active_lock:
+                    self._active_cancellations.discard(cancelled)
+                active.pop(index, None)
+                return False
             return True
 
         while pending and len(active) < self._max_workers:

--- a/neatlogs/core/masking_exporter.py
+++ b/neatlogs/core/masking_exporter.py
@@ -9,8 +9,8 @@ import logging
 import queue
 import threading
 import time
-from dataclasses import dataclass
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any, Callable
 
 try:
@@ -22,13 +22,14 @@ except ImportError:  # OpenTelemetry 1.35-1.38 compatibility
         LogExporter as LogRecordExporter,
         LogExportResult as LogRecordExportResult,
     )
+
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Event, ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.trace import Link, Status, StatusCode
 
-from .mask import effective_mask
 from .delivery import DeliveryDiagnostics
+from .mask import effective_mask
 
 logger = logging.getLogger(__name__)
 

--- a/neatlogs/core/media.py
+++ b/neatlogs/core/media.py
@@ -8,9 +8,11 @@ import hashlib
 import mimetypes
 from collections.abc import Mapping, Sequence
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlsplit, urlunsplit
 
 from .capture import DEFAULT_MAX_CAPTURE_VALUE_BYTES, UPLOAD_UNAVAILABLE_REASON
+
+_MEDIA_KINDS = {"image", "audio", "video", "document", "file", "input_file"}
 
 
 def _kind(mime_type: str, declared: str = "") -> str:
@@ -76,9 +78,29 @@ def _inline(data: str, mime_type: str, declared: str, purpose: str) -> dict[str,
     return record
 
 
+def _sanitized_reference(reference: str) -> str:
+    """Remove credentials and bearer material from a captured media locator."""
+
+    try:
+        parsed = urlsplit(reference)
+    except ValueError:
+        # Malformed bracketed hosts must still fail closed instead of falling
+        # back to serializing their credential-bearing original value.
+        safe = reference.split("#", 1)[0].split("?", 1)[0]
+        if "://" in safe:
+            scheme, remainder = safe.split("://", 1)
+            safe = f"{scheme}://{remainder.rsplit('@', 1)[-1]}"
+        return safe
+    # ``urlsplit`` leaves opaque provider IDs in ``path``. Preserve those, but
+    # never retain URL userinfo, query credentials, or fragments in telemetry.
+    netloc = parsed.netloc.rsplit("@", 1)[-1]
+    return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+
+
 def _reference(reference: str, mime_type: str, declared: str, purpose: str) -> dict[str, Any]:
-    digest = hashlib.sha256(reference.encode()).hexdigest()
-    parsed = urlparse(reference)
+    safe_reference = _sanitized_reference(reference)
+    digest = hashlib.sha256(safe_reference.encode()).hexdigest()
+    parsed = urlsplit(safe_reference)
     guessed = mimetypes.guess_type(parsed.path)[0] or ""
     source = "provider" if not parsed.scheme or parsed.scheme in {"gs", "s3"} else "url"
     return {
@@ -86,19 +108,189 @@ def _reference(reference: str, mime_type: str, declared: str, purpose: str) -> d
         "type": _kind(mime_type or guessed, declared),
         "source": source,
         "mime_type": mime_type or guessed or "application/octet-stream",
-        "reference": reference,
+        "reference": safe_reference,
         "purpose": purpose,
         "state": "available",
     }
 
 
+def _unavailable_placeholder(record: Mapping[str, Any]) -> dict[str, Any]:
+    """A secret-free replacement for inline bytes that cannot be uploaded."""
+
+    return {
+        "neatlogs_media": {
+            key: record[key]
+            for key in (
+                "id",
+                "type",
+                "source",
+                "mime_type",
+                "byte_length",
+                "sha256",
+                "purpose",
+                "state",
+                "safe_preview",
+            )
+            if key in record
+        }
+    }
+
+
+def sanitize_media_payload(value: Any, purpose: str = "capture") -> Any:
+    """Clone provider-shaped media while removing unsafe inline/URL secrets.
+
+    Small inline values remain available to ordinary capture. Large inline
+    values are replaced by typed failure metadata because no authenticated
+    upload authority exists yet. Remote locators retain only scheme/host/path.
+    """
+
+    def sanitize(
+        node: Any,
+        inherited_declared: str = "",
+        inherited_mime_type: str = "",
+    ) -> Any:
+        if isinstance(node, Mapping):
+            declared = str(node.get("type") or "")
+            media_declared = declared if declared.lower() in _MEDIA_KINDS else inherited_declared
+            mime_type = str(
+                node.get("mime_type")
+                or node.get("mimeType")
+                or node.get("media_type")
+                or node.get("mediaType")
+                or inherited_mime_type
+            )
+            result = {}
+            for key, item in node.items():
+                keyed_kind = str(key).lower().replace("input_", "")
+                child_declared = keyed_kind if keyed_kind in _MEDIA_KINDS else media_declared
+                result[key] = sanitize(item, child_declared, mime_type)
+
+            for key in ("image_url", "imageUrl"):
+                image = node.get(key)
+                if isinstance(image, Mapping) and isinstance(image.get("url"), str):
+                    original = image["url"]
+                    record = (
+                        _inline(original, mime_type, "image", purpose)
+                        if original.startswith("data:")
+                        else _reference(original, mime_type, "image", purpose)
+                    )
+                    image_result = dict(result[key])
+                    if record is not None and record.get("state") == "failed":
+                        image_result["url"] = _unavailable_placeholder(record)
+                    elif record is not None:
+                        image_result["url"] = record.get("reference", original)
+                    result[key] = image_result
+                elif isinstance(image, str):
+                    record = (
+                        _inline(image, mime_type, "image", purpose)
+                        if image.startswith("data:")
+                        else _reference(image, mime_type, "image", purpose)
+                    )
+                    if record is not None and record.get("state") == "failed":
+                        result[key] = _unavailable_placeholder(record)
+                    elif record is not None:
+                        result[key] = record.get("reference", image)
+
+            for key in ("input_audio", "inputAudio"):
+                audio = node.get(key)
+                if isinstance(audio, Mapping) and isinstance(audio.get("data"), str):
+                    fmt = str(audio.get("format") or "")
+                    record = _inline(
+                        audio["data"],
+                        mime_type or (f"audio/{fmt}" if fmt else "audio/unknown"),
+                        "audio",
+                        purpose,
+                    )
+                    if record is not None and record.get("state") == "failed":
+                        audio_result = dict(result[key])
+                        audio_result["data"] = _unavailable_placeholder(record)
+                        result[key] = audio_result
+
+            for key in ("inline_data", "inlineData"):
+                inline_data = node.get(key)
+                if isinstance(inline_data, Mapping) and isinstance(inline_data.get("data"), str):
+                    record = _inline(
+                        inline_data["data"],
+                        str(
+                            inline_data.get("mime_type") or inline_data.get("mimeType") or mime_type
+                        ),
+                        declared,
+                        purpose,
+                    )
+                    if record is not None and record.get("state") == "failed":
+                        inline_result = dict(result[key])
+                        inline_result["data"] = _unavailable_placeholder(record)
+                        result[key] = inline_result
+
+            file_data = node.get("file_data") or node.get("fileData")
+            if isinstance(file_data, str):
+                record = _inline(file_data, mime_type, declared or "document", purpose)
+                if record is not None and record.get("state") == "failed":
+                    key = "file_data" if "file_data" in node else "fileData"
+                    result[key] = _unavailable_placeholder(record)
+
+            raw_key = "data" if "data" in node else "bytes" if "bytes" in node else None
+            raw_data = node.get(raw_key) if raw_key is not None else None
+            if isinstance(raw_data, str) and (media_declared or mime_type):
+                record = _inline(raw_data, mime_type, media_declared, purpose)
+                if record is not None and record.get("state") == "failed":
+                    result[raw_key] = _unavailable_placeholder(record)
+            if (
+                isinstance(raw_data, (bytes, bytearray))
+                and (media_declared or mime_type)
+                and len(raw_data) > DEFAULT_MAX_CAPTURE_VALUE_BYTES
+            ):
+                digest = hashlib.sha256(raw_data).hexdigest()
+                result[raw_key] = _unavailable_placeholder(
+                    {
+                        "id": f"nl_media_{digest[:24]}",
+                        "type": _kind(mime_type, media_declared),
+                        "source": "inline",
+                        "mime_type": mime_type or "application/octet-stream",
+                        "byte_length": len(raw_data),
+                        "sha256": digest,
+                        "purpose": purpose,
+                        "state": "failed",
+                        "safe_preview": f"upload unavailable: {UPLOAD_UNAVAILABLE_REASON}",
+                    }
+                )
+
+            reference_key = next(
+                (key for key in ("file_id", "file_uri", "fileUri", "url") if key in node),
+                None,
+            )
+            if reference_key is not None:
+                reference = node.get(reference_key)
+                if isinstance(reference, str) and (
+                    declared.lower() == "url" or media_declared or mime_type
+                ):
+                    result[reference_key] = _sanitized_reference(reference)
+            return result
+        if isinstance(node, Sequence) and not isinstance(node, (str, bytes, bytearray)):
+            return [sanitize(item) for item in node]
+        return node
+
+    return sanitize(value)
+
+
 def media_references(value: Any, purpose: str) -> list[dict[str, Any]]:
     found: list[dict[str, Any]] = []
 
-    def visit(node: Any) -> None:
+    def visit(
+        node: Any,
+        inherited_declared: str = "",
+        inherited_mime_type: str = "",
+    ) -> None:
         if isinstance(node, Mapping):
             declared = str(node.get("type") or "")
-            mime_type = str(node.get("mime_type") or node.get("mimeType") or "")
+            media_declared = declared if declared.lower() in _MEDIA_KINDS else inherited_declared
+            mime_type = str(
+                node.get("mime_type")
+                or node.get("mimeType")
+                or node.get("media_type")
+                or node.get("mediaType")
+                or inherited_mime_type
+            )
             image = node.get("image_url") or node.get("imageUrl")
             if isinstance(image, Mapping):
                 image = image.get("url")
@@ -136,13 +328,18 @@ def media_references(value: Any, purpose: str) -> list[dict[str, Any]]:
                 record = _inline(file_data, mime_type, declared or "document", purpose)
                 if record:
                     found.append(record)
-            raw_data = node.get("data")
-            if isinstance(raw_data, (bytes, bytearray)) and (declared or mime_type):
+            raw_key = "data" if "data" in node else "bytes" if "bytes" in node else None
+            raw_data = node.get(raw_key) if raw_key is not None else None
+            if isinstance(raw_data, str) and (media_declared or mime_type):
+                record = _inline(raw_data, mime_type, media_declared, purpose)
+                if record:
+                    found.append(record)
+            if isinstance(raw_data, (bytes, bytearray)) and (media_declared or mime_type):
                 digest = hashlib.sha256(raw_data).hexdigest()
                 found.append(
                     {
                         "id": f"nl_media_{digest[:24]}",
-                        "type": _kind(mime_type, declared),
+                        "type": _kind(mime_type, media_declared),
                         "source": "inline",
                         "mime_type": mime_type or "application/octet-stream",
                         "byte_length": len(raw_data),
@@ -168,13 +365,19 @@ def media_references(value: Any, purpose: str) -> list[dict[str, Any]]:
                 or node.get("fileUri")
                 or node.get("url")
             )
-            if isinstance(reference, str) and (declared in {"file", "input_file"} or mime_type):
-                found.append(_reference(reference, mime_type, declared or "document", purpose))
-            for child in node.values():
-                visit(child)
+            if isinstance(reference, str) and (
+                declared.lower() == "url" or media_declared or mime_type
+            ):
+                found.append(
+                    _reference(reference, mime_type, media_declared or "document", purpose)
+                )
+            for key, child in node.items():
+                keyed_kind = str(key).lower().replace("input_", "")
+                child_declared = keyed_kind if keyed_kind in _MEDIA_KINDS else media_declared
+                visit(child, child_declared, mime_type)
         elif isinstance(node, Sequence) and not isinstance(node, (str, bytes, bytearray)):
             for child in node:
-                visit(child)
+                visit(child, inherited_declared, inherited_mime_type)
 
     visit(value)
     unique: dict[tuple[Any, ...], dict[str, Any]] = {}

--- a/neatlogs/core/media.py
+++ b/neatlogs/core/media.py
@@ -1,0 +1,128 @@
+"""Typed multimodal discovery without fetching remote content or truncating data."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import mimetypes
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import urlparse
+
+
+def _kind(mime_type: str, declared: str = "") -> str:
+    value = declared.lower().replace("input_", "")
+    if value in {"image", "audio", "video", "document"}:
+        return value
+    if mime_type.startswith("image/"):
+        return "image"
+    if mime_type.startswith("audio/"):
+        return "audio"
+    if mime_type.startswith("video/"):
+        return "video"
+    if mime_type == "application/pdf" or mime_type.startswith("text/"):
+        return "document"
+    return "media"
+
+
+def _inline(data: str, mime_type: str, declared: str, purpose: str) -> dict[str, Any] | None:
+    encoded = data
+    if data.startswith("data:"):
+        header, separator, encoded = data.partition(",")
+        if not separator:
+            return None
+        mime_type = header[5:].split(";", 1)[0] or mime_type
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+    except (ValueError, TypeError):
+        return None
+    digest = hashlib.sha256(raw).hexdigest()
+    return {
+        "id": f"nl_media_{digest[:24]}",
+        "type": _kind(mime_type, declared),
+        "source": "inline",
+        "mime_type": mime_type or "application/octet-stream",
+        "byte_length": len(raw),
+        "sha256": digest,
+        "purpose": purpose,
+        "state": "inline",
+    }
+
+
+def _reference(reference: str, mime_type: str, declared: str, purpose: str) -> dict[str, Any]:
+    digest = hashlib.sha256(reference.encode()).hexdigest()
+    parsed = urlparse(reference)
+    guessed = mimetypes.guess_type(parsed.path)[0] or ""
+    source = "provider" if not parsed.scheme or parsed.scheme in {"gs", "s3"} else "url"
+    return {
+        "id": f"nl_media_{digest[:24]}",
+        "type": _kind(mime_type or guessed, declared),
+        "source": source,
+        "mime_type": mime_type or guessed or "application/octet-stream",
+        "reference": reference,
+        "purpose": purpose,
+        "state": "available",
+    }
+
+
+def media_references(value: Any, purpose: str) -> list[dict[str, Any]]:
+    found: list[dict[str, Any]] = []
+
+    def visit(node: Any) -> None:
+        if isinstance(node, Mapping):
+            declared = str(node.get("type") or "")
+            mime_type = str(node.get("mime_type") or node.get("mimeType") or "")
+            image = node.get("image_url") or node.get("imageUrl")
+            if isinstance(image, Mapping):
+                image = image.get("url")
+            if isinstance(image, str):
+                record = (
+                    _inline(image, mime_type, "image", purpose)
+                    if image.startswith("data:")
+                    else _reference(image, mime_type, "image", purpose)
+                )
+                if record:
+                    found.append(record)
+            audio = node.get("input_audio") or node.get("inputAudio")
+            if isinstance(audio, Mapping) and isinstance(audio.get("data"), str):
+                fmt = str(audio.get("format") or "")
+                record = _inline(
+                    audio["data"],
+                    mime_type or (f"audio/{fmt}" if fmt else "audio/unknown"),
+                    "audio",
+                    purpose,
+                )
+                if record:
+                    found.append(record)
+            file_data = node.get("file_data") or node.get("fileData")
+            if isinstance(file_data, str):
+                record = _inline(file_data, mime_type, declared or "document", purpose)
+                if record:
+                    found.append(record)
+            reference = (
+                node.get("file_id")
+                or node.get("file_uri")
+                or node.get("fileUri")
+                or node.get("url")
+            )
+            if isinstance(reference, str) and (declared in {"file", "input_file"} or mime_type):
+                found.append(_reference(reference, mime_type, declared or "document", purpose))
+            for child in node.values():
+                visit(child)
+        elif isinstance(node, Sequence) and not isinstance(node, (str, bytes, bytearray)):
+            for child in node:
+                visit(child)
+
+    visit(value)
+    unique: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for record in found:
+        if record is not None:
+            key = (record.get("sha256"), record.get("reference"), record.get("type"))
+            unique[key] = record
+    return list(unique.values())
+
+
+def set_media_attributes(span: Any, prefix: str, value: Any, purpose: str) -> None:
+    for index, record in enumerate(media_references(value, purpose)):
+        for key, item in record.items():
+            span.set_attribute(f"{prefix}.media.{index}.{key}", item)

--- a/neatlogs/core/media.py
+++ b/neatlogs/core/media.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import mimetypes
 from collections.abc import Mapping, Sequence
 from typing import Any
 from urllib.parse import urlparse
+
+from .capture import DEFAULT_MAX_CAPTURE_VALUE_BYTES, UPLOAD_UNAVAILABLE_REASON
 
 
 def _kind(mime_type: str, declared: str = "") -> str:
@@ -25,6 +28,22 @@ def _kind(mime_type: str, declared: str = "") -> str:
     return "media"
 
 
+def _base64_metadata(encoded: str) -> tuple[int, str] | None:
+    """Validate/digest base64 incrementally without duplicating the full media."""
+
+    digest = hashlib.sha256()
+    byte_length = 0
+    chunk_size = 64 * 1024  # divisible by four, so quartets never cross chunks
+    try:
+        for offset in range(0, len(encoded), chunk_size):
+            decoded = base64.b64decode(encoded[offset : offset + chunk_size], validate=True)
+            digest.update(decoded)
+            byte_length += len(decoded)
+    except (binascii.Error, ValueError, TypeError):
+        return None
+    return byte_length, digest.hexdigest()
+
+
 def _inline(data: str, mime_type: str, declared: str, purpose: str) -> dict[str, Any] | None:
     encoded = data
     if data.startswith("data:"):
@@ -32,21 +51,29 @@ def _inline(data: str, mime_type: str, declared: str, purpose: str) -> dict[str,
         if not separator:
             return None
         mime_type = header[5:].split(";", 1)[0] or mime_type
-    try:
-        raw = base64.b64decode(encoded, validate=True)
-    except (ValueError, TypeError):
+    metadata = _base64_metadata(encoded)
+    if metadata is None:
         return None
-    digest = hashlib.sha256(raw).hexdigest()
-    return {
+    byte_length, digest = metadata
+    record = {
         "id": f"nl_media_{digest[:24]}",
         "type": _kind(mime_type, declared),
         "source": "inline",
         "mime_type": mime_type or "application/octet-stream",
-        "byte_length": len(raw),
+        "byte_length": byte_length,
         "sha256": digest,
         "purpose": purpose,
-        "state": "inline",
     }
+    if len(data.encode("utf-8")) > DEFAULT_MAX_CAPTURE_VALUE_BYTES:
+        record.update(
+            {
+                "state": "failed",
+                "safe_preview": f"upload unavailable: {UPLOAD_UNAVAILABLE_REASON}",
+            }
+        )
+    else:
+        record["state"] = "inline"
+    return record
 
 
 def _reference(reference: str, mime_type: str, declared: str, purpose: str) -> dict[str, Any]:
@@ -94,11 +121,47 @@ def media_references(value: Any, purpose: str) -> list[dict[str, Any]]:
                 )
                 if record:
                     found.append(record)
+            inline_data = node.get("inline_data") or node.get("inlineData")
+            if isinstance(inline_data, Mapping) and isinstance(inline_data.get("data"), str):
+                record = _inline(
+                    inline_data["data"],
+                    str(inline_data.get("mime_type") or inline_data.get("mimeType") or mime_type),
+                    declared,
+                    purpose,
+                )
+                if record:
+                    found.append(record)
             file_data = node.get("file_data") or node.get("fileData")
             if isinstance(file_data, str):
                 record = _inline(file_data, mime_type, declared or "document", purpose)
                 if record:
                     found.append(record)
+            raw_data = node.get("data")
+            if isinstance(raw_data, (bytes, bytearray)) and (declared or mime_type):
+                digest = hashlib.sha256(raw_data).hexdigest()
+                found.append(
+                    {
+                        "id": f"nl_media_{digest[:24]}",
+                        "type": _kind(mime_type, declared),
+                        "source": "inline",
+                        "mime_type": mime_type or "application/octet-stream",
+                        "byte_length": len(raw_data),
+                        "sha256": digest,
+                        "purpose": purpose,
+                        "state": (
+                            "inline"
+                            if len(raw_data) <= DEFAULT_MAX_CAPTURE_VALUE_BYTES
+                            else "failed"
+                        ),
+                        **(
+                            {}
+                            if len(raw_data) <= DEFAULT_MAX_CAPTURE_VALUE_BYTES
+                            else {
+                                "safe_preview": (f"upload unavailable: {UPLOAD_UNAVAILABLE_REASON}")
+                            }
+                        ),
+                    }
+                )
             reference = (
                 node.get("file_id")
                 or node.get("file_uri")

--- a/neatlogs/core/transport.py
+++ b/neatlogs/core/transport.py
@@ -1,0 +1,33 @@
+"""OTLP HTTP session policy that complements (without duplicating) OTel retry."""
+
+from __future__ import annotations
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+def build_otlp_session() -> requests.Session:
+    """Retry POST 429/read-timeout failures that OTel Python 1.43 does not.
+
+    The upstream exporter already retries 408, 5xx, and connection failures.
+    Restricting this adapter to 429 and read errors avoids nested retries for
+    the statuses handled by that outer OTLP loop.
+    """
+    retry = Retry(
+        total=2,
+        connect=0,
+        read=2,
+        status=2,
+        other=0,
+        allowed_methods=frozenset({"POST"}),
+        status_forcelist=frozenset({429}),
+        backoff_factor=0.1,
+        respect_retry_after_header=False,
+        raise_on_status=False,
+    )
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session

--- a/neatlogs/core/transport.py
+++ b/neatlogs/core/transport.py
@@ -2,32 +2,73 @@
 
 from __future__ import annotations
 
+import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
 import requests
 from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
+
+_MAX_RATE_LIMIT_ATTEMPTS = 3
+_MAX_RETRY_AFTER_SECONDS = 5.0
+
+
+def _retry_after_seconds(value: str | None, fallback: float) -> float:
+    if not value:
+        return fallback
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        try:
+            when = parsedate_to_datetime(value)
+            if when.tzinfo is None:
+                when = when.replace(tzinfo=timezone.utc)
+            return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
+        except (TypeError, ValueError, OverflowError):
+            return fallback
+
+
+class _OtlpSession(requests.Session):
+    """Retry only definitely-rejected 429 requests inside the caller's deadline.
+
+    The OpenTelemetry exporter owns connection/408/5xx retries. In particular,
+    read timeouts are not retried here because the receiver may already have
+    accepted the POST. Keeping urllib3 retries disabled also supports every
+    urllib3 version allowed by ``requests>=2.31`` without relying on newer
+    ``Retry`` constructor arguments.
+    """
+
+    def request(self, method, url, **kwargs):
+        timeout = kwargs.get("timeout")
+        if method.upper() != "POST" or not isinstance(timeout, (int, float)):
+            return super().request(method, url, **kwargs)
+
+        deadline = time.monotonic() + max(0.0, float(timeout))
+        for attempt in range(_MAX_RATE_LIMIT_ATTEMPTS):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise requests.exceptions.Timeout("OTLP export deadline exceeded")
+            kwargs["timeout"] = remaining
+            response = super().request(method, url, **kwargs)
+            if response.status_code != 429 or attempt + 1 == _MAX_RATE_LIMIT_ATTEMPTS:
+                return response
+
+            delay = min(
+                _MAX_RETRY_AFTER_SECONDS,
+                _retry_after_seconds(response.headers.get("Retry-After"), 0.1 * (2**attempt)),
+            )
+            if delay >= deadline - time.monotonic():
+                return response
+            response.close()
+            if delay:
+                time.sleep(delay)
+        return response
 
 
 def build_otlp_session() -> requests.Session:
-    """Retry POST 429/read-timeout failures that OTel Python 1.43 does not.
-
-    The upstream exporter already retries 408, 5xx, and connection failures.
-    Restricting this adapter to 429 and read errors avoids nested retries for
-    the statuses handled by that outer OTLP loop.
-    """
-    retry = Retry(
-        total=2,
-        connect=0,
-        read=2,
-        status=2,
-        other=0,
-        allowed_methods=frozenset({"POST"}),
-        status_forcelist=frozenset({429}),
-        backoff_factor=0.1,
-        respect_retry_after_header=False,
-        raise_on_status=False,
-    )
-    session = requests.Session()
-    adapter = HTTPAdapter(max_retries=retry)
+    """Build a dedicated OTLP session with no urllib3-level POST retries."""
+    session = _OtlpSession()
+    adapter = HTTPAdapter(max_retries=0)
     session.mount("https://", adapter)
     session.mount("http://", adapter)
     return session

--- a/neatlogs/core/upload_authority.py
+++ b/neatlogs/core/upload_authority.py
@@ -21,14 +21,30 @@ class OverflowPayload:
     encoding: str = "identity"
 
 
+@dataclass(frozen=True)
+class OverflowExportReceipt:
+    """Proof that backend validation completed and its small reference exported."""
+
+    upload_id: str
+    project_id: str
+    state: str
+    reference_exported: bool
+
+    @property
+    def complete(self) -> bool:
+        return bool(
+            self.upload_id and self.project_id and self.state == "ready" and self.reference_exported
+        )
+
+
 class UploadAuthority(Protocol):
     """Internal seam; no backend URL or authentication contract is assumed."""
 
     available: bool
     unavailable_reason: str
 
-    def export_overflow(self, payload: OverflowPayload) -> bool:
-        """Upload bytes and export the resulting small canonical reference."""
+    def export_overflow(self, payload: OverflowPayload) -> OverflowExportReceipt | None:
+        """Upload, validate, and export a small reference, returning its receipt."""
 
 
 class DisabledUploadAuthority:
@@ -37,6 +53,6 @@ class DisabledUploadAuthority:
     available = False
     unavailable_reason = UPLOAD_UNAVAILABLE_REASON
 
-    def export_overflow(self, payload: OverflowPayload) -> bool:
+    def export_overflow(self, payload: OverflowPayload) -> None:
         del payload
-        return False
+        return None

--- a/neatlogs/core/upload_authority.py
+++ b/neatlogs/core/upload_authority.py
@@ -1,0 +1,42 @@
+"""Injectable boundary for the not-yet-deployed authenticated upload contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from .capture import UPLOAD_UNAVAILABLE_REASON
+
+
+@dataclass(frozen=True)
+class OverflowPayload:
+    """A complete, masked OTLP item offered to an upload implementation."""
+
+    content: bytes
+    sha256: str
+    byte_length: int
+    signal: str
+    purpose: str = "otlp_overflow"
+    mime_type: str = "application/x-protobuf"
+    encoding: str = "identity"
+
+
+class UploadAuthority(Protocol):
+    """Internal seam; no backend URL or authentication contract is assumed."""
+
+    available: bool
+    unavailable_reason: str
+
+    def export_overflow(self, payload: OverflowPayload) -> bool:
+        """Upload bytes and export the resulting small canonical reference."""
+
+
+class DisabledUploadAuthority:
+    """Production default until the authenticated backend contract is deployed."""
+
+    available = False
+    unavailable_reason = UPLOAD_UNAVAILABLE_REASON
+
+    def export_overflow(self, payload: OverflowPayload) -> bool:
+        del payload
+        return False

--- a/neatlogs/crewai.py
+++ b/neatlogs/crewai.py
@@ -40,6 +40,7 @@ from typing import Any
 from opentelemetry.trace import StatusCode
 
 from ._wrap_utils import attach_as_current, detach, get_tracer, serialize
+from .core.capture import bound_text
 
 _CLASS_HOOKS_INSTALLED = False
 _LLM_INPUT_CAPTURE_LIMIT = 1 * 1024 * 1024
@@ -53,14 +54,14 @@ def _crewai_span_attributes(kind: str) -> dict[str, Any]:
 
 
 def _serialize_crewai_io(value: Any) -> str:
-    """Serialize CrewAI tool I/O without discarding data before export."""
+    """Serialize CrewAI tool I/O within the explicit capture boundary."""
     if isinstance(value, str):
-        return value
+        return bound_text(value)
     try:
-        return json.dumps(value, default=str, ensure_ascii=False)
+        return serialize(value)
     except Exception:
         try:
-            return str(value)
+            return bound_text(str(value))
         except Exception:
             return f"<unserializable {type(value).__name__}>"
 

--- a/neatlogs/decorators/_base.py
+++ b/neatlogs/decorators/_base.py
@@ -15,6 +15,7 @@ from opentelemetry import trace as otel_trace
 from opentelemetry.trace import Status, StatusCode
 
 F = TypeVar("F", bound=Callable[..., Any])
+_MAX_SEMANTIC_STREAM_EVENTS = 128
 
 
 def _capture_code_attrs(func: Callable[..., Any]) -> Dict[str, Any]:
@@ -237,17 +238,35 @@ def _decorate_span(
             return bound
 
         def _record_stream_chunk(span, index: int, value: Any) -> None:
+            if index >= _MAX_SEMANTIC_STREAM_EVENTS:
+                return
+            serialized = _safe_json_dumps(value)
+            summary: Dict[str, Any] = {
+                "value_type": type(value).__name__,
+                "encoded_bytes": len(serialized.encode("utf-8")),
+            }
+            if isinstance(value, dict):
+                summary["keys"] = sorted(str(key) for key in value.keys())
+            elif isinstance(value, (list, tuple)):
+                summary["items"] = len(value)
             span.add_event(
                 "neatlogs.stream.chunk",
                 {
                     "neatlogs.stream.chunk.index": index,
-                    "neatlogs.stream.chunk.value": _safe_json_dumps(value),
-                    "neatlogs.stream.chunk.mime_type": "application/json",
+                    "neatlogs.stream.chunk.summary": _safe_json_dumps(summary),
                 },
             )
 
+        def _set_stream_counts(span, count: int) -> None:
+            span.set_attribute("neatlogs.stream.chunk_count", count)
+            if count > _MAX_SEMANTIC_STREAM_EVENTS:
+                span.set_attribute(
+                    "neatlogs.stream.events_dropped",
+                    count - _MAX_SEMANTIC_STREAM_EVENTS,
+                )
+
         def _finish_stream(span, chunks: list[Any], bound_inputs: Dict[str, Any]) -> None:
-            span.set_attribute("neatlogs.stream.chunk_count", len(chunks))
+            _set_stream_counts(span, len(chunks))
             if postprocess_result is not None:
                 try:
                     postprocess_result(span, chunks, bound_inputs)
@@ -279,13 +298,13 @@ def _decorate_span(
                         _finish_stream(span, chunks, bound_inputs)
                     except (GeneratorExit, asyncio.CancelledError):
                         span.set_attribute("neatlogs.stream.cancelled", True)
-                        span.set_attribute("neatlogs.stream.chunk_count", len(chunks))
+                        _set_stream_counts(span, len(chunks))
                         if cap_out:
                             span.set_attribute("output.value", _safe_json_dumps(chunks))
                             span.set_attribute("output.mime_type", "application/json")
                         raise
                     except Exception as exc:
-                        span.set_attribute("neatlogs.stream.chunk_count", len(chunks))
+                        _set_stream_counts(span, len(chunks))
                         if cap_out:
                             span.set_attribute("output.value", _safe_json_dumps(chunks))
                             span.set_attribute("output.mime_type", "application/json")
@@ -319,13 +338,13 @@ def _decorate_span(
                         _finish_stream(span, chunks, bound_inputs)
                     except GeneratorExit:
                         span.set_attribute("neatlogs.stream.cancelled", True)
-                        span.set_attribute("neatlogs.stream.chunk_count", len(chunks))
+                        _set_stream_counts(span, len(chunks))
                         if cap_out:
                             span.set_attribute("output.value", _safe_json_dumps(chunks))
                             span.set_attribute("output.mime_type", "application/json")
                         raise
                     except Exception as exc:
-                        span.set_attribute("neatlogs.stream.chunk_count", len(chunks))
+                        _set_stream_counts(span, len(chunks))
                         if cap_out:
                             span.set_attribute("output.value", _safe_json_dumps(chunks))
                             span.set_attribute("output.mime_type", "application/json")
@@ -393,6 +412,10 @@ def _decorate_span(
                             span.set_attribute("output.mime_type", "application/json")
                         span.set_status(Status(StatusCode.OK))
                         return result
+                    except asyncio.CancelledError:
+                        span.set_attribute("neatlogs.stream.cancelled", True)
+                        span.set_status(Status(StatusCode.UNSET))
+                        raise
                     except Exception as e:
                         span.record_exception(e)
                         span.set_status(Status(StatusCode.ERROR, str(e)))

--- a/neatlogs/google_genai.py
+++ b/neatlogs/google_genai.py
@@ -426,7 +426,12 @@ def _set_usage_attributes(span: Any, usage: Any) -> None:
 
 
 def _finalize_stream(
-    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+    span: Any,
+    chunks: List[Any],
+    duration_ms: float,
+    ttft_ms: Optional[float],
+    *,
+    interrupted: bool = False,
 ) -> None:
     """Finalize a streaming response span from accumulated chunks."""
     text_parts: List[str] = []
@@ -493,7 +498,7 @@ def _finalize_stream(
                 round(duration_ms - ttft_ms, 3),
             )
 
-    span.set_status(StatusCode.OK)
+    span.set_status(StatusCode.UNSET if interrupted else StatusCode.OK)
     span.end()
 
 

--- a/neatlogs/hermes_plugin.py
+++ b/neatlogs/hermes_plugin.py
@@ -70,8 +70,8 @@ from opentelemetry.trace import (
 )
 
 from ._wrap_utils import configure, get_tracer, serialize
-from .core.logger import get_logger
 from .constants import DEFAULT_INGEST_ENDPOINT
+from .core.logger import get_logger
 
 
 class _FixedIdGen(RandomIdGenerator):

--- a/neatlogs/hermes_plugin.py
+++ b/neatlogs/hermes_plugin.py
@@ -71,6 +71,7 @@ from opentelemetry.trace import (
 
 from ._wrap_utils import configure, get_tracer, serialize
 from .core.logger import get_logger
+from .constants import DEFAULT_INGEST_ENDPOINT
 
 
 class _FixedIdGen(RandomIdGenerator):
@@ -178,7 +179,7 @@ def _ensure_configured() -> bool:
 
     # Resolve the endpoint to the SAME canonical default as neatlogs.init()
     # (ingest.neatlogs.com) and honor NEATLOGS_ENDPOINT when set.
-    endpoint = os.environ.get("NEATLOGS_ENDPOINT", "").strip() or "https://ingest.neatlogs.com"
+    endpoint = os.environ.get("NEATLOGS_ENDPOINT", "").strip() or DEFAULT_INGEST_ENDPOINT
     # workflow_name is an init()/configure() argument, not an env var, so we pass
     # our default directly. configure() only sets wrapper-mode defaults; if
     # neatlogs.init() already ran in this process (mixed library+plugin use),

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -31,6 +31,7 @@ from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
 from ._wrap_utils import _normalize_traces_endpoint
 from .constants import DEFAULT_INGEST_ENDPOINT, export_queue_capacity
 from .core.byte_limited_exporter import ByteLimitedSpanExporter
+from .core.byte_limited_log_exporter import ByteLimitedLogExporter
 from .core.deadline import bounded_call
 from .core.delivery import (
     DeliveryDiagnostics,
@@ -591,7 +592,14 @@ def init(
         _log_provider.add_log_record_processor(
             NeatlogsLogFilter(
                 ObservableBatchLogRecordProcessor(
-                    MaskingLogExporter(_otlp_log_exporter, mask, diagnostics=_delivery_diagnostics),
+                    MaskingLogExporter(
+                        ByteLimitedLogExporter(
+                            _otlp_log_exporter,
+                            diagnostics=_delivery_diagnostics,
+                        ),
+                        mask,
+                        diagnostics=_delivery_diagnostics,
+                    ),
                     max_export_batch_size=batch_size,
                     max_queue_size=export_queue_capacity(batch_size),
                     schedule_delay_millis=int(flush_interval * 1000),
@@ -639,7 +647,7 @@ def init(
         if debug:
             logger.debug(f"Instrumented libraries: {manager.instrumented}")
 
-    atexit.register(shutdown)
+    atexit.register(_atexit_shutdown)
     _init_signature = candidate_signature
     _initialized = True
     if register_shutdown_handlers:
@@ -690,7 +698,7 @@ def get_log_provider() -> Optional[LoggerProvider]:
     return _log_provider
 
 
-def get_delivery_diagnostics() -> Dict[str, int]:
+def get_delivery_diagnostics() -> Dict[str, Any]:
     """Return loss counters for the current or most recently closed pipeline."""
 
     return _delivery_diagnostics.snapshot()
@@ -749,7 +757,18 @@ def get_session_config():
     return _session_config.copy()
 
 
-def shutdown(timeout_millis: int = 30000, termination_reason: str = "shutdown") -> bool:
+def _atexit_shutdown() -> None:
+    """Synchronous interpreter-exit cleanup (Python 3.12 forbids new threads)."""
+
+    shutdown(_synchronous=True)
+
+
+def shutdown(
+    timeout_millis: int = 30000,
+    termination_reason: str = "shutdown",
+    *,
+    _synchronous: bool = False,
+) -> bool:
     """Run one shutdown at a time and make same-thread re-entry non-blocking."""
     global _shutdown_state, _shutdown_owner, _shutdown_result
     current_thread = threading.get_ident()
@@ -767,7 +786,11 @@ def shutdown(timeout_millis: int = 30000, termination_reason: str = "shutdown") 
 
     try:
         with _lifecycle_operation_lock:
-            result = _perform_shutdown(timeout_millis, termination_reason)
+            result = _perform_shutdown(
+                timeout_millis,
+                termination_reason,
+                synchronous=_synchronous,
+            )
     except BaseException:
         with _shutdown_condition:
             _shutdown_result = False
@@ -783,7 +806,12 @@ def shutdown(timeout_millis: int = 30000, termination_reason: str = "shutdown") 
             _shutdown_condition.notify_all()
 
 
-def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
+def _perform_shutdown(
+    timeout_millis: int,
+    termination_reason: str,
+    *,
+    synchronous: bool = False,
+) -> bool:
     """End active Neatlogs spans, then flush and shut down SDK providers."""
     global _tracer_provider, _owns_tracer_provider, _log_provider, _span_processor, _initialized
     global _init_signature
@@ -791,7 +819,7 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
     global _debug_mode
 
     try:
-        atexit.unregister(shutdown)
+        atexit.unregister(_atexit_shutdown)
     except Exception:
         pass
 
@@ -816,7 +844,11 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
     # it is ingested.
     if log_provider:
         logger.debug("Shutting down log provider...")
-        completed, result = bounded_call(log_provider.shutdown, deadline)
+        completed, result = bounded_call(
+            log_provider.shutdown,
+            deadline,
+            synchronous=synchronous,
+        )
         if not completed:
             logger.error("Log provider shutdown failed or timed out: %s", result)
             success = False
@@ -843,7 +875,11 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
 
     if tracer_provider:
         if owns_tracer_provider:
-            completed, result = bounded_call(tracer_provider.shutdown, deadline)
+            completed, result = bounded_call(
+                tracer_provider.shutdown,
+                deadline,
+                synchronous=synchronous,
+            )
             if completed:
                 # neatlogs created this provider → safe to fully shut down.
                 success = (result is None or bool(result)) and success
@@ -857,6 +893,7 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
                     timeout_millis=max(0, int((deadline - time.monotonic()) * 1000))
                 ),
                 deadline,
+                synchronous=synchronous,
             )
             if completed:
                 # Provider is shared (host app / Langfuse / another SDK set it). Calling
@@ -870,12 +907,20 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
                 logger.error("Tracer provider flush failed or timed out: %s", result)
                 success = False
             for processor in reversed(transport_span_processors):
-                completed, result = bounded_call(processor.shutdown, deadline)
+                completed, result = bounded_call(
+                    processor.shutdown,
+                    deadline,
+                    synchronous=synchronous,
+                )
                 if not completed:
                     logger.warning("Neatlogs transport shutdown failed or timed out: %s", result)
                     success = False
             if span_processor is not None:
-                completed, result = bounded_call(span_processor.shutdown, deadline)
+                completed, result = bounded_call(
+                    span_processor.shutdown,
+                    deadline,
+                    synchronous=synchronous,
+                )
                 if not completed:
                     logger.warning(
                         "Neatlogs span processor shutdown failed or timed out: %s", result

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -32,7 +32,7 @@ from ._wrap_utils import _normalize_traces_endpoint
 from .constants import DEFAULT_INGEST_ENDPOINT, export_queue_capacity
 from .core.byte_limited_exporter import ByteLimitedSpanExporter
 from .core.byte_limited_log_exporter import ByteLimitedLogExporter
-from .core.deadline import bounded_call
+from .core.deadline import DeadlineWorker, bounded_call
 from .core.delivery import (
     DeliveryDiagnostics,
     ObservableBatchLogRecordProcessor,
@@ -67,6 +67,7 @@ _shutdown_condition = threading.Condition(threading.RLock())
 _shutdown_state = "idle"
 _shutdown_owner = None
 _shutdown_result = True
+_shutdown_worker = None
 _lifecycle_operation_lock = threading.RLock()
 _session_config = {
     "session_id": None,
@@ -305,7 +306,7 @@ def init(
               signal termination. Defaults to True. Set False only when the host
               application owns signal handling and calls ``neatlogs.shutdown()``.
     """
-    global _initialized, _init_signature
+    global _initialized, _init_signature, _shutdown_worker
 
     candidate_signature = _configuration_signature(
         api_key=api_key,
@@ -647,6 +648,7 @@ def init(
         if debug:
             logger.debug(f"Instrumented libraries: {manager.instrumented}")
 
+    _shutdown_worker = DeadlineWorker("neatlogs-default-shutdown")
     atexit.register(_atexit_shutdown)
     _init_signature = candidate_signature
     _initialized = True
@@ -770,36 +772,60 @@ def shutdown(
     _synchronous: bool = False,
 ) -> bool:
     """Run one shutdown at a time and make same-thread re-entry non-blocking."""
-    global _shutdown_state, _shutdown_owner, _shutdown_result
+    global _shutdown_state, _shutdown_owner, _shutdown_result, _shutdown_worker
+    deadline = time.monotonic() + max(0, timeout_millis) / 1000
     current_thread = threading.get_ident()
     with _shutdown_condition:
+        if _shutdown_worker is None:
+            if _synchronous:
+                return False
+            _shutdown_worker = DeadlineWorker("neatlogs-default-shutdown")
         if _shutdown_state == "closing":
             # end_active_spans() invokes processors synchronously. If one of
             # those callbacks re-enters shutdown on this thread, waiting here
             # would deadlock the original shutdown.
-            if _shutdown_owner == current_thread:
+            if _shutdown_owner == current_thread or (
+                _shutdown_worker is not None and _shutdown_worker.is_current()
+            ):
                 return _shutdown_result
-            _shutdown_condition.wait_for(lambda: _shutdown_state == "idle")
-            return _shutdown_result
+            completed = _shutdown_condition.wait_for(
+                lambda: _shutdown_state == "idle",
+                timeout=max(0.0, deadline - time.monotonic()),
+            )
+            return _shutdown_result if completed else False
         _shutdown_state = "closing"
         _shutdown_owner = current_thread
 
+    acquired = _lifecycle_operation_lock.acquire(timeout=max(0.0, deadline - time.monotonic()))
+    if not acquired:
+        with _shutdown_condition:
+            _shutdown_result = False
+            _shutdown_state = "idle"
+            _shutdown_owner = None
+            _shutdown_condition.notify_all()
+        return False
+    shutdown_worker = _shutdown_worker
     try:
-        with _lifecycle_operation_lock:
+        try:
             result = _perform_shutdown(
-                timeout_millis,
+                max(0, int((deadline - time.monotonic()) * 1000)),
                 termination_reason,
                 synchronous=_synchronous,
             )
-    except BaseException:
-        with _shutdown_condition:
-            _shutdown_result = False
-        raise
-    else:
-        with _shutdown_condition:
-            _shutdown_result = result
-        return result
+        except BaseException:
+            with _shutdown_condition:
+                _shutdown_result = False
+            raise
+        else:
+            with _shutdown_condition:
+                _shutdown_result = result
+            return result
     finally:
+        if shutdown_worker is not None:
+            shutdown_worker.close()
+        if _shutdown_worker is shutdown_worker:
+            _shutdown_worker = None
+        _lifecycle_operation_lock.release()
         with _shutdown_condition:
             _shutdown_state = "idle"
             _shutdown_owner = None
@@ -816,7 +842,7 @@ def _perform_shutdown(
     global _tracer_provider, _owns_tracer_provider, _log_provider, _span_processor, _initialized
     global _init_signature
     global _instrumentation_manager, _transport_span_processors, _completion_span_processor
-    global _debug_mode
+    global _debug_mode, _shutdown_worker
 
     try:
         atexit.unregister(_atexit_shutdown)
@@ -834,6 +860,7 @@ def _perform_shutdown(
     completion_span_processor = _completion_span_processor
     transport_span_processors = list(_transport_span_processors)
     instrumentation_manager = _instrumentation_manager
+    shutdown_worker = _shutdown_worker
     if completion_span_processor is not None:
         completion_span_processor.begin_shutdown()
     if span_processor is not None:
@@ -848,6 +875,7 @@ def _perform_shutdown(
             log_provider.shutdown,
             deadline,
             synchronous=synchronous,
+            worker=shutdown_worker,
         )
         if not completed:
             logger.error("Log provider shutdown failed or timed out: %s", result)
@@ -859,19 +887,42 @@ def _perform_shutdown(
     # Root end creates the completion marker, so it must happen only after all
     # buffered LOG records have drained.
     if span_processor:
-        try:
-            ended = span_processor.end_active_spans(termination_reason)
+        completed, result = bounded_call(
+            lambda: span_processor.end_active_spans(termination_reason),
+            deadline,
+            synchronous=synchronous,
+            worker=shutdown_worker,
+        )
+        if completed:
+            ended = result
             if ended:
                 logger.info(f"Ended {ended} active Neatlogs span(s) during {termination_reason}")
-            span_processor._log_performance_stats()
-        except Exception as e:
-            logger.warning(f"Error logging performance stats: {e}")
+        else:
+            logger.warning("Ending active Neatlogs spans failed or timed out: %s", result)
+            success = False
+        completed, result = bounded_call(
+            span_processor._log_performance_stats,
+            deadline,
+            synchronous=synchronous,
+            worker=shutdown_worker,
+        )
+        if not completed:
+            logger.warning("Logging performance stats failed or timed out: %s", result)
+            success = False
         remaining_millis = max(0, int((deadline - time.monotonic()) * 1000))
         if not span_processor.wait_for_downstream(remaining_millis):
             logger.warning("Timed out waiting for ending spans to reach the export queue")
             success = False
     if completion_span_processor is not None:
-        completion_span_processor.emit_deferred()
+        completed, result = bounded_call(
+            completion_span_processor.emit_deferred,
+            deadline,
+            synchronous=synchronous,
+            worker=shutdown_worker,
+        )
+        if not completed:
+            logger.warning("Completion marker emission failed or timed out: %s", result)
+            success = False
 
     if tracer_provider:
         if owns_tracer_provider:
@@ -879,6 +930,7 @@ def _perform_shutdown(
                 tracer_provider.shutdown,
                 deadline,
                 synchronous=synchronous,
+                worker=shutdown_worker,
             )
             if completed:
                 # neatlogs created this provider → safe to fully shut down.
@@ -894,6 +946,7 @@ def _perform_shutdown(
                 ),
                 deadline,
                 synchronous=synchronous,
+                worker=shutdown_worker,
             )
             if completed:
                 # Provider is shared (host app / Langfuse / another SDK set it). Calling
@@ -911,6 +964,7 @@ def _perform_shutdown(
                     processor.shutdown,
                     deadline,
                     synchronous=synchronous,
+                    worker=shutdown_worker,
                 )
                 if not completed:
                     logger.warning("Neatlogs transport shutdown failed or timed out: %s", result)
@@ -920,6 +974,7 @@ def _perform_shutdown(
                     span_processor.shutdown,
                     deadline,
                     synchronous=synchronous,
+                    worker=shutdown_worker,
                 )
                 if not completed:
                     logger.warning(
@@ -927,21 +982,37 @@ def _perform_shutdown(
                     )
                     success = False
 
-    try:
-        from opentelemetry.instrumentation.logging import LoggingInstrumentor
+    def uninstrument_logging() -> None:
+        try:
+            from opentelemetry.instrumentation.logging import LoggingInstrumentor
 
-        LoggingInstrumentor().uninstrument()
-    except Exception:
-        pass
+            LoggingInstrumentor().uninstrument()
+        except Exception:
+            pass
+
+    completed, result = bounded_call(
+        uninstrument_logging,
+        deadline,
+        synchronous=synchronous,
+        worker=shutdown_worker,
+    )
+    if not completed:
+        logger.debug("Logging uninstrument timed out: %s", result)
+        success = False
 
     # Reverse the framework/provider instrumentation so a later init() (or a test
     # re-init with a fresh TracerProvider) rebinds cleanly instead of leaving the
     # old instrumentor pointing at the now-dead provider.
     if instrumentation_manager is not None:
-        try:
-            instrumentation_manager.uninstrument_all()
-        except Exception as e:
-            logger.debug(f"Error uninstrumenting libraries: {e}")
+        completed, result = bounded_call(
+            instrumentation_manager.uninstrument_all,
+            deadline,
+            synchronous=synchronous,
+            worker=shutdown_worker,
+        )
+        if not completed:
+            logger.debug("Instrumentation cleanup failed or timed out: %s", result)
+            success = False
         _instrumentation_manager = None
 
     # Drop the cached wrapper tracer (used by wrap()/trace processors like the

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -3,32 +3,43 @@ Neatlogs SDK.
 """
 
 import atexit
-import concurrent.futures
 import functools
+import hashlib
+import json
 import math
 import os
 import re
+import queue
 import signal
 import sys
 import threading
+import time
 from typing import Any, Callable, Dict, List, Optional
 
 from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk._logs import LoggerProvider
-from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.environment_variables import (
     OTEL_ATTRIBUTE_COUNT_LIMIT,
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
 )
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import SpanLimits, TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
 
 from ._wrap_utils import _normalize_traces_endpoint
+from .constants import DEFAULT_INGEST_ENDPOINT, export_queue_capacity
+from .core.byte_limited_exporter import ByteLimitedSpanExporter
+from .core.deadline import bounded_call
+from .core.delivery import (
+    DeliveryDiagnostics,
+    ObservableBatchLogRecordProcessor,
+    ObservableBatchSpanProcessor,
+)
 from .core.logger import get_logger
 from .core.span_processor import CompletionMarkerSpanProcessor, NeatlogsSpanProcessor
+from .core.transport import build_otlp_session
 from .errors import NeatlogsConfigurationError
 from .instrumentation.manager import InstrumentationManager
 from .version import __version__
@@ -37,6 +48,7 @@ logger = get_logger()
 
 
 _initialized = False
+_init_signature = None
 _tracer_provider = None
 _owns_tracer_provider = False  # True only when neatlogs created the provider (safe to shut down)
 
@@ -47,6 +59,7 @@ _transport_span_processors = []
 _completion_span_processor = None
 _instrumentation_manager = None
 _debug_mode = False
+_delivery_diagnostics = DeliveryDiagnostics()
 _signal_handlers = {}
 _signal_shutdown_in_progress = False
 _shutdown_condition = threading.Condition(threading.RLock())
@@ -181,10 +194,26 @@ def _serialize_init(func):
     return wrapped
 
 
+def _configuration_signature(**values):
+    api_key = values.pop("api_key")
+    resolved_key = str(api_key).strip() if api_key is not None else ""
+    if not resolved_key:
+        resolved_key = (os.getenv("NEATLOGS_API_KEY") or "").strip()
+    values["api_key_sha256"] = hashlib.sha256(resolved_key.encode()).hexdigest()
+    values["disable_export"] = bool(values["disable_export"]) or os.getenv(
+        "NEATLOGS_DISABLE_EXPORT", ""
+    ).lower() in ("true", "1", "yes")
+    mask = values.pop("mask")
+    provider = values.pop("tracer_provider")
+    values["mask_identity"] = id(mask) if mask is not None else None
+    values["provider_identity"] = id(provider) if provider is not None else None
+    return json.dumps(values, sort_keys=True, separators=(",", ":"), default=str)
+
+
 @_serialize_init
 def init(
     api_key: Optional[str] = None,
-    endpoint: str = "https://ingest.neatlogs.com",
+    endpoint: str = DEFAULT_INGEST_ENDPOINT,
     workflow_name: Optional[str] = None,
     user_id: Optional[str] = None,
     tags: Optional[List[str]] = None,
@@ -275,12 +304,40 @@ def init(
               signal termination. Defaults to True. Set False only when the host
               application owns signal handling and calls ``neatlogs.shutdown()``.
     """
-    global _initialized
+    global _initialized, _init_signature
+
+    candidate_signature = _configuration_signature(
+        api_key=api_key,
+        endpoint=endpoint,
+        workflow_name=workflow_name,
+        user_id=user_id,
+        tags=tags or [],
+        instrumentations=instrumentations or [],
+        sample_rate=sample_rate,
+        batch_size=batch_size,
+        flush_interval=flush_interval,
+        debug=debug,
+        disable_export=disable_export,
+        capture_logs=capture_logs,
+        log_level=log_level,
+        mask=mask,
+        pii_enabled=pii_enabled,
+        pii_entities=pii_entities or [],
+        pii_span_types=pii_span_types or [],
+        tracer_provider=tracer_provider,
+        isolate=isolate,
+        register_shutdown_handlers=register_shutdown_handlers,
+    )
 
     if _initialized:
-        if debug:
-            logger.warning("Neatlogs already initialized, skipping re-initialization")
-        return
+        if _init_signature == candidate_signature:
+            if debug:
+                logger.warning("Neatlogs already initialized with the same configuration")
+            return
+        raise NeatlogsConfigurationError(
+            "Neatlogs is already running with different configuration; "
+            "call shutdown() before reinitializing"
+        )
 
     sampler = _trace_sampler(sample_rate)
     if tracer_provider is not None and float(sample_rate) != 1.0:
@@ -292,6 +349,9 @@ def init(
         raise NeatlogsConfigurationError(
             "tracer_provider must be private and must not be the process-global provider"
         )
+
+    global _delivery_diagnostics
+    _delivery_diagnostics = DeliveryDiagnostics()
 
     disable_export_resolved = bool(disable_export) or (
         os.getenv("NEATLOGS_DISABLE_EXPORT", "").lower() in ("true", "1", "yes")
@@ -447,6 +507,8 @@ def init(
         otlp_exporter = OTLPSpanExporter(
             endpoint=traces_endpoint,
             headers=otlp_headers,
+            compression=Compression.Gzip,
+            session=build_otlp_session(),
         )
         # Wrap the exporter so rootless infra-HTTP auto-spans (boot pings, dependency
         # warmups, outbound fetches outside any traced request) are never sent — on
@@ -473,10 +535,18 @@ def init(
             def force_flush(self, timeout_millis: int = 30000):
                 return self._inner.force_flush(timeout_millis)
 
-        batch_processor = BatchSpanProcessor(
-            _FilteredOTLPExporter(MaskingSpanExporter(otlp_exporter, mask)),
+        batch_processor = ObservableBatchSpanProcessor(
+            _FilteredOTLPExporter(
+                MaskingSpanExporter(
+                    ByteLimitedSpanExporter(otlp_exporter, diagnostics=_delivery_diagnostics),
+                    mask,
+                    diagnostics=_delivery_diagnostics,
+                )
+            ),
             max_export_batch_size=batch_size,
+            max_queue_size=export_queue_capacity(batch_size),
             schedule_delay_millis=int(flush_interval * 1000),
+            diagnostics=_delivery_diagnostics,
         )
         provider.add_span_processor(batch_processor)
         # Registered after the batch processor so a root is queued for export
@@ -512,12 +582,22 @@ def init(
         _otlp_log_exporter = OTLPLogExporter(
             endpoint=logs_endpoint,
             headers={"x-api-key": resolved_key},
+            compression=Compression.Gzip,
+            session=build_otlp_session(),
         )
         _log_provider = LoggerProvider(resource=resource)
         # NeatlogsLogFilter drops external-module and no-trace records before
         # BatchLogRecordProcessor batches and sends them via OTLPLogExporter.
         _log_provider.add_log_record_processor(
-            NeatlogsLogFilter(BatchLogRecordProcessor(MaskingLogExporter(_otlp_log_exporter, mask)))
+            NeatlogsLogFilter(
+                ObservableBatchLogRecordProcessor(
+                    MaskingLogExporter(_otlp_log_exporter, mask, diagnostics=_delivery_diagnostics),
+                    max_export_batch_size=batch_size,
+                    max_queue_size=export_queue_capacity(batch_size),
+                    schedule_delay_millis=int(flush_interval * 1000),
+                    diagnostics=_delivery_diagnostics,
+                )
+            )
         )
         try:
             import logging as _stdlib_logging
@@ -560,6 +640,7 @@ def init(
             logger.debug(f"Instrumented libraries: {manager.instrumented}")
 
     atexit.register(shutdown)
+    _init_signature = candidate_signature
     _initialized = True
     if register_shutdown_handlers:
         _register_shutdown_signal_handlers()
@@ -609,6 +690,12 @@ def get_log_provider() -> Optional[LoggerProvider]:
     return _log_provider
 
 
+def get_delivery_diagnostics() -> Dict[str, int]:
+    """Return loss counters for the current or most recently closed pipeline."""
+
+    return _delivery_diagnostics.snapshot()
+
+
 def flush_all(timeout_millis: int = 30000) -> Dict[str, bool]:
     """Flush every live Neatlogs pipeline concurrently under one deadline.
 
@@ -625,25 +712,35 @@ def flush_all(timeout_millis: int = 30000) -> Dict[str, bool]:
     if not operations:
         return {}
 
-    results: Dict[str, bool] = {}
+    results: Dict[str, bool] = {name: False for name, _ in operations}
     timeout_seconds = max(0, timeout_millis) / 1000
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=len(operations))
-    try:
-        futures = {
-            executor.submit(operation, timeout_millis): name for name, operation in operations
-        }
-        done, pending = concurrent.futures.wait(futures, timeout=timeout_seconds)
-        for future in done:
-            name = futures[future]
-            try:
-                results[name] = bool(future.result())
-            except Exception:
-                results[name] = False
-        for future in pending:
-            results[futures[future]] = False
-            future.cancel()
-    finally:
-        executor.shutdown(wait=False, cancel_futures=True)
+    deadline = time.monotonic() + timeout_seconds
+    completed: queue.Queue[tuple[str, bool]] = queue.Queue()
+
+    def run(name: str, operation: Callable[[int], bool]) -> None:
+        try:
+            completed.put((name, bool(operation(timeout_millis))))
+        except BaseException:
+            completed.put((name, False))
+
+    if timeout_seconds <= 0:
+        return results
+    for name, operation in operations:
+        threading.Thread(
+            target=run,
+            args=(name, operation),
+            name="neatlogs-flush",
+            daemon=True,
+        ).start()
+
+    remaining = len(operations)
+    while remaining and time.monotonic() < deadline:
+        try:
+            name, success = completed.get(timeout=max(0.001, deadline - time.monotonic()))
+        except queue.Empty:
+            break
+        results[name] = success
+        remaining -= 1
     return results
 
 
@@ -689,7 +786,9 @@ def shutdown(timeout_millis: int = 30000, termination_reason: str = "shutdown") 
 def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
     """End active Neatlogs spans, then flush and shut down SDK providers."""
     global _tracer_provider, _owns_tracer_provider, _log_provider, _span_processor, _initialized
+    global _init_signature
     global _instrumentation_manager, _transport_span_processors, _completion_span_processor
+    global _debug_mode
 
     try:
         atexit.unregister(shutdown)
@@ -699,71 +798,89 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
     _restore_shutdown_signal_handlers()
 
     success = True
-    if _completion_span_processor is not None:
-        _completion_span_processor.begin_shutdown()
-    if _span_processor is not None:
-        _span_processor.begin_shutdown(termination_reason)
+    deadline = time.monotonic() + max(0, timeout_millis) / 1000
+    log_provider = _log_provider
+    tracer_provider = _tracer_provider
+    owns_tracer_provider = _owns_tracer_provider
+    span_processor = _span_processor
+    completion_span_processor = _completion_span_processor
+    transport_span_processors = list(_transport_span_processors)
+    instrumentation_manager = _instrumentation_manager
+    if completion_span_processor is not None:
+        completion_span_processor.begin_shutdown()
+    if span_processor is not None:
+        span_processor.begin_shutdown(termination_reason)
 
     # LOG records must drain before trace completion. The tracer batch contains
     # neatlogs.trace.complete, which can trigger backend finalization as soon as
     # it is ingested.
-    if _log_provider:
-        try:
-            logger.debug("Shutting down log provider...")
-            ok = _log_provider.shutdown()
-            success = (ok is None or bool(ok)) and success
-            logger.debug("Log provider shut down successfully")
-        except Exception as e:
-            logger.error(f"Error shutting down log provider: {e}", exc_info=True)
+    if log_provider:
+        logger.debug("Shutting down log provider...")
+        completed, result = bounded_call(log_provider.shutdown, deadline)
+        if not completed:
+            logger.error("Log provider shutdown failed or timed out: %s", result)
             success = False
+        else:
+            success = (result is None or bool(result)) and success
+            logger.debug("Log provider shut down successfully")
 
     # Root end creates the completion marker, so it must happen only after all
     # buffered LOG records have drained.
-    if _span_processor:
+    if span_processor:
         try:
-            ended = _span_processor.end_active_spans(termination_reason)
+            ended = span_processor.end_active_spans(termination_reason)
             if ended:
                 logger.info(f"Ended {ended} active Neatlogs span(s) during {termination_reason}")
-            _span_processor._log_performance_stats()
+            span_processor._log_performance_stats()
         except Exception as e:
             logger.warning(f"Error logging performance stats: {e}")
-        if not _span_processor.wait_for_downstream(timeout_millis):
+        remaining_millis = max(0, int((deadline - time.monotonic()) * 1000))
+        if not span_processor.wait_for_downstream(remaining_millis):
             logger.warning("Timed out waiting for ending spans to reach the export queue")
             success = False
-    if _completion_span_processor is not None:
-        _completion_span_processor.emit_deferred()
+    if completion_span_processor is not None:
+        completion_span_processor.emit_deferred()
 
-    if _tracer_provider:
-        try:
-            if _owns_tracer_provider:
+    if tracer_provider:
+        if owns_tracer_provider:
+            completed, result = bounded_call(tracer_provider.shutdown, deadline)
+            if completed:
                 # neatlogs created this provider → safe to fully shut down.
-                logger.debug("Shutting down tracer provider (owned by neatlogs)...")
-                ok = _tracer_provider.shutdown()
-                success = (ok is None or bool(ok)) and success
+                success = (result is None or bool(result)) and success
                 logger.debug("Tracer provider shut down successfully")
             else:
+                logger.error("Tracer provider shutdown failed or timed out: %s", result)
+                success = False
+        else:
+            completed, result = bounded_call(
+                lambda: tracer_provider.force_flush(
+                    timeout_millis=max(0, int((deadline - time.monotonic()) * 1000))
+                ),
+                deadline,
+            )
+            if completed:
                 # Provider is shared (host app / Langfuse / another SDK set it). Calling
                 # provider.shutdown() would tear down EVERY processor on it — including the
                 # co-tenant's exporter — silently killing their telemetry. Only flush our
                 # own spans and shut down JUST the neatlogs span processor, leaving the
                 # shared provider and other exporters intact.
                 logger.debug("Shared tracer provider — flushing without shutting it down")
-                ok = _tracer_provider.force_flush(timeout_millis=timeout_millis)
-                success = (ok is None or bool(ok)) and success
-                for processor in reversed(_transport_span_processors):
-                    try:
-                        processor.shutdown()
-                    except Exception as e:
-                        logger.warning(f"Error shutting down Neatlogs transport: {e}")
-                        success = False
-                if _span_processor is not None:
-                    try:
-                        _span_processor.shutdown()
-                    except Exception as e:
-                        logger.warning(f"Error shutting down neatlogs span processor: {e}")
-        except Exception as e:
-            logger.error(f"Error shutting down tracer provider: {e}", exc_info=True)
-            success = False
+                success = (result is None or bool(result)) and success
+            else:
+                logger.error("Tracer provider flush failed or timed out: %s", result)
+                success = False
+            for processor in reversed(transport_span_processors):
+                completed, result = bounded_call(processor.shutdown, deadline)
+                if not completed:
+                    logger.warning("Neatlogs transport shutdown failed or timed out: %s", result)
+                    success = False
+            if span_processor is not None:
+                completed, result = bounded_call(span_processor.shutdown, deadline)
+                if not completed:
+                    logger.warning(
+                        "Neatlogs span processor shutdown failed or timed out: %s", result
+                    )
+                    success = False
 
     try:
         from opentelemetry.instrumentation.logging import LoggingInstrumentor
@@ -775,9 +892,9 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
     # Reverse the framework/provider instrumentation so a later init() (or a test
     # re-init with a fresh TracerProvider) rebinds cleanly instead of leaving the
     # old instrumentor pointing at the now-dead provider.
-    if _instrumentation_manager is not None:
+    if instrumentation_manager is not None:
         try:
-            _instrumentation_manager.uninstrument_all()
+            instrumentation_manager.uninstrument_all()
         except Exception as e:
             logger.debug(f"Error uninstrumenting libraries: {e}")
         _instrumentation_manager = None
@@ -794,7 +911,9 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
         pass
 
     _initialized = False
+    _init_signature = None
     _tracer_provider = None
+    _owns_tracer_provider = False
     _log_provider = None
     _span_processor = None
     _transport_span_processors = []
@@ -803,6 +922,8 @@ def _perform_shutdown(timeout_millis: int, termination_reason: str) -> bool:
     _session_config["session_id"] = None
     _session_config["user_id"] = None
     _session_config["workflow_name"] = None
+    _session_config["_api_key"] = None
+    _session_config["_base_url"] = None
 
     logger.info("Neatlogs SDK shutdown complete")
     return success

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -8,8 +8,8 @@ import hashlib
 import json
 import math
 import os
-import re
 import queue
+import re
 import signal
 import sys
 import threading

--- a/neatlogs/openai.py
+++ b/neatlogs/openai.py
@@ -504,7 +504,12 @@ def _patch_async_responses(responses: Any) -> None:
 
 
 def _finalize_responses_stream(
-    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+    span: Any,
+    chunks: List[Any],
+    duration_ms: float,
+    ttft_ms: Optional[float],
+    *,
+    interrupted: bool = False,
 ) -> None:
     """Finalize a streaming Responses API span (events carry .type / .delta / .response)."""
     text_parts: List[str] = []
@@ -537,7 +542,7 @@ def _finalize_responses_stream(
     span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
     if ttft_ms is not None:
         span.set_attribute("neatlogs.llm.metrics.ttft_ms", round(ttft_ms, 3))
-    span.set_status(StatusCode.OK)
+    span.set_status(StatusCode.UNSET if interrupted else StatusCode.OK)
     span.end()
 
 

--- a/neatlogs/openai.py
+++ b/neatlogs/openai.py
@@ -26,6 +26,8 @@ from ._wrap_utils import (
     is_suppressed,
     serialize,
 )
+from .core.choice_accumulator import ChoiceAccumulator, OpenAIStreamFinalizer
+from .core.media import set_media_attributes
 
 _PATCHED = False
 _ORIG_INIT = None
@@ -143,6 +145,7 @@ def _patch_completions(completions: Any) -> None:
                 span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", content)
             else:
                 span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", serialize(content))
+            set_media_attributes(span, f"neatlogs.llm.input_messages.{i}", content, "input")
             if msg.get("tool_call_id"):
                 span.set_attribute(
                     f"neatlogs.llm.input_messages.{i}.tool_call_id", msg["tool_call_id"]
@@ -153,6 +156,8 @@ def _patch_completions(completions: Any) -> None:
         if tools:
             for i, tool in enumerate(tools):
                 fn = tool.get("function", {})
+                span.set_attribute(f"neatlogs.llm.tools.{i}.type", tool.get("type", "function"))
+                span.set_attribute(f"neatlogs.llm.tools.{i}.definition", serialize(tool))
                 span.set_attribute(f"neatlogs.llm.tools.{i}.name", fn.get("name", ""))
                 if fn.get("description"):
                     span.set_attribute(f"neatlogs.llm.tools.{i}.description", fn["description"])
@@ -186,7 +191,7 @@ def _patch_completions(completions: Any) -> None:
             raise
 
         if is_stream:
-            return SyncStreamWrapper(response, span, _finalize_stream)
+            return SyncStreamWrapper(response, span, OpenAIStreamFinalizer())
 
         duration_ms = (time.perf_counter() - start) * 1000
         _finalize_response(span, response, duration_ms)
@@ -236,11 +241,14 @@ def _patch_async_completions(completions: Any) -> None:
                 span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", content)
             else:
                 span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", serialize(content))
+            set_media_attributes(span, f"neatlogs.llm.input_messages.{i}", content, "input")
 
         tools = kwargs.get("tools")
         if tools:
             for i, tool in enumerate(tools):
                 fn = tool.get("function", {})
+                span.set_attribute(f"neatlogs.llm.tools.{i}.type", tool.get("type", "function"))
+                span.set_attribute(f"neatlogs.llm.tools.{i}.definition", serialize(tool))
                 span.set_attribute(f"neatlogs.llm.tools.{i}.name", fn.get("name", ""))
                 if fn.get("description"):
                     span.set_attribute(f"neatlogs.llm.tools.{i}.description", fn["description"])
@@ -273,7 +281,7 @@ def _patch_async_completions(completions: Any) -> None:
             raise
 
         if is_stream:
-            return AsyncStreamWrapper(response, span, _finalize_stream)
+            return AsyncStreamWrapper(response, span, OpenAIStreamFinalizer())
 
         duration_ms = (time.perf_counter() - start) * 1000
         _finalize_response(span, response, duration_ms)
@@ -346,139 +354,10 @@ def _set_request_metadata(span: Any, kwargs: dict) -> None:
 
 def _finalize_response(span: Any, response: Any, duration_ms: float) -> None:
     """Extract neatlogs attributes from a non-streaming ChatCompletion response."""
-    choices = getattr(response, "choices", []) or []
-    for i, choice in enumerate(choices):
-        message = getattr(choice, "message", None)
-        if not message:
-            continue
-        span.set_attribute(f"neatlogs.llm.output_messages.{i}.role", "assistant")
-        if getattr(message, "content", None):
-            span.set_attribute(f"neatlogs.llm.output_messages.{i}.content", message.content)
-        if getattr(message, "tool_calls", None):
-            for j, tc in enumerate(message.tool_calls):
-                span.set_attribute(f"neatlogs.llm.tool_calls.{j}.id", tc.id)
-                span.set_attribute(f"neatlogs.llm.tool_calls.{j}.name", tc.function.name)
-                span.set_attribute(f"neatlogs.llm.tool_calls.{j}.arguments", tc.function.arguments)
-
-        finish_reason = getattr(choice, "finish_reason", None)
-        if finish_reason:
-            span.set_attribute("neatlogs.llm.finish_reason", finish_reason)
-
-    usage = getattr(response, "usage", None)
-    if usage:
-        if getattr(usage, "prompt_tokens", None) is not None:
-            span.set_attribute("neatlogs.llm.token_count.prompt", usage.prompt_tokens)
-        if getattr(usage, "completion_tokens", None) is not None:
-            span.set_attribute("neatlogs.llm.token_count.completion", usage.completion_tokens)
-        total = getattr(usage, "total_tokens", None)
-        if total is not None:
-            span.set_attribute("neatlogs.llm.token_count.total", total)
-        if getattr(usage, "prompt_tokens_details", None):
-            cached = getattr(usage.prompt_tokens_details, "cached_tokens", None)
-            if cached is not None:
-                span.set_attribute("neatlogs.llm.token_count.cache_read", cached)
-        if getattr(usage, "completion_tokens_details", None):
-            reasoning = getattr(usage.completion_tokens_details, "reasoning_tokens", None)
-            if reasoning is not None:
-                span.set_attribute("neatlogs.llm.token_count.reasoning", reasoning)
-
-    model = getattr(response, "model", None)
-    if model:
-        span.set_attribute("neatlogs.llm.model_name", model)
-
+    accumulator = ChoiceAccumulator()
+    accumulator.add_response(response)
+    accumulator.apply(span)
     span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
-    span.set_status(StatusCode.OK)
-    span.end()
-
-
-def _finalize_stream(
-    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
-) -> None:
-    """Finalize a streaming response span from accumulated chunks."""
-    text_parts: List[str] = []
-    tool_calls_acc: dict = {}
-    finish_reason = None
-    model = None
-    usage = None
-
-    for chunk in chunks:
-        # Usage can arrive either in a dedicated choices-empty chunk (OpenAI) or
-        # riding along with the final content chunk that still has choices
-        # (OpenRouter). Read it on EVERY chunk so neither layout is missed.
-        if getattr(chunk, "usage", None):
-            usage = chunk.usage
-
-        if not getattr(chunk, "choices", None):
-            continue
-
-        choice = chunk.choices[0]
-        delta = getattr(choice, "delta", None)
-        if not delta:
-            continue
-
-        if getattr(delta, "content", None):
-            text_parts.append(delta.content)
-
-        for tc in getattr(delta, "tool_calls", None) or []:
-            idx = tc.index
-            if idx not in tool_calls_acc:
-                tool_calls_acc[idx] = {"id": "", "name": "", "arguments": ""}
-            if tc.id:
-                tool_calls_acc[idx]["id"] = tc.id
-            if tc.function and tc.function.name:
-                tool_calls_acc[idx]["name"] = tc.function.name
-            if tc.function and tc.function.arguments:
-                tool_calls_acc[idx]["arguments"] += tc.function.arguments
-
-        if getattr(choice, "finish_reason", None):
-            finish_reason = choice.finish_reason
-
-        if getattr(chunk, "model", None):
-            model = chunk.model
-
-    # Output messages
-    full_text = "".join(text_parts)
-    if full_text:
-        span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
-        span.set_attribute("neatlogs.llm.output_messages.0.content", full_text)
-
-    # Tool calls
-    for j, tc in enumerate(tool_calls_acc.values()):
-        span.set_attribute(f"neatlogs.llm.tool_calls.{j}.id", tc["id"])
-        span.set_attribute(f"neatlogs.llm.tool_calls.{j}.name", tc["name"])
-        span.set_attribute(f"neatlogs.llm.tool_calls.{j}.arguments", tc["arguments"])
-
-    if model:
-        span.set_attribute("neatlogs.llm.model_name", model)
-    if finish_reason:
-        span.set_attribute("neatlogs.llm.finish_reason", finish_reason)
-
-    if usage:
-        if getattr(usage, "prompt_tokens", None) is not None:
-            span.set_attribute("neatlogs.llm.token_count.prompt", usage.prompt_tokens)
-        if getattr(usage, "completion_tokens", None) is not None:
-            span.set_attribute("neatlogs.llm.token_count.completion", usage.completion_tokens)
-        total = getattr(usage, "total_tokens", None)
-        if total is not None:
-            span.set_attribute("neatlogs.llm.token_count.total", total)
-        if getattr(usage, "prompt_tokens_details", None):
-            cached = getattr(usage.prompt_tokens_details, "cached_tokens", None)
-            if cached is not None:
-                span.set_attribute("neatlogs.llm.token_count.cache_read", cached)
-        if getattr(usage, "completion_tokens_details", None):
-            reasoning = getattr(usage.completion_tokens_details, "reasoning_tokens", None)
-            if reasoning is not None:
-                span.set_attribute("neatlogs.llm.token_count.reasoning", reasoning)
-
-    span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
-    if ttft_ms is not None:
-        span.set_attribute("neatlogs.llm.metrics.ttft_ms", round(ttft_ms, 3))
-        if duration_ms > ttft_ms:
-            span.set_attribute(
-                "neatlogs.llm.metrics.streaming_time_to_generate_ms",
-                round(duration_ms - ttft_ms, 3),
-            )
-
     span.set_status(StatusCode.OK)
     span.end()
 

--- a/neatlogs/openrouter.py
+++ b/neatlogs/openrouter.py
@@ -311,7 +311,12 @@ def _finalize_chat(span: Any, response: Any, duration_ms: float) -> None:
 
 
 def _finalize_chat_stream(
-    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+    span: Any,
+    chunks: List[Any],
+    duration_ms: float,
+    ttft_ms: Optional[float],
+    *,
+    interrupted: bool = False,
 ) -> None:
     text_parts: List[str] = []
     tool_calls_acc: dict = {}
@@ -363,7 +368,7 @@ def _finalize_chat_stream(
         span.set_attribute("neatlogs.llm.finish_reason", str(finish_reason))
     _set_chat_usage(span, usage)
 
-    _ok(span, duration_ms, ttft_ms)
+    _ok(span, duration_ms, ttft_ms, interrupted=interrupted)
 
 
 def _set_chat_usage(span: Any, usage: Any) -> None:
@@ -513,7 +518,12 @@ def _finalize_responses(span: Any, response: Any, duration_ms: float) -> None:
 
 
 def _finalize_responses_stream(
-    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+    span: Any,
+    chunks: List[Any],
+    duration_ms: float,
+    ttft_ms: Optional[float],
+    *,
+    interrupted: bool = False,
 ) -> None:
     text_parts: List[str] = []
     model = None
@@ -537,7 +547,7 @@ def _finalize_responses_stream(
     if model:
         span.set_attribute("neatlogs.llm.model_name", str(model))
     _set_responses_usage(span, usage)
-    _ok(span, duration_ms, ttft_ms)
+    _ok(span, duration_ms, ttft_ms, interrupted=interrupted)
 
 
 def _set_responses_usage(span: Any, usage: Any) -> None:
@@ -706,7 +716,13 @@ def _finalize_rerank(span: Any, response: Any, duration_ms: float) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _ok(span: Any, duration_ms: float, ttft_ms: Optional[float] = None) -> None:
+def _ok(
+    span: Any,
+    duration_ms: float,
+    ttft_ms: Optional[float] = None,
+    *,
+    interrupted: bool = False,
+) -> None:
     span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
     if ttft_ms is not None:
         span.set_attribute("neatlogs.llm.metrics.ttft_ms", round(ttft_ms, 3))
@@ -715,7 +731,7 @@ def _ok(span: Any, duration_ms: float, ttft_ms: Optional[float] = None) -> None:
                 "neatlogs.llm.metrics.streaming_time_to_generate_ms",
                 round(duration_ms - ttft_ms, 3),
             )
-    span.set_status(StatusCode.OK)
+    span.set_status(StatusCode.UNSET if interrupted else StatusCode.OK)
     span.end()
 
 

--- a/neatlogs/vertex_ai.py
+++ b/neatlogs/vertex_ai.py
@@ -368,7 +368,12 @@ def _set_usage_attributes(span: Any, usage: Any) -> None:
 
 
 def _finalize_stream(
-    span: Any, chunks: List[Any], duration_ms: float, ttft_ms: Optional[float]
+    span: Any,
+    chunks: List[Any],
+    duration_ms: float,
+    ttft_ms: Optional[float],
+    *,
+    interrupted: bool = False,
 ) -> None:
     """Finalize a streaming response span from accumulated chunks."""
     text_parts: List[str] = []
@@ -434,7 +439,7 @@ def _finalize_stream(
                 round(duration_ms - ttft_ms, 3),
             )
 
-    span.set_status(StatusCode.OK)
+    span.set_status(StatusCode.UNSET if interrupted else StatusCode.OK)
     span.end()
 
 

--- a/tests/unit/test_byte_limited_exporter.py
+++ b/tests/unit/test_byte_limited_exporter.py
@@ -1,3 +1,6 @@
+import hashlib
+
+import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
 
@@ -6,13 +9,14 @@ from neatlogs.core.delivery import DeliveryDiagnostics
 
 
 class RecordingExporter:
-    def __init__(self, result=SpanExportResult.SUCCESS):
+    def __init__(self, result=SpanExportResult.SUCCESS, results=None):
         self.batches = []
         self.result = result
+        self.results = iter(results) if results is not None else None
 
     def export(self, spans):
         self.batches.append(list(spans))
-        return self.result
+        return next(self.results) if self.results is not None else self.result
 
     def force_flush(self, timeout_millis=30000):
         return True
@@ -42,13 +46,52 @@ def test_splits_batches_using_encoded_protobuf_upper_bound():
     assert [len(batch) for batch in sink.batches] == [2, 1]
 
 
-def test_forwards_one_oversized_span_without_truncation_or_drop():
+def test_rejects_one_oversized_span_when_backend_upload_authority_is_unavailable():
     spans = _finished_spans(count=1, payload_size=16_384)
     sink = RecordingExporter()
-    exporter = ByteLimitedSpanExporter(sink, max_export_bytes=128)
+    diagnostics = DeliveryDiagnostics()
+    exporter = ByteLimitedSpanExporter(sink, max_export_bytes=128, diagnostics=diagnostics)
+
+    assert exporter.export(spans) is SpanExportResult.FAILURE
+    assert sink.batches == []
+    snapshot = diagnostics.snapshot()
+    assert snapshot["span_overflow_unavailable"] == 1
+    assert snapshot["span_overflow_failures"] == 1
+    assert snapshot["span_export_failures"] == 1
+
+
+def test_injectable_upload_authority_receives_complete_masked_envelope():
+    spans = _finished_spans(count=1, payload_size=16_384)
+
+    class Authority:
+        available = True
+        unavailable_reason = ""
+
+        def __init__(self):
+            self.payloads = []
+
+        def export_overflow(self, payload):
+            self.payloads.append(payload)
+            return True
+
+    authority = Authority()
+    diagnostics = DeliveryDiagnostics()
+    exporter = ByteLimitedSpanExporter(
+        RecordingExporter(),
+        max_export_bytes=128,
+        diagnostics=diagnostics,
+        upload_authority=authority,
+    )
 
     assert exporter.export(spans) is SpanExportResult.SUCCESS
-    assert sink.batches == [spans]
+    assert len(authority.payloads) == 1
+    payload = authority.payloads[0]
+    assert payload.purpose == "otlp_overflow"
+    assert payload.byte_length == len(payload.content)
+    assert payload.sha256 == hashlib.sha256(payload.content).hexdigest()
+    snapshot = diagnostics.snapshot()
+    assert snapshot["span_overflow_exports"] == 1
+    assert snapshot["span_upload_authority_available"] is True
 
 
 def test_exposes_final_export_failure_count():
@@ -60,3 +103,33 @@ def test_exposes_final_export_failure_count():
 
     assert exporter.export(spans) is SpanExportResult.FAILURE
     assert diagnostics.snapshot()["span_export_failures"] == 2
+
+
+@pytest.mark.parametrize(
+    ("results", "expected_attempts", "expected_failures"),
+    [
+        ([SpanExportResult.FAILURE], 1, 3),
+        ([SpanExportResult.SUCCESS, SpanExportResult.FAILURE], 2, 2),
+        (
+            [SpanExportResult.SUCCESS, SpanExportResult.SUCCESS, SpanExportResult.FAILURE],
+            3,
+            1,
+        ),
+    ],
+)
+def test_split_failure_counts_failed_and_all_unattempted_tail_batches(
+    results, expected_attempts, expected_failures
+):
+    spans = _finished_spans(count=3, payload_size=256)
+    max_bytes = max(ByteLimitedSpanExporter._encoded_upper_bound(span) for span in spans)
+    sink = RecordingExporter(results=results)
+    diagnostics = DeliveryDiagnostics()
+    exporter = ByteLimitedSpanExporter(
+        sink,
+        max_export_bytes=max_bytes,
+        diagnostics=diagnostics,
+    )
+
+    assert exporter.export(spans) is SpanExportResult.FAILURE
+    assert len(sink.batches) == expected_attempts
+    assert diagnostics.snapshot()["span_export_failures"] == expected_failures

--- a/tests/unit/test_byte_limited_exporter.py
+++ b/tests/unit/test_byte_limited_exporter.py
@@ -1,0 +1,62 @@
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
+
+from neatlogs.core.byte_limited_exporter import ByteLimitedSpanExporter
+from neatlogs.core.delivery import DeliveryDiagnostics
+
+
+class RecordingExporter:
+    def __init__(self, result=SpanExportResult.SUCCESS):
+        self.batches = []
+        self.result = result
+
+    def export(self, spans):
+        self.batches.append(list(spans))
+        return self.result
+
+    def force_flush(self, timeout_millis=30000):
+        return True
+
+    def shutdown(self):
+        return None
+
+
+def _finished_spans(count=3, payload_size=2048):
+    sink = RecordingExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(sink))
+    tracer = provider.get_tracer("byte-test")
+    for index in range(count):
+        with tracer.start_as_current_span(f"span-{index}") as span:
+            span.set_attribute("neatlogs.llm.input", "x" * payload_size)
+    return [span for batch in sink.batches for span in batch]
+
+
+def test_splits_batches_using_encoded_protobuf_upper_bound():
+    spans = _finished_spans()
+    one_span_bytes = ByteLimitedSpanExporter._encoded_upper_bound(spans[0])
+    sink = RecordingExporter()
+    exporter = ByteLimitedSpanExporter(sink, max_export_bytes=one_span_bytes * 2)
+
+    assert exporter.export(spans) is SpanExportResult.SUCCESS
+    assert [len(batch) for batch in sink.batches] == [2, 1]
+
+
+def test_forwards_one_oversized_span_without_truncation_or_drop():
+    spans = _finished_spans(count=1, payload_size=16_384)
+    sink = RecordingExporter()
+    exporter = ByteLimitedSpanExporter(sink, max_export_bytes=128)
+
+    assert exporter.export(spans) is SpanExportResult.SUCCESS
+    assert sink.batches == [spans]
+
+
+def test_exposes_final_export_failure_count():
+    spans = _finished_spans(count=2)
+    diagnostics = DeliveryDiagnostics()
+    exporter = ByteLimitedSpanExporter(
+        RecordingExporter(SpanExportResult.FAILURE), diagnostics=diagnostics
+    )
+
+    assert exporter.export(spans) is SpanExportResult.FAILURE
+    assert diagnostics.snapshot()["span_export_failures"] == 2

--- a/tests/unit/test_byte_limited_exporter.py
+++ b/tests/unit/test_byte_limited_exporter.py
@@ -6,6 +6,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
 
 from neatlogs.core.byte_limited_exporter import ByteLimitedSpanExporter
 from neatlogs.core.delivery import DeliveryDiagnostics
+from neatlogs.core.upload_authority import OverflowExportReceipt
 
 
 class RecordingExporter:
@@ -72,7 +73,12 @@ def test_injectable_upload_authority_receives_complete_masked_envelope():
 
         def export_overflow(self, payload):
             self.payloads.append(payload)
-            return True
+            return OverflowExportReceipt(
+                upload_id="upload-1",
+                project_id="project-1",
+                state="ready",
+                reference_exported=True,
+            )
 
     authority = Authority()
     diagnostics = DeliveryDiagnostics()
@@ -94,6 +100,30 @@ def test_injectable_upload_authority_receives_complete_masked_envelope():
     assert snapshot["span_upload_authority_available"] is True
 
 
+def test_upload_authority_boolean_does_not_falsely_claim_delivery():
+    spans = _finished_spans(count=1, payload_size=16_384)
+
+    class IncompleteAuthority:
+        available = True
+        unavailable_reason = ""
+
+        def export_overflow(self, _payload):
+            return True
+
+    diagnostics = DeliveryDiagnostics()
+    exporter = ByteLimitedSpanExporter(
+        RecordingExporter(),
+        max_export_bytes=128,
+        diagnostics=diagnostics,
+        upload_authority=IncompleteAuthority(),
+    )
+
+    assert exporter.export(spans) is SpanExportResult.FAILURE
+    snapshot = diagnostics.snapshot()
+    assert snapshot["span_overflow_exports"] == 0
+    assert snapshot["span_overflow_failures"] == 1
+
+
 def test_exposes_final_export_failure_count():
     spans = _finished_spans(count=2)
     diagnostics = DeliveryDiagnostics()
@@ -103,6 +133,28 @@ def test_exposes_final_export_failure_count():
 
     assert exporter.export(spans) is SpanExportResult.FAILURE
     assert diagnostics.snapshot()["span_export_failures"] == 2
+
+
+def test_exporter_exception_counts_current_and_unattempted_tail():
+    spans = _finished_spans(count=3, payload_size=256)
+    max_bytes = max(ByteLimitedSpanExporter._encoded_upper_bound(span) for span in spans)
+
+    class RaisingExporter(RecordingExporter):
+        def export(self, spans):
+            self.batches.append(list(spans))
+            raise RuntimeError("transport failed")
+
+    diagnostics = DeliveryDiagnostics()
+    sink = RaisingExporter()
+    exporter = ByteLimitedSpanExporter(
+        sink,
+        max_export_bytes=max_bytes,
+        diagnostics=diagnostics,
+    )
+
+    assert exporter.export(spans) is SpanExportResult.FAILURE
+    assert len(sink.batches) == 1
+    assert diagnostics.snapshot()["span_export_failures"] == 3
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_byte_limited_log_exporter.py
+++ b/tests/unit/test_byte_limited_log_exporter.py
@@ -95,3 +95,25 @@ def test_log_split_failure_counts_failed_and_unattempted_tail(
     assert exporter.export(records) is LogRecordExportResult.FAILURE
     assert len(sink.batches) == expected_attempts
     assert diagnostics.snapshot()["log_export_failures"] == expected_failures
+
+
+def test_log_exporter_exception_counts_current_and_unattempted_tail():
+    records = _finished_logs(count=3, payload_size=256)
+    max_bytes = max(ByteLimitedLogExporter._encoded_upper_bound(item) for item in records)
+
+    class RaisingExporter(RecordingExporter):
+        def export(self, batch):
+            self.batches.append(list(batch))
+            raise RuntimeError("transport failed")
+
+    diagnostics = DeliveryDiagnostics()
+    sink = RaisingExporter()
+    exporter = ByteLimitedLogExporter(
+        sink,
+        max_export_bytes=max_bytes,
+        diagnostics=diagnostics,
+    )
+
+    assert exporter.export(records) is LogRecordExportResult.FAILURE
+    assert len(sink.batches) == 1
+    assert diagnostics.snapshot()["log_export_failures"] == 3

--- a/tests/unit/test_byte_limited_log_exporter.py
+++ b/tests/unit/test_byte_limited_log_exporter.py
@@ -1,0 +1,97 @@
+import pytest
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import (
+    InMemoryLogRecordExporter,
+    LogRecordExportResult,
+    SimpleLogRecordProcessor,
+)
+
+from neatlogs.core.byte_limited_log_exporter import ByteLimitedLogExporter
+from neatlogs.core.delivery import DeliveryDiagnostics
+
+
+class RecordingExporter:
+    def __init__(self, results=None):
+        self.batches = []
+        self.results = iter(results) if results is not None else None
+
+    def export(self, batch):
+        self.batches.append(list(batch))
+        if self.results is None:
+            return LogRecordExportResult.SUCCESS
+        return next(self.results)
+
+    def force_flush(self, timeout_millis=30000):
+        return True
+
+    def shutdown(self):
+        return None
+
+
+def _finished_logs(count=3, payload_size=2048):
+    sink = InMemoryLogRecordExporter()
+    provider = LoggerProvider()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(sink))
+    logger = provider.get_logger("byte-test")
+    for index in range(count):
+        logger.emit(body=f"{index}:" + "x" * payload_size)
+    provider.shutdown()
+    return list(sink.get_finished_logs())
+
+
+def test_splits_log_batches_using_encoded_protobuf_upper_bound():
+    records = _finished_logs()
+    one_record_bytes = max(ByteLimitedLogExporter._encoded_upper_bound(item) for item in records)
+    sink = RecordingExporter()
+    exporter = ByteLimitedLogExporter(sink, max_export_bytes=one_record_bytes * 2)
+
+    assert exporter.export(records) is LogRecordExportResult.SUCCESS
+    assert [len(batch) for batch in sink.batches] == [2, 1]
+
+
+def test_rejects_oversized_log_when_upload_authority_is_unavailable():
+    records = _finished_logs(count=1, payload_size=16_384)
+    diagnostics = DeliveryDiagnostics()
+    sink = RecordingExporter()
+    exporter = ByteLimitedLogExporter(sink, max_export_bytes=128, diagnostics=diagnostics)
+
+    assert exporter.export(records) is LogRecordExportResult.FAILURE
+    assert sink.batches == []
+    snapshot = diagnostics.snapshot()
+    assert snapshot["log_overflow_unavailable"] == 1
+    assert snapshot["log_overflow_failures"] == 1
+    assert snapshot["log_export_failures"] == 1
+
+
+@pytest.mark.parametrize(
+    ("results", "expected_attempts", "expected_failures"),
+    [
+        ([LogRecordExportResult.FAILURE], 1, 3),
+        ([LogRecordExportResult.SUCCESS, LogRecordExportResult.FAILURE], 2, 2),
+        (
+            [
+                LogRecordExportResult.SUCCESS,
+                LogRecordExportResult.SUCCESS,
+                LogRecordExportResult.FAILURE,
+            ],
+            3,
+            1,
+        ),
+    ],
+)
+def test_log_split_failure_counts_failed_and_unattempted_tail(
+    results, expected_attempts, expected_failures
+):
+    records = _finished_logs(count=3, payload_size=256)
+    max_bytes = max(ByteLimitedLogExporter._encoded_upper_bound(item) for item in records)
+    sink = RecordingExporter(results)
+    diagnostics = DeliveryDiagnostics()
+    exporter = ByteLimitedLogExporter(
+        sink,
+        max_export_bytes=max_bytes,
+        diagnostics=diagnostics,
+    )
+
+    assert exporter.export(records) is LogRecordExportResult.FAILURE
+    assert len(sink.batches) == expected_attempts
+    assert diagnostics.snapshot()["log_export_failures"] == expected_failures

--- a/tests/unit/test_capture_limits.py
+++ b/tests/unit/test_capture_limits.py
@@ -1,14 +1,22 @@
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter, SimpleLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
+from opentelemetry.trace import StatusCode
 
 from neatlogs._wrap_utils import serialize
 from neatlogs.core.byte_limited_exporter import ByteLimitedSpanExporter
 from neatlogs.core.byte_limited_log_exporter import ByteLimitedLogExporter
-from neatlogs.core.capture import DEFAULT_MAX_CAPTURE_VALUE_BYTES
+from neatlogs.core.capture import (
+    DEFAULT_MAX_CAPTURE_ITEM_BYTES,
+    DEFAULT_MAX_CAPTURE_VALUE_BYTES,
+    limit_log_capture,
+    limit_span_capture,
+)
 from neatlogs.core.delivery import DeliveryDiagnostics
 from neatlogs.core.masking_exporter import MaskingLogExporter, MaskingSpanExporter
+from neatlogs.core.upload_authority import OverflowExportReceipt
 
 
 class _SpanSink:
@@ -90,7 +98,12 @@ def test_masking_precedes_injected_overflow_authority():
 
         def export_overflow(self, payload):
             self.payload = payload
-            return True
+            return OverflowExportReceipt(
+                upload_id="upload-1",
+                project_id="project-1",
+                state="ready",
+                reference_exported=True,
+            )
 
     def mask(snapshot):
         snapshot["attributes"]["secret"] = "masked"
@@ -122,3 +135,68 @@ def test_masking_precedes_injected_overflow_authority():
     assert b"must-not-cross-authority" not in authority.payload.content
     assert b"masked" in authority.payload.content
     assert sink.spans == []
+
+
+def test_span_capture_budget_covers_name_status_resource_and_mapping_keys():
+    sink = _SpanSink()
+    provider = TracerProvider(
+        resource=Resource(
+            {
+                "resource-key-" + "k" * 200: "resource-value-" + "r" * 200,
+            }
+        )
+    )
+    provider.add_span_processor(SimpleSpanProcessor(sink))
+    span = provider.get_tracer("capture-test").start_span("name-" + "n" * 1_200_000)
+    span.set_status(StatusCode.ERROR, "status-" + "s" * 200)
+    span.add_event("event-" + "e" * 200, {"event-key-" + "k" * 200: "value"})
+    span.end()
+    provider.shutdown()
+
+    bounded, truncations = limit_span_capture(
+        sink.spans[0],
+        max_item_bytes=2_000,
+        max_value_bytes=80,
+    )
+
+    assert truncations >= 5
+    assert len(bounded.name.encode()) <= 80
+    assert len(bounded.status.description.encode()) <= 80
+    assert all(len(key.encode()) <= 80 for key in bounded.resource.attributes)
+    assert all(len(key.encode()) <= 80 for key in bounded.events[0].attributes)
+    assert len(bounded.events[0].name.encode()) <= 80
+    assert len(bounded.name.encode()) < DEFAULT_MAX_CAPTURE_ITEM_BYTES
+
+
+def test_log_capture_bounds_bytes_resource_fields_and_collision_safe_mapping_keys():
+    inner = InMemoryLogRecordExporter()
+    provider = LoggerProvider(
+        resource=Resource({"resource-key-" + "k" * 200: "resource-value-" + "r" * 200})
+    )
+    provider.add_log_record_processor(SimpleLogRecordProcessor(inner))
+    provider.get_logger("capture-test").emit(
+        body={
+            "shared-prefix-" + "a" * 200: b"a" * 200,
+            "shared-prefix-" + "b" * 200: b"b" * 200,
+        },
+        severity_text="severity-" + "s" * 200,
+        event_name="event-" + "e" * 200,
+    )
+    provider.shutdown()
+
+    bounded, truncations = limit_log_capture(
+        inner.get_finished_logs()[0],
+        max_item_bytes=2_000,
+        max_value_bytes=80,
+    )
+    record = bounded.log_record
+    resource = getattr(bounded, "resource", None) or getattr(record, "resource", None)
+
+    assert truncations >= 7
+    assert len(record.body) == 2
+    assert len(set(record.body)) == 2
+    assert all(len(key.encode()) <= 80 for key in record.body)
+    assert all(isinstance(value, bytes) and len(value) <= 80 for value in record.body.values())
+    assert len(record.severity_text.encode()) <= 80
+    assert len(record.event_name.encode()) <= 80
+    assert all(len(key.encode()) <= 80 for key in resource.attributes)

--- a/tests/unit/test_capture_limits.py
+++ b/tests/unit/test_capture_limits.py
@@ -1,0 +1,124 @@
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter, SimpleLogRecordProcessor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
+
+from neatlogs._wrap_utils import serialize
+from neatlogs.core.byte_limited_exporter import ByteLimitedSpanExporter
+from neatlogs.core.byte_limited_log_exporter import ByteLimitedLogExporter
+from neatlogs.core.capture import DEFAULT_MAX_CAPTURE_VALUE_BYTES
+from neatlogs.core.delivery import DeliveryDiagnostics
+from neatlogs.core.masking_exporter import MaskingLogExporter, MaskingSpanExporter
+
+
+class _SpanSink:
+    def __init__(self):
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def force_flush(self, timeout_millis=30000):
+        return True
+
+    def shutdown(self):
+        return None
+
+
+def test_serialize_has_a_byte_bound_and_self_describing_truncation():
+    value = serialize({"payload": "é" * 80_000})
+
+    assert len(value.encode("utf-8")) <= DEFAULT_MAX_CAPTURE_VALUE_BYTES
+    assert "...[neatlogs-truncated" in value
+    assert "original_bytes=" in value
+    assert "sha256=" in value
+    assert "overflow=backend_upload_contract_unavailable" in value
+
+
+def test_post_mask_span_capture_is_bounded_and_reported():
+    sink = _SpanSink()
+    diagnostics = DeliveryDiagnostics()
+    exporter = ByteLimitedSpanExporter(sink, diagnostics=diagnostics)
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    span = provider.get_tracer("capture-test").start_span("large")
+    span.set_attribute("output.value", "x" * 150_000)
+    span.end()
+    provider.shutdown()
+
+    exported = sink.spans[0]
+    assert len(exported.attributes["output.value"].encode()) <= DEFAULT_MAX_CAPTURE_VALUE_BYTES
+    assert "...[neatlogs-truncated" in exported.attributes["output.value"]
+    assert exported.attributes["neatlogs.capture.truncated"] is True
+    assert exported.attributes["neatlogs.capture.overflow.state"] == "disabled"
+    assert diagnostics.snapshot()["span_capture_truncations"] == 1
+
+
+def test_post_mask_log_capture_is_bounded_and_reported():
+    diagnostics = DeliveryDiagnostics()
+    inner = InMemoryLogRecordExporter()
+    provider = LoggerProvider()
+    provider.add_log_record_processor(
+        SimpleLogRecordProcessor(
+            MaskingLogExporter(
+                ByteLimitedLogExporter(inner, diagnostics=diagnostics),
+                None,
+                diagnostics=diagnostics,
+            )
+        )
+    )
+
+    provider.get_logger("capture-test").emit(body="x" * 150_000)
+    provider.shutdown()
+
+    exported = inner.get_finished_logs()[0].log_record
+    assert len(exported.body.encode()) <= DEFAULT_MAX_CAPTURE_VALUE_BYTES
+    assert "...[neatlogs-truncated" in exported.body
+    assert exported.attributes["neatlogs.capture.truncated"] is True
+    assert diagnostics.snapshot()["log_capture_truncations"] == 1
+
+
+def test_masking_precedes_injected_overflow_authority():
+    class Authority:
+        available = True
+        unavailable_reason = ""
+
+        def __init__(self):
+            self.payload = None
+
+        def export_overflow(self, payload):
+            self.payload = payload
+            return True
+
+    def mask(snapshot):
+        snapshot["attributes"]["secret"] = "masked"
+        return snapshot
+
+    authority = Authority()
+    sink = _SpanSink()
+    provider = TracerProvider()
+    provider.add_span_processor(
+        SimpleSpanProcessor(
+            MaskingSpanExporter(
+                ByteLimitedSpanExporter(
+                    sink,
+                    max_export_bytes=128,
+                    upload_authority=authority,
+                ),
+                mask,
+            )
+        )
+    )
+
+    span = provider.get_tracer("capture-test").start_span("oversized")
+    span.set_attribute("secret", "must-not-cross-authority")
+    span.set_attribute("padding", "x" * 2048)
+    span.end()
+    provider.shutdown()
+
+    assert authority.payload is not None
+    assert b"must-not-cross-authority" not in authority.payload.content
+    assert b"masked" in authority.payload.content
+    assert sink.spans == []

--- a/tests/unit/test_choice_accumulator.py
+++ b/tests/unit/test_choice_accumulator.py
@@ -220,21 +220,54 @@ def test_incremental_choice_capture_is_memory_bounded_and_explicit(
     assert "original_bytes=120000" in content
 
 
-def test_legacy_stream_capture_bounds_chunk_references_with_diagnostics(
+def test_legacy_stream_keeps_terminal_usage_beyond_1024_small_events(
     tracer_provider, in_memory_span_exporter
 ):
+    events = [
+        SimpleNamespace(type="response.output_text.delta", delta="x", response=None)
+        for _ in range(1024)
+    ]
+    usage = SimpleNamespace(input_tokens=11, output_tokens=22)
+    events.append(
+        SimpleNamespace(
+            type="response.completed",
+            delta=None,
+            response=SimpleNamespace(model="gpt-test", usage=usage),
+        )
+    )
+
+    span = tracer_provider.get_tracer("neatlogs.test").start_span("responses")
+    wrapper = SyncStreamWrapper(iter(events), span, _finalize_responses_stream)
+    list(wrapper)
+
+    finished = in_memory_span_exporter.get_finished_spans()[0]
+    assert finished.status.status_code is StatusCode.OK
+    assert finished.attributes["neatlogs.llm.token_count.prompt"] == 11
+    assert finished.attributes["neatlogs.llm.token_count.completion"] == 22
+    assert "neatlogs.stream.chunks_dropped" not in finished.attributes
+
+
+def test_legacy_stream_huge_chunk_is_not_retained_or_marked_successful(
+    tracer_provider, in_memory_span_exporter
+):
+    seen = []
+
     def finalizer(span, chunks, _duration, _ttft, *, interrupted=False):
-        span.set_attribute("captured.chunks", len(chunks))
+        seen.extend(chunks)
         span.set_status(StatusCode.UNSET if interrupted else StatusCode.OK)
         span.end()
 
+    huge = SimpleNamespace(payload="secret" * 250_000)
     span = tracer_provider.get_tracer("neatlogs.test").start_span("legacy-stream")
-    wrapper = SyncStreamWrapper(iter(range(1026)), span, finalizer)
+    wrapper = SyncStreamWrapper(iter([huge]), span, finalizer)
     list(wrapper)
 
-    attributes = in_memory_span_exporter.get_finished_spans()[0].attributes
-    assert attributes["captured.chunks"] == 1024
-    assert attributes["neatlogs.stream.chunks_dropped"] == 2
+    finished = in_memory_span_exporter.get_finished_spans()[0]
+    attributes = finished.attributes
+    assert seen == []
+    assert finished.status.status_code is StatusCode.UNSET
+    assert attributes["neatlogs.stream.chunks_dropped"] == 1
+    assert attributes["neatlogs.stream.capture_incomplete"] is True
     assert attributes["neatlogs.capture.truncated"] is True
     assert attributes["neatlogs.capture.overflow.reason"] == "backend_upload_contract_unavailable"
 

--- a/tests/unit/test_choice_accumulator.py
+++ b/tests/unit/test_choice_accumulator.py
@@ -1,9 +1,12 @@
 import asyncio
+from types import SimpleNamespace
 
 import pytest
+from opentelemetry.trace import StatusCode
 
 from neatlogs._wrap_utils import AsyncStreamWrapper, SyncStreamWrapper
 from neatlogs.core.choice_accumulator import ChoiceAccumulator, OpenAIStreamFinalizer
+from neatlogs.openai import _finalize_responses_stream
 
 
 def _chunk(choices, *, usage=None, model=None, response_id=None):
@@ -116,6 +119,124 @@ def test_sync_for_loop_break_finalizes_without_explicit_close(
     finished = in_memory_span_exporter.get_finished_spans()[0]
     assert finished.attributes["neatlogs.llm.output_messages.0.content"] == "first"
     assert finished.attributes["neatlogs.stream.cancelled"] is True
+
+
+def test_sync_iterator_break_does_not_close_provider_stream(
+    tracer_provider, in_memory_span_exporter
+):
+    class ProviderStream:
+        def __init__(self):
+            self.values = iter(
+                [
+                    _chunk([{"index": 0, "delta": {"content": "first"}}]),
+                    _chunk([{"index": 0, "delta": {"content": "second"}}]),
+                ]
+            )
+            self.closed = False
+
+        def __next__(self):
+            if self.closed:
+                raise RuntimeError("provider stream was closed")
+            return next(self.values)
+
+        def close(self):
+            self.closed = True
+
+    span = tracer_provider.get_tracer("neatlogs.test").start_span("llm")
+    source = ProviderStream()
+    wrapper = SyncStreamWrapper(source, span, OpenAIStreamFinalizer())
+    iterator = iter(wrapper)
+
+    next(iterator)
+    iterator.close()  # what generator cleanup does when a for-loop is abandoned
+
+    assert source.closed is False
+    assert next(source)["choices"][0]["delta"]["content"] == "second"
+    finished = in_memory_span_exporter.get_finished_spans()[0]
+    assert finished.status.status_code is StatusCode.UNSET
+
+
+def test_legacy_provider_finalizer_preserves_unset_on_early_close(
+    tracer_provider, in_memory_span_exporter
+):
+    event = SimpleNamespace(type="response.output_text.delta", delta="partial", response=None)
+    span = tracer_provider.get_tracer("neatlogs.openai").start_span("responses")
+    wrapper = SyncStreamWrapper(iter([event]), span, _finalize_responses_stream)
+
+    next(wrapper)
+    wrapper.close()
+
+    finished = in_memory_span_exporter.get_finished_spans()[0]
+    assert finished.attributes["neatlogs.stream.cancelled"] is True
+    assert finished.status.status_code is StatusCode.UNSET
+
+
+def test_reasoning_content_uses_backend_thinking_selector_for_response_and_stream(
+    tracer_provider, in_memory_span_exporter
+):
+    response_span = tracer_provider.get_tracer("neatlogs.test").start_span("response")
+    response = ChoiceAccumulator()
+    response.add_response(
+        {"choices": [{"message": {"content": "answer", "reasoning_content": "private"}}]}
+    )
+    response.apply(response_span)
+    response_span.end()
+
+    stream_span = tracer_provider.get_tracer("neatlogs.test").start_span("stream")
+    stream = ChoiceAccumulator()
+    stream.add_chunk(
+        stream_span,
+        _chunk([{"index": 0, "delta": {"reasoning_content": "stream-private"}}]),
+    )
+    stream.apply(stream_span)
+    stream_span.end()
+
+    response_attrs, stream_attrs = [
+        item.attributes for item in in_memory_span_exporter.get_finished_spans()
+    ]
+    assert response_attrs["neatlogs.llm.output_messages.0.thinking"] == "private"
+    assert stream_attrs["neatlogs.llm.output_messages.0.thinking"] == "stream-private"
+    assert "neatlogs.llm.output_messages.0.reasoning" not in response_attrs
+    assert "neatlogs.llm.output_messages.0.reasoning" not in stream_attrs
+
+
+def test_incremental_choice_capture_is_memory_bounded_and_explicit(
+    tracer_provider, in_memory_span_exporter
+):
+    span = tracer_provider.get_tracer("neatlogs.test").start_span("large-stream")
+    accumulator = ChoiceAccumulator()
+    for _ in range(120):
+        accumulator.add_chunk(
+            span,
+            _chunk([{"index": 0, "delta": {"content": "x" * 1000}}]),
+        )
+    accumulator.apply(span)
+    span.end()
+
+    attributes = in_memory_span_exporter.get_finished_spans()[0].attributes
+    content = attributes["neatlogs.llm.output_messages.0.content"]
+    assert len(content.encode()) <= 100_000
+    assert "...[neatlogs-truncated" in content
+    assert "original_bytes=120000" in content
+
+
+def test_legacy_stream_capture_bounds_chunk_references_with_diagnostics(
+    tracer_provider, in_memory_span_exporter
+):
+    def finalizer(span, chunks, _duration, _ttft, *, interrupted=False):
+        span.set_attribute("captured.chunks", len(chunks))
+        span.set_status(StatusCode.UNSET if interrupted else StatusCode.OK)
+        span.end()
+
+    span = tracer_provider.get_tracer("neatlogs.test").start_span("legacy-stream")
+    wrapper = SyncStreamWrapper(iter(range(1026)), span, finalizer)
+    list(wrapper)
+
+    attributes = in_memory_span_exporter.get_finished_spans()[0].attributes
+    assert attributes["captured.chunks"] == 1024
+    assert attributes["neatlogs.stream.chunks_dropped"] == 2
+    assert attributes["neatlogs.capture.truncated"] is True
+    assert attributes["neatlogs.capture.overflow.reason"] == "backend_upload_contract_unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_choice_accumulator.py
+++ b/tests/unit/test_choice_accumulator.py
@@ -1,0 +1,151 @@
+import asyncio
+
+import pytest
+
+from neatlogs._wrap_utils import AsyncStreamWrapper, SyncStreamWrapper
+from neatlogs.core.choice_accumulator import ChoiceAccumulator, OpenAIStreamFinalizer
+
+
+def _chunk(choices, *, usage=None, model=None, response_id=None):
+    return {
+        "choices": choices,
+        "usage": usage,
+        "model": model,
+        "id": response_id,
+    }
+
+
+def test_interleaved_choices_and_tool_fragments_are_preserved(
+    tracer_provider, in_memory_span_exporter
+):
+    span = tracer_provider.get_tracer("neatlogs.test").start_span("llm")
+    accumulator = ChoiceAccumulator()
+    accumulator.add_chunk(
+        span,
+        _chunk(
+            [
+                {
+                    "index": 1,
+                    "delta": {
+                        "content": "B",
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"name": "lookup", "arguments": '{"q":'},
+                            }
+                        ],
+                    },
+                },
+                {"index": 0, "delta": {"content": "A"}},
+            ],
+            model="gpt-test",
+            response_id="response-1",
+        ),
+    )
+    accumulator.add_chunk(
+        span,
+        _chunk(
+            [
+                {
+                    "index": 1,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"arguments": '"weather"}'},
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                },
+                {"index": 0, "delta": {"content": "0"}, "finish_reason": "stop"},
+            ],
+            usage={"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+        ),
+    )
+    accumulator.apply(span)
+    span.end()
+
+    attributes = in_memory_span_exporter.get_finished_spans()[0].attributes
+    assert attributes["neatlogs.llm.output_messages.0.content"] == "A0"
+    assert attributes["neatlogs.llm.output_messages.1.content"] == "B"
+    assert attributes["neatlogs.llm.choices.0.finish_reason"] == "stop"
+    assert attributes["neatlogs.llm.choices.1.finish_reason"] == "tool_calls"
+    assert attributes["neatlogs.llm.tool_calls.0.name"] == "lookup"
+    assert attributes["neatlogs.llm.tool_calls.0.arguments"] == '{"q":"weather"}'
+    assert attributes["neatlogs.llm.tool_calls.0.choice_index"] == 1
+    assert attributes["neatlogs.llm.tool_calls.0.tool_call_index"] == 0
+    assert attributes["neatlogs.llm.tool_calls.0.id"].startswith("nl_")
+    assert attributes["neatlogs.llm.tool_calls.0.id_synthetic"] is True
+    assert attributes["neatlogs.llm.token_count.total"] == 6
+
+
+def test_sync_early_close_exports_partial_content_as_interrupted(
+    tracer_provider, in_memory_span_exporter
+):
+    span = tracer_provider.get_tracer("neatlogs.test").start_span("llm")
+    stream = iter([_chunk([{"index": 0, "delta": {"content": "partial"}}])])
+    wrapper = SyncStreamWrapper(stream, span, OpenAIStreamFinalizer())
+
+    next(wrapper)
+    assert not wrapper._chunks
+    wrapper.close()
+
+    finished = in_memory_span_exporter.get_finished_spans()[0]
+    assert finished.attributes["neatlogs.llm.output_messages.0.content"] == "partial"
+    assert finished.attributes["neatlogs.stream.cancelled"] is True
+    assert finished.status.status_code.name == "UNSET"
+
+
+def test_sync_for_loop_break_finalizes_without_explicit_close(
+    tracer_provider, in_memory_span_exporter
+):
+    span = tracer_provider.get_tracer("neatlogs.test").start_span("llm")
+    stream = iter(
+        [
+            _chunk([{"index": 0, "delta": {"content": "first"}}]),
+            _chunk([{"index": 0, "delta": {"content": "second"}}]),
+        ]
+    )
+    wrapper = SyncStreamWrapper(stream, span, OpenAIStreamFinalizer())
+
+    for chunk in wrapper:
+        assert chunk["choices"][0]["delta"]["content"] == "first"
+        break
+
+    finished = in_memory_span_exporter.get_finished_spans()[0]
+    assert finished.attributes["neatlogs.llm.output_messages.0.content"] == "first"
+    assert finished.attributes["neatlogs.stream.cancelled"] is True
+
+
+@pytest.mark.asyncio
+async def test_async_cancellation_exports_partial_content_as_interrupted(
+    tracer_provider, in_memory_span_exporter
+):
+    async def stream():
+        yield _chunk([{"index": 0, "delta": {"content": "partial"}}])
+        await asyncio.Future()
+
+    span = tracer_provider.get_tracer("neatlogs.test").start_span("llm")
+    wrapper = AsyncStreamWrapper(stream(), span, OpenAIStreamFinalizer())
+    await anext(wrapper)
+    assert not wrapper._chunks
+    await wrapper.aclose()
+
+    finished = in_memory_span_exporter.get_finished_spans()[0]
+    assert finished.attributes["neatlogs.llm.output_messages.0.content"] == "partial"
+    assert finished.attributes["neatlogs.stream.cancelled"] is True
+    assert finished.status.status_code.name == "UNSET"
+
+
+def test_flattened_callback_can_report_capture_fidelity_explicitly(
+    tracer_provider, in_memory_span_exporter
+):
+    span = tracer_provider.get_tracer("neatlogs.test").start_span("flattened")
+    accumulator = ChoiceAccumulator(capture_fidelity="flattened")
+    accumulator.add_response({"choices": [{"message": {"content": "flat"}}]})
+    accumulator.apply(span)
+    span.end()
+
+    attributes = in_memory_span_exporter.get_finished_spans()[0].attributes
+    assert attributes["neatlogs.capture_fidelity"] == "flattened"

--- a/tests/unit/test_crewai_tool_fidelity.py
+++ b/tests/unit/test_crewai_tool_fidelity.py
@@ -31,7 +31,7 @@ def _finished_span(in_memory_span_exporter, name: str):
     return next(span for span in in_memory_span_exporter.get_finished_spans() if span.name == name)
 
 
-def test_base_tool_preserves_long_structured_input_output_and_return_value(
+def test_base_tool_bounds_long_structured_input_output_without_changing_return_value(
     in_memory_span_exporter,
 ) -> None:
     _install_test_tracer(in_memory_span_exporter)
@@ -60,12 +60,13 @@ def test_base_tool_preserves_long_structured_input_output_and_return_value(
     tool_span = _finished_span(in_memory_span_exporter, "crewai.tool.long_tool")
     captured_input = tool_span.attributes["input.value"]
     captured_output = tool_span.attributes["output.value"]
-    assert input_tail in captured_input
-    assert output_tail in captured_output
-    assert len(captured_input) > 100_000
-    assert len(captured_output) > 100_000
-    assert json.loads(captured_input) == {"payload": argument}
-    assert json.loads(captured_output) == result
+    assert input_tail not in captured_input
+    assert output_tail not in captured_output
+    assert len(captured_input.encode()) <= 100_000
+    assert len(captured_output.encode()) <= 100_000
+    assert "...[neatlogs-truncated" in captured_input
+    assert "overflow=backend_upload_contract_unavailable" in captured_input
+    assert "...[neatlogs-truncated" in captured_output
     assert tool_span.attributes["neatlogs.framework"] == "crewai"
     assert tool_span.attributes["neatlogs.span.kind"] == "tool"
 

--- a/tests/unit/test_decorator_streaming.py
+++ b/tests/unit/test_decorator_streaming.py
@@ -1,5 +1,6 @@
-import pytest
 import asyncio
+
+import pytest
 from opentelemetry import trace as otel_trace
 
 import neatlogs

--- a/tests/unit/test_decorator_streaming.py
+++ b/tests/unit/test_decorator_streaming.py
@@ -1,4 +1,5 @@
 import pytest
+import asyncio
 from opentelemetry import trace as otel_trace
 
 import neatlogs
@@ -32,6 +33,9 @@ def test_sync_generator_span_stays_open_and_records_every_chunk(
         0,
         1,
     ]
+    assert all(
+        "neatlogs.stream.chunk.value" not in event.attributes for event in finished[0].events
+    )
     assert finished[0].attributes["output.value"] == '[{"delta": "a"}, {"delta": "b"}]'
 
 
@@ -75,3 +79,29 @@ async def test_async_generator_span_stays_open_and_records_every_chunk(
     assert len(finished) == 1
     assert finished[0].attributes["neatlogs.stream.chunk_count"] == 2
     assert len(finished[0].events) == 2
+
+
+@pytest.mark.asyncio
+async def test_cancelled_coroutine_is_interrupted_not_error(
+    tracer_provider, in_memory_span_exporter
+):
+    otel_trace.set_tracer_provider(tracer_provider)
+    set_neatlogs_provider(tracer_provider)
+
+    started = asyncio.Event()
+
+    @neatlogs.span(kind="CHAIN")
+    async def wait_forever():
+        started.set()
+        await asyncio.Future()
+
+    task = asyncio.create_task(wait_forever())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    finished = in_memory_span_exporter.get_finished_spans()
+    assert len(finished) == 1
+    assert finished[0].attributes["neatlogs.stream.cancelled"] is True
+    assert finished[0].status.status_code.name == "UNSET"

--- a/tests/unit/test_delivery_diagnostics.py
+++ b/tests/unit/test_delivery_diagnostics.py
@@ -43,3 +43,12 @@ def test_exposes_queue_saturation_before_otel_drops():
 
     assert diagnostics.snapshot()["span_queue_drops"] == 1
     processor.shutdown()
+
+
+def test_default_diagnostics_report_backend_upload_contract_dependency():
+    diagnostics = DeliveryDiagnostics()
+
+    snapshot = diagnostics.snapshot()
+    assert snapshot["span_upload_authority_available"] is False
+    assert snapshot["log_upload_authority_available"] is False
+    assert snapshot["span_upload_authority_reason"] == "backend_upload_contract_unavailable"

--- a/tests/unit/test_delivery_diagnostics.py
+++ b/tests/unit/test_delivery_diagnostics.py
@@ -1,0 +1,45 @@
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
+
+from neatlogs.core.delivery import DeliveryDiagnostics, ObservableBatchSpanProcessor
+
+
+class Exporter:
+    def __init__(self):
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def force_flush(self, timeout_millis=30000):
+        return True
+
+    def shutdown(self):
+        return None
+
+
+def _finished_span():
+    sink = Exporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(sink))
+    provider.get_tracer("delivery-test").start_span("span").end()
+    return sink.spans[0]
+
+
+def test_exposes_queue_saturation_before_otel_drops():
+    diagnostics = DeliveryDiagnostics()
+    processor = ObservableBatchSpanProcessor(
+        Exporter(),
+        max_queue_size=1,
+        max_export_batch_size=1,
+        schedule_delay_millis=60_000,
+        diagnostics=diagnostics,
+    )
+    span = _finished_span()
+    processor._batch_processor._queue.appendleft(span)
+
+    processor.on_end(span)
+
+    assert diagnostics.snapshot()["span_queue_drops"] == 1
+    processor.shutdown()

--- a/tests/unit/test_graceful_trace_shutdown.py
+++ b/tests/unit/test_graceful_trace_shutdown.py
@@ -221,6 +221,25 @@ def test_shutdown_drains_logs_before_trace_completion(monkeypatch):
     assert order == ["fence", "logs", "root-marker", "traces"]
 
 
+def test_shutdown_deadline_detaches_a_stuck_exporter_generation(monkeypatch):
+    release = threading.Event()
+
+    class Provider:
+        def shutdown(self):
+            release.wait()
+
+    monkeypatch.setattr(init_module, "_tracer_provider", Provider())
+    monkeypatch.setattr(init_module, "_owns_tracer_provider", True)
+    monkeypatch.setattr(init_module, "_log_provider", None)
+    monkeypatch.setattr(init_module, "_span_processor", None)
+    monkeypatch.setattr(init_module, "_completion_span_processor", None)
+    monkeypatch.setattr(init_module, "_instrumentation_manager", None)
+
+    assert init_module.shutdown(timeout_millis=20) is False
+    assert init_module._tracer_provider is None
+    release.set()
+
+
 def test_completion_marker_is_deferred_until_requested():
     provider = TracerProvider()
     lifecycle = NeatlogsSpanProcessor(

--- a/tests/unit/test_graceful_trace_shutdown.py
+++ b/tests/unit/test_graceful_trace_shutdown.py
@@ -1,5 +1,7 @@
 import importlib
 import signal
+import subprocess
+import sys
 import threading
 
 import pytest
@@ -13,6 +15,58 @@ from neatlogs._wrap_utils import set_neatlogs_provider
 from neatlogs.core.span_processor import CompletionMarkerSpanProcessor, NeatlogsSpanProcessor
 
 init_module = importlib.import_module("neatlogs.init")
+
+
+@pytest.mark.parametrize("pipeline", ["default", "client"])
+def test_python_312_atexit_shutdown_never_starts_a_thread(tmp_path, pipeline):
+    marker = tmp_path / f"{pipeline}.shutdown"
+    if pipeline == "default":
+        setup = f"""
+import importlib
+import neatlogs
+neatlogs.init(
+    api_key="test-key",
+    disable_export=True,
+    instrumentations=[],
+    register_shutdown_handlers=False,
+)
+module = importlib.import_module("neatlogs.init")
+class Provider:
+    def shutdown(self):
+        open({str(marker)!r}, "w").write("closed")
+module._tracer_provider = Provider()
+module._owns_tracer_provider = True
+module._log_provider = None
+module._span_processor = None
+module._completion_span_processor = None
+module._instrumentation_manager = None
+"""
+    else:
+        setup = f"""
+from neatlogs.client import Client
+client = Client(api_key="test-key", workflow_name="test", disable_export=True)
+class Provider:
+    def shutdown(self):
+        open({str(marker)!r}, "w").write("closed")
+client.tracer_provider = Provider()
+"""
+
+    script = setup + """
+import threading
+def forbidden(*args, **kwargs):
+    raise RuntimeError("cannot create new thread at interpreter shutdown")
+threading.Thread.start = forbidden
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert marker.read_text() == "closed"
+    assert "cannot create new thread" not in completed.stderr
 
 
 def test_end_active_spans_closes_children_then_root_and_emits_completion_marker():

--- a/tests/unit/test_graceful_trace_shutdown.py
+++ b/tests/unit/test_graceful_trace_shutdown.py
@@ -3,6 +3,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 
 import pytest
 from opentelemetry import trace as otel_trace
@@ -12,6 +13,9 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import StatusCode
 
 from neatlogs._wrap_utils import set_neatlogs_provider
+from neatlogs.client import Client
+from neatlogs.core.deadline import DeadlineWorker, bounded_call
+from neatlogs.core.masking_exporter import _MaskRunner
 from neatlogs.core.span_processor import CompletionMarkerSpanProcessor, NeatlogsSpanProcessor
 
 init_module = importlib.import_module("neatlogs.init")
@@ -67,6 +71,141 @@ threading.Thread.start = forbidden
     assert completed.returncode == 0, completed.stderr
     assert marker.read_text() == "closed"
     assert "cannot create new thread" not in completed.stderr
+
+
+def test_prestarted_deadline_worker_returns_at_deadline_without_starting_a_thread(monkeypatch):
+    worker = DeadlineWorker("neatlogs-test-shutdown")
+    monkeypatch.setattr(
+        threading.Thread,
+        "start",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("late thread start")),
+    )
+    started = time.monotonic()
+
+    completed, result = bounded_call(
+        lambda: time.sleep(0.2),
+        time.monotonic() + 0.02,
+        synchronous=True,
+        worker=worker,
+    )
+
+    elapsed = time.monotonic() - started
+    assert completed is False
+    assert isinstance(result, TimeoutError)
+    assert elapsed < 0.1
+    worker.close()
+
+
+def test_mask_runner_uses_workers_started_before_atexit(monkeypatch):
+    runner = _MaskRunner(timeout_seconds=0.1)
+    monkeypatch.setattr(
+        threading.Thread,
+        "start",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("late thread start")),
+    )
+
+    assert runner.apply(lambda snapshot: snapshot, {"signal": "span"}) == {"signal": "span"}
+    runner.shutdown()
+
+
+def test_atexit_flush_with_mask_uses_only_prestarted_workers(tmp_path):
+    marker = tmp_path / "masked.shutdown"
+    script = f"""
+import atexit
+import threading
+import time
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from neatlogs.core.deadline import DeadlineWorker, bounded_call
+from neatlogs.core.masking_exporter import MaskingSpanExporter
+
+inner = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(BatchSpanProcessor(
+    MaskingSpanExporter(inner, lambda snapshot: snapshot),
+    schedule_delay_millis=60_000,
+))
+worker = DeadlineWorker("atexit-test")
+provider.get_tracer("test").start_span("queued").end()
+def cleanup():
+    completed, _ = bounded_call(
+        provider.shutdown,
+        time.monotonic() + 1,
+        synchronous=True,
+        worker=worker,
+    )
+    open({str(marker)!r}, "w").write(f"{{completed}}:{{len(inner.get_finished_spans())}}")
+atexit.register(cleanup)
+def forbidden(*args, **kwargs):
+    raise RuntimeError("cannot create new thread at interpreter shutdown")
+threading.Thread.start = forbidden
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert marker.read_text() == "True:1"
+    assert "cannot create new thread" not in completed.stderr
+
+
+def test_concurrent_client_shutdown_wait_is_deadline_bounded():
+    client = Client(api_key="test-key", workflow_name="bounded", disable_export=True)
+    entered = threading.Event()
+    release = threading.Event()
+
+    class SlowProvider:
+        def shutdown(self):
+            entered.set()
+            release.wait(1)
+
+    client.tracer_provider = SlowProvider()
+    owner = threading.Thread(target=lambda: client.shutdown(timeout_millis=500), daemon=True)
+    owner.start()
+    assert entered.wait(0.2)
+    started = time.monotonic()
+
+    assert client.shutdown(timeout_millis=20) is False
+    assert time.monotonic() - started < 0.1
+
+    release.set()
+    owner.join(1)
+
+
+def test_concurrent_default_shutdown_wait_is_deadline_bounded(monkeypatch):
+    entered = threading.Event()
+    release = threading.Event()
+
+    class SlowProvider:
+        def shutdown(self):
+            entered.set()
+            release.wait(1)
+
+    monkeypatch.setattr(init_module, "_tracer_provider", SlowProvider())
+    monkeypatch.setattr(init_module, "_owns_tracer_provider", True)
+    monkeypatch.setattr(init_module, "_log_provider", None)
+    monkeypatch.setattr(init_module, "_span_processor", None)
+    monkeypatch.setattr(init_module, "_completion_span_processor", None)
+    monkeypatch.setattr(init_module, "_instrumentation_manager", None)
+
+    owner = threading.Thread(
+        target=lambda: init_module.shutdown(timeout_millis=500),
+        daemon=True,
+    )
+    owner.start()
+    assert entered.wait(0.2)
+    started = time.monotonic()
+
+    assert init_module.shutdown(timeout_millis=20) is False
+    assert time.monotonic() - started < 0.1
+
+    release.set()
+    owner.join(1)
 
 
 def test_end_active_spans_closes_children_then_root_and_emits_completion_marker():

--- a/tests/unit/test_init_identity.py
+++ b/tests/unit/test_init_identity.py
@@ -1,0 +1,44 @@
+import pytest
+
+import neatlogs
+from neatlogs.errors import NeatlogsConfigurationError
+
+
+def test_identical_init_is_idempotent_but_conflicting_init_is_typed_error():
+    neatlogs.init(
+        api_key="key-a",
+        workflow_name="identity",
+        disable_export=True,
+        register_shutdown_handlers=False,
+    )
+    neatlogs.init(
+        api_key="key-a",
+        workflow_name="identity",
+        disable_export=True,
+        register_shutdown_handlers=False,
+    )
+
+    with pytest.raises(NeatlogsConfigurationError, match="different configuration"):
+        neatlogs.init(
+            api_key="key-b",
+            workflow_name="identity",
+            disable_export=True,
+            register_shutdown_handlers=False,
+        )
+
+    assert neatlogs.shutdown()
+
+
+def test_explicit_shutdown_allows_a_new_configuration_generation():
+    neatlogs.init(
+        api_key="first",
+        disable_export=True,
+        register_shutdown_handlers=False,
+    )
+    assert neatlogs.shutdown()
+    neatlogs.init(
+        api_key="second",
+        disable_export=True,
+        register_shutdown_handlers=False,
+    )
+    assert neatlogs.shutdown()

--- a/tests/unit/test_mask_application.py
+++ b/tests/unit/test_mask_application.py
@@ -1,6 +1,8 @@
 """Masking is applied once, off the normalizer, at the final exporter boundary."""
 
 import asyncio
+import threading
+import time
 
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter, SimpleLogRecordProcessor
@@ -10,7 +12,8 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from neatlogs.core.mask import register_mask
-from neatlogs.core.masking_exporter import MaskingLogExporter, MaskingSpanExporter
+from neatlogs.core.masking_exporter import MaskingLogExporter, MaskingSpanExporter, _MaskRunner
+from neatlogs.core.delivery import DeliveryDiagnostics
 from neatlogs.core.span_processor import NeatlogsSpanProcessor
 
 
@@ -112,6 +115,59 @@ def test_awaitable_mask_runs_and_callback_failure_fails_closed():
     span.end()
     provider.shutdown()
     assert inner.get_finished_spans() == ()
+
+
+def test_context_aware_mask_timeout_is_fail_closed_and_cancellable():
+    blocker = threading.Event()
+    observed = {}
+
+    def stuck_mask(snapshot, context):
+        observed["context"] = context
+        blocker.wait()
+        return snapshot
+
+    provider = TracerProvider()
+    inner = InMemorySpanExporter()
+    diagnostics = DeliveryDiagnostics()
+    provider.add_span_processor(
+        SimpleSpanProcessor(
+            MaskingSpanExporter(inner, stuck_mask, timeout_seconds=0.02, diagnostics=diagnostics)
+        )
+    )
+    span = provider.get_tracer("neatlogs.test").start_span("secret")
+    span.set_attribute("neatlogs.input.value", "must-not-export")
+    span.end()
+
+    context = observed["context"]
+    assert context.signal_type == "span"
+    assert context.cancelled.is_set()
+    assert inner.get_finished_spans() == ()
+    assert diagnostics.snapshot()["masked_span_drops"] == 1
+    blocker.set()
+    provider.shutdown()
+
+
+def test_mask_batch_uses_bounded_parallel_workers():
+    active = 0
+    peak = 0
+    lock = threading.Lock()
+
+    def mask(snapshot):
+        nonlocal active, peak
+        with lock:
+            active += 1
+            peak = max(peak, active)
+        time.sleep(0.02)
+        with lock:
+            active -= 1
+        return snapshot
+
+    runner = _MaskRunner(timeout_seconds=1, max_workers=4)
+    results = runner.apply_many([(mask, {"signal": "span", "index": i}) for i in range(8)])
+    runner.shutdown()
+
+    assert all(result is not None for result in results)
+    assert 2 <= peak <= 4
 
 
 def test_global_mask_covers_logs_and_drops_failed_items():

--- a/tests/unit/test_mask_application.py
+++ b/tests/unit/test_mask_application.py
@@ -37,6 +37,38 @@ def _counting_mask(counter, tag):
     return mask
 
 
+def test_optional_second_positional_parameter_keeps_legacy_value():
+    seen = []
+
+    def mask(snapshot, keys=("secret",)):
+        seen.append(keys)
+        return snapshot
+
+    runner = _MaskRunner()
+    try:
+        assert runner.apply(mask, {"signal": "span", "attributes": {}}) is not None
+    finally:
+        runner.shutdown()
+
+    assert seen == [("secret",)]
+
+
+def test_keyword_only_context_is_an_explicit_opt_in():
+    seen = []
+
+    def mask(snapshot, *, context):
+        seen.append(context)
+        return snapshot
+
+    runner = _MaskRunner()
+    try:
+        assert runner.apply(mask, {"signal": "span", "attributes": {}}) is not None
+    finally:
+        runner.shutdown()
+
+    assert seen[0].signal_type == "span"
+
+
 def test_global_mask_applied_once_to_exported_clone():
     counter = {"n": 0}
     provider, inner = _pipeline(_counting_mask(counter, "G"))
@@ -121,7 +153,7 @@ def test_context_aware_mask_timeout_is_fail_closed_and_cancellable():
     blocker = threading.Event()
     observed = {}
 
-    def stuck_mask(snapshot, context):
+    def stuck_mask(snapshot, *, context):
         observed["context"] = context
         blocker.wait()
         return snapshot

--- a/tests/unit/test_mask_application.py
+++ b/tests/unit/test_mask_application.py
@@ -11,9 +11,9 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+from neatlogs.core.delivery import DeliveryDiagnostics
 from neatlogs.core.mask import register_mask
 from neatlogs.core.masking_exporter import MaskingLogExporter, MaskingSpanExporter, _MaskRunner
-from neatlogs.core.delivery import DeliveryDiagnostics
 from neatlogs.core.span_processor import NeatlogsSpanProcessor
 
 

--- a/tests/unit/test_media_capture.py
+++ b/tests/unit/test_media_capture.py
@@ -32,3 +32,34 @@ def test_inline_and_remote_media_preserve_type_source_digest_and_reference(
     attrs = in_memory_span_exporter.get_finished_spans()[0].attributes
     assert attrs["neatlogs.llm.input_messages.0.media.0.type"] == "image"
     assert attrs["neatlogs.llm.input_messages.0.media.1.type"] == "document"
+
+
+def test_large_typed_media_reports_disabled_upload_instead_of_silent_hash_only():
+    raw = b"x" * 80_000
+    payload = {
+        "inline_data": {
+            "mime_type": "application/pdf",
+            "data": base64.b64encode(raw).decode(),
+        }
+    }
+
+    records = media_references(payload, "document")
+
+    assert len(records) == 1
+    assert records[0]["type"] == "document"
+    assert records[0]["byte_length"] == len(raw)
+    assert records[0]["sha256"] == hashlib.sha256(raw).hexdigest()
+    assert records[0]["state"] == "failed"
+    assert "backend_upload_contract_unavailable" in records[0]["safe_preview"]
+
+
+def test_binary_media_requires_explicit_type_and_arbitrary_strings_are_not_media():
+    assert media_references("plain user text", "input") == []
+    assert media_references({"data": b"raw without a type"}, "input") == []
+
+    records = media_references(
+        {"type": "audio", "mime_type": "audio/wav", "data": b"RIFF"},
+        "input",
+    )
+    assert records[0]["type"] == "audio"
+    assert records[0]["byte_length"] == 4

--- a/tests/unit/test_media_capture.py
+++ b/tests/unit/test_media_capture.py
@@ -1,0 +1,34 @@
+import base64
+import hashlib
+
+from neatlogs.core.media import media_references, set_media_attributes
+
+
+def test_inline_and_remote_media_preserve_type_source_digest_and_reference(
+    tracer_provider, in_memory_span_exporter
+):
+    raw = b"full-image-bytes"
+    payload = [
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(raw).decode()}"},
+        },
+        {
+            "type": "input_file",
+            "file_id": "file-provider-123",
+            "mime_type": "application/pdf",
+        },
+    ]
+    records = media_references(payload, "input")
+    assert records[0]["sha256"] == hashlib.sha256(raw).hexdigest()
+    assert records[0]["byte_length"] == len(raw)
+    assert records[0]["source"] == "inline"
+    assert records[1]["reference"] == "file-provider-123"
+    assert records[1]["source"] == "provider"
+
+    span = tracer_provider.get_tracer("neatlogs.test").start_span("media")
+    set_media_attributes(span, "neatlogs.llm.input_messages.0", payload, "input")
+    span.end()
+    attrs = in_memory_span_exporter.get_finished_spans()[0].attributes
+    assert attrs["neatlogs.llm.input_messages.0.media.0.type"] == "image"
+    assert attrs["neatlogs.llm.input_messages.0.media.1.type"] == "document"

--- a/tests/unit/test_media_capture.py
+++ b/tests/unit/test_media_capture.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 
+from neatlogs._wrap_utils import serialize
 from neatlogs.core.media import media_references, set_media_attributes
 
 
@@ -63,3 +64,87 @@ def test_binary_media_requires_explicit_type_and_arbitrary_strings_are_not_media
     )
     assert records[0]["type"] == "audio"
     assert records[0]["byte_length"] == 4
+
+
+def test_remote_media_strips_userinfo_query_and_fragment_from_all_capture_fields():
+    secret_url = (
+        "https://user:password@bucket.example/private.pdf"
+        "?X-Amz-Credential=AKIA_TEST&X-Amz-Signature=secret#fragment"
+    )
+    payload = {
+        "type": "input_file",
+        "mime_type": "application/pdf",
+        "url": secret_url,
+    }
+
+    record = media_references(payload, "input")[0]
+    captured = serialize(payload)
+
+    assert record["reference"] == "https://bucket.example/private.pdf"
+    assert "user" not in record["reference"]
+    assert "password" not in record["reference"]
+    assert "X-Amz" not in captured
+    assert "secret" not in captured
+
+
+def test_large_inline_media_body_is_replaced_by_typed_unavailable_metadata():
+    raw = b"unique-secret-media" * 6000
+    encoded = base64.b64encode(raw).decode()
+    payload = [
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{encoded}"},
+        }
+    ]
+
+    captured = serialize(payload)
+
+    assert encoded[:100] not in captured
+    assert "unique-secret-media" not in captured
+    assert "backend_upload_contract_unavailable" in captured
+    assert hashlib.sha256(raw).hexdigest() in captured
+    assert len(captured.encode()) < 2_000
+
+
+def test_anthropic_source_media_is_sanitized_without_losing_typed_metadata():
+    raw = b"private-anthropic-image" * 5000
+    encoded = base64.b64encode(raw).decode()
+    payload = [
+        {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": encoded,
+            },
+        },
+        {
+            "type": "document",
+            "source": {
+                "type": "url",
+                "url": "https://user:pass@example.test/report.pdf?token=secret#page=1",
+            },
+        },
+    ]
+
+    records = media_references(payload, "input")
+    captured = serialize(payload)
+
+    assert any(record["sha256"] == hashlib.sha256(raw).hexdigest() for record in records)
+    assert any(record.get("reference") == "https://example.test/report.pdf" for record in records)
+    assert encoded[:100] not in captured
+    assert "pass" not in captured
+    assert "token" not in captured
+
+
+def test_bedrock_nested_bytes_are_replaced_when_upload_is_unavailable():
+    raw = b"private-bedrock-image" * 6000
+    payload = {"image": {"format": "png", "source": {"bytes": raw}}}
+
+    records = media_references(payload, "input")
+    captured = serialize(payload)
+
+    assert records[0]["type"] == "image"
+    assert records[0]["state"] == "failed"
+    assert hashlib.sha256(raw).hexdigest() in captured
+    assert "private-bedrock-image" not in captured

--- a/tests/unit/test_transport_retry.py
+++ b/tests/unit/test_transport_retry.py
@@ -22,6 +22,7 @@ def test_python_transport_retries_429_post_without_overlapping_otel_5xx_policy()
             requests_seen += 1
             self.rfile.read(int(self.headers.get("Content-Length", "0")))
             self.send_response(429 if requests_seen < 3 else 200)
+            self.send_header("Retry-After", "0")
             self.send_header("Content-Length", "0")
             self.end_headers()
 
@@ -115,7 +116,49 @@ def test_transport_bounds_read_timeout_retries():
     finally:
         server.shutdown()
         server.server_close()
-    assert requests_seen == 3
+    # The response is ambiguous after the body has been accepted, so neither
+    # requests nor urllib3 may replay this POST.
+    assert requests_seen == 1
+
+
+def test_rate_limit_retry_after_cannot_escape_export_deadline():
+    requests_seen = 0
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            nonlocal requests_seen
+            requests_seen += 1
+            self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            self.send_response(429)
+            self.send_header("Retry-After", "30")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    started = time.monotonic()
+    try:
+        response = build_otlp_session().post(
+            f"http://127.0.0.1:{server.server_port}/v1/traces",
+            data=b"protobuf",
+            timeout=0.05,
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert response.status_code == 429
+    assert requests_seen == 1
+    assert elapsed < 0.5
+
+
+def test_transport_uses_no_version_sensitive_urllib3_retry_configuration():
+    session = build_otlp_session()
+    assert session.get_adapter("https://").max_retries.total == 0
 
 
 def test_upstream_exporter_rejects_work_after_shutdown():

--- a/tests/unit/test_transport_retry.py
+++ b/tests/unit/test_transport_retry.py
@@ -1,0 +1,128 @@
+import threading
+import gzip
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+import requests
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.exporter.otlp.proto.http import trace_exporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
+
+from neatlogs.core.transport import build_otlp_session
+
+
+def test_python_transport_retries_429_post_without_overlapping_otel_5xx_policy():
+    requests_seen = 0
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            nonlocal requests_seen
+            requests_seen += 1
+            self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            self.send_response(429 if requests_seen < 3 else 200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        response = build_otlp_session().post(
+            f"http://127.0.0.1:{server.server_port}/v1/traces",
+            data=b"protobuf",
+            timeout=1,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert response.status_code == 200
+    assert requests_seen == 3
+
+
+def test_upstream_otel_retries_503_and_gzip_is_receiver_compatible(monkeypatch):
+    requests_seen = 0
+    decoded = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            nonlocal requests_seen
+            requests_seen += 1
+            body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            assert self.headers.get("Content-Encoding") == "gzip"
+            decoded.append(gzip.decompress(body))
+            self.send_response(503 if requests_seen == 1 else 200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *_args):
+            pass
+
+    monkeypatch.setattr(trace_exporter.random, "uniform", lambda *_args: 0)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        exporter = OTLPSpanExporter(
+            endpoint=f"http://127.0.0.1:{server.server_port}/v1/traces",
+            compression=Compression.Gzip,
+            session=build_otlp_session(),
+        )
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        provider.get_tracer("retry-test").start_span("span").end()
+        provider.shutdown()
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert requests_seen == 2
+    assert all(decoded)
+
+
+def test_transport_bounds_read_timeout_retries():
+    requests_seen = 0
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            nonlocal requests_seen
+            requests_seen += 1
+            self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            time.sleep(0.05)
+            try:
+                self.send_response(200)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+            except BrokenPipeError:
+                pass
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        with pytest.raises(requests.exceptions.RequestException):
+            build_otlp_session().post(
+                f"http://127.0.0.1:{server.server_port}/v1/traces",
+                data=b"protobuf",
+                timeout=0.01,
+            )
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert requests_seen == 3
+
+
+def test_upstream_exporter_rejects_work_after_shutdown():
+    exporter = OTLPSpanExporter(
+        endpoint="http://127.0.0.1:1/v1/traces",
+        session=build_otlp_session(),
+    )
+    exporter.shutdown()
+    assert exporter.export(()) is SpanExportResult.FAILURE

--- a/tests/unit/test_transport_retry.py
+++ b/tests/unit/test_transport_retry.py
@@ -1,12 +1,11 @@
-import threading
 import gzip
+import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 import requests
-from opentelemetry.exporter.otlp.proto.http import Compression
-from opentelemetry.exporter.otlp.proto.http import trace_exporter
+from opentelemetry.exporter.otlp.proto.http import Compression, trace_exporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult


### PR DESCRIPTION
## Phase 2 scope

This PR contains the Python shared-SDK-kernel work recorded for launch-readiness Phase 2, plus the safe Python-only portion of Phase 8 that can ship before a backend upload API exists.

- Adds byte-aware OTLP span and log batching, gzip transport, deadline-bounded shutdown/flush behavior, and delivery diagnostics.
- Applies masking to spans and logs through isolated exporters with timeout and failure accounting.
- Preserves multi-choice, streaming, tool-call, typed-media, cancellation, and provider-stream ownership semantics.
- Adds bounded capture with explicit truncation metadata and counters instead of silent/unbounded serialization.
- Removes nested urllib3 read retries; 429 retries honor the exporter deadline and `Retry-After`, while OpenTelemetry remains the sole owner of connection/408/5xx retry behavior.
- Uses workers created during SDK/exporter initialization for bounded Python 3.12+ interpreter-exit cleanup; the `atexit` path does not start a new thread.

## Safe Phase 8 Python SDK scope

- Calculates encoded protobuf size before span and log batching and splits normal traffic conservatively.
- Detects typed image, audio, PDF, binary, and provider media; calculates SHA-256, byte length, MIME type, source, and purpose without fetching remote data or retaining an unbounded decoded copy.
- Removes userinfo, query strings, and fragments from captured remote media locators. When upload is unavailable, large inline media is replaced by typed failure metadata instead of retaining a base64 prefix.
- Bounds span/log names, bodies, status/severity/event fields, resource/record/event/link attributes, mapping keys, strings, and bytes to 100,000 bytes per value and 1 MB of aggregate captured data per telemetry item. Truncation is explicit and collision-safe.
- Adds an internal injectable upload-authority boundary after canonicalization and masking. A bare boolean cannot establish delivery; success requires a structured project-scoped, validated `ready` receipt whose small reference was exported.
- Does not invent an upload endpoint or authentication format. Generic overflow and large typed-media upload remain disabled pending the backend authenticated, project-scoped upload-session contract.

Phase 8 backend upload-session state, validation, quarantine/PII processing, persistence, cleanup, authenticated reads, and end-to-end recovery proof are not implemented in this SDK repository.

## Deployment gate

Gzip remains enabled because the backend is intended to deploy first. Do not release this SDK commit until the default trace and log ingest routes accept and verify gzip-compressed OTLP. The gzip review thread remains open to track that deployment gate.

## Validation

- `uv run pytest -q tests/unit`: 288 passed
- Python 3.12 focused subprocess `atexit` and deadline/concurrent-shutdown regressions: passed
- Python 3.13 built-wheel `atexit` smoke with thread creation forbidden during finalization: passed
- Python 3.12 built-wheel import/client shutdown smoke with `requests==2.31.0` and `urllib3==1.26.20`: passed
- `uv run black --check neatlogs tests/unit`: passed
- `uv run isort --check-only neatlogs tests/unit`: passed
- `uv run python -m compileall -q neatlogs tests/unit`: passed
- `uv build`: wheel and sdist built successfully
- `git diff --check`: passed
