### PR TITLE
Phase 6: coalesce exact SDK prompt fetches

### DIFF
--- a/neatlogs/prompt/_singleflight.py
+++ b/neatlogs/prompt/_singleflight.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Dict, Generic, Optional, TypeVar, cast
+
+T = TypeVar("T")
+
+
+@dataclass
+class _SyncFlight(Generic[T]):
+    event: threading.Event = field(default_factory=threading.Event)
+    error: Optional[BaseException] = None
+    result: Optional[T] = None
+    has_result: bool = False
+
+
+class SyncSingleFlight(Generic[T]):
+    """Run one synchronous operation per key and share its outcome with waiters."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._flights: Dict[str, _SyncFlight[T]] = {}
+
+    def run(self, key: str, operation: Callable[[], T]) -> T:
+        with self._lock:
+            flight = self._flights.get(key)
+            leader = flight is None
+            if flight is None:
+                flight = _SyncFlight()
+                self._flights[key] = flight
+
+        if not leader:
+            flight.event.wait()
+            if flight.error is not None:
+                raise flight.error
+            if not flight.has_result:
+                raise RuntimeError("Single-flight operation completed without a result")
+            return cast(T, flight.result)
+
+        try:
+            flight.result = operation()
+            flight.has_result = True
+            return cast(T, flight.result)
+        except BaseException as error:
+            flight.error = error
+            raise
+        finally:
+            flight.event.set()
+            with self._lock:
+                if self._flights.get(key) is flight:
+                    self._flights.pop(key, None)
+
+
+class AsyncSingleFlight(Generic[T]):
+    """Run one event-loop task per key without transferring caller cancellation."""
+
+    def __init__(self) -> None:
+        self._tasks: Dict[str, asyncio.Task[T]] = {}
+
+    async def run(self, key: str, operation: Callable[[], Awaitable[T]]) -> T:
+        task = self._tasks.get(key)
+        if task is None:
+            task = asyncio.create_task(operation())
+            self._tasks[key] = task
+
+            def clear_flight(completed: asyncio.Task[T]) -> None:
+                if self._tasks.get(key) is completed:
+                    self._tasks.pop(key, None)
+                # A shielded task can outlive every cancelled waiter. Observe its
+                # terminal exception so asyncio does not report it as unhandled.
+                if not completed.cancelled():
+                    completed.exception()
+
+            task.add_done_callback(clear_flight)
+        return await asyncio.shield(task)

--- a/neatlogs/prompt/client.py
+++ b/neatlogs/prompt/client.py
@@ -11,6 +11,7 @@ from urllib.parse import quote
 import requests
 
 from ..core.logger import get_logger
+from ._singleflight import AsyncSingleFlight, SyncSingleFlight
 
 logger = get_logger()
 
@@ -28,9 +29,21 @@ class PromptClientError(Exception):
 class PromptApiError(PromptClientError):
     """Raised when the backend returns an API error."""
 
+    def __init__(self, message: str, *, status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
+
 
 class PromptNotFoundError(PromptClientError):
     """Raised when a prompt/label/version is not found and no fallback is provided."""
+
+
+def _prompt_selector_description(label: Optional[str], version: Optional[int]) -> str:
+    if label is not None:
+        return f"label '{label}'"
+    if version is not None:
+        return f"version {version}"
+    return "latest version"
 
 
 # ---------------------------------------------------------------------------
@@ -47,12 +60,6 @@ class _CacheEntry:
 
     def is_expired(self) -> bool:
         return (_time.monotonic() - self.fetched_at) >= self.ttl_seconds
-
-
-@dataclass
-class _SyncFetchFlight:
-    event: threading.Event = field(default_factory=threading.Event)
-    error: Optional[BaseException] = None
 
 
 class PromptCache:
@@ -213,8 +220,7 @@ class PromptClient:
         self.api_key = api_key
         self._session = session or requests.Session()
         self._cache = PromptCache(default_ttl=cache_ttl_seconds)
-        self._cold_fetch_lock = threading.Lock()
-        self._cold_fetches: Dict[str, _SyncFetchFlight] = {}
+        self._cold_fetches: SyncSingleFlight[PromptHandle] = SyncSingleFlight()
 
     def get_prompt(
         self,
@@ -255,15 +261,18 @@ class PromptClient:
             )
             return entry.value
 
-        return self._coalesced_cold_fetch(
+        return self._cold_fetches.run(
             cache_key,
-            name,
-            label=label,
-            version=version,
-            ttl=cache_ttl_seconds,
+            lambda: self._fetch_and_cache(
+                cache_key,
+                name,
+                label=label,
+                version=version,
+                ttl=cache_ttl_seconds,
+            ),
         )
 
-    def _coalesced_cold_fetch(
+    def _fetch_and_cache(
         self,
         cache_key: str,
         name: str,
@@ -272,38 +281,9 @@ class PromptClient:
         version: Optional[int],
         ttl: Optional[float],
     ) -> PromptHandle:
-        """Let one thread perform a cold network fetch for each cache key."""
-        with self._cold_fetch_lock:
-            cached = self._cache.get(cache_key)
-            if cached is not None:
-                return cached.value
-            flight = self._cold_fetches.get(cache_key)
-            leader = flight is None
-            if flight is None:
-                flight = _SyncFetchFlight()
-                self._cold_fetches[cache_key] = flight
-
-        if not leader:
-            flight.event.wait()
-            if flight.error is not None:
-                raise flight.error
-            cached = self._cache.get(cache_key)
-            if cached is None:
-                raise PromptClientError("Coalesced prompt fetch completed without a result")
-            return cached.value
-
-        try:
-            handle = self._fetch_prompt(name, label=label, version=version)
-            self._cache.set(cache_key, handle, ttl)
-            return handle
-        except BaseException as error:
-            flight.error = error
-            raise
-        finally:
-            flight.event.set()
-            with self._cold_fetch_lock:
-                if self._cold_fetches.get(cache_key) is flight:
-                    self._cold_fetches.pop(cache_key, None)
+        handle = self._fetch_prompt(name, label=label, version=version)
+        self._cache.set(cache_key, handle, ttl)
+        return handle
 
     def _fetch_prompt(
         self,
@@ -321,7 +301,13 @@ class PromptClient:
             params = {"version": version}
         else:
             params = {"latest": "true"}
-        payload = self._request_json(method="GET", path=path, params=params)
+        try:
+            payload = self._request_json(method="GET", path=path, params=params)
+        except PromptApiError as error:
+            if error.status_code == 404:
+                selector = _prompt_selector_description(label, version)
+                raise PromptNotFoundError(f"Prompt '{name}' {selector} not found") from error
+            raise
         return PromptHandle(_normalize_prompt_object(payload))
 
     def _background_refresh(
@@ -562,7 +548,10 @@ class PromptClient:
 
         if response.status_code >= 400:
             body = _safe_response_text(response)
-            raise PromptApiError(f"{method} {path} failed ({response.status_code}): {body}")
+            raise PromptApiError(
+                f"{method} {path} failed ({response.status_code}): {body}",
+                status_code=response.status_code,
+            )
 
         try:
             payload = response.json()
@@ -802,7 +791,7 @@ class AsyncPromptClient:
             },
         )
         self._cache = PromptCache(default_ttl=cache_ttl_seconds)
-        self._cold_fetches: Dict[str, asyncio.Task[PromptHandle]] = {}
+        self._cold_fetches: AsyncSingleFlight[PromptHandle] = AsyncSingleFlight()
 
     async def get_prompt(
         self,
@@ -828,25 +817,16 @@ class AsyncPromptClient:
             )
             return entry.value
 
-        task = self._cold_fetches.get(cache_key)
-        if task is None:
-            task = asyncio.create_task(
-                self._fetch_and_cache(
-                    cache_key,
-                    name,
-                    label=label,
-                    version=version,
-                    ttl=cache_ttl_seconds,
-                )
-            )
-            self._cold_fetches[cache_key] = task
-
-            def clear_flight(completed: asyncio.Task[PromptHandle]) -> None:
-                if self._cold_fetches.get(cache_key) is completed:
-                    self._cold_fetches.pop(cache_key, None)
-
-            task.add_done_callback(clear_flight)
-        return await asyncio.shield(task)
+        return await self._cold_fetches.run(
+            cache_key,
+            lambda: self._fetch_and_cache(
+                cache_key,
+                name,
+                label=label,
+                version=version,
+                ttl=cache_ttl_seconds,
+            ),
+        )
 
     async def _fetch_and_cache(
         self,
@@ -876,7 +856,13 @@ class AsyncPromptClient:
             params = {"version": version}
         else:
             params = {"latest": "true"}
-        payload = await self._request_json(method="GET", path=path, params=params)
+        try:
+            payload = await self._request_json(method="GET", path=path, params=params)
+        except PromptApiError as error:
+            if error.status_code == 404:
+                selector = _prompt_selector_description(label, version)
+                raise PromptNotFoundError(f"Prompt '{name}' {selector} not found") from error
+            raise
         return PromptHandle(_normalize_prompt_object(payload))
 
     def _background_refresh(
@@ -942,7 +928,10 @@ class AsyncPromptClient:
 
         if response.status_code >= 400:
             body = response.text[:400] if response.text else "<empty>"
-            raise PromptApiError(f"{method} {path} failed ({response.status_code}): {body}")
+            raise PromptApiError(
+                f"{method} {path} failed ({response.status_code}): {body}",
+                status_code=response.status_code,
+            )
 
         try:
             payload = response.json()

--- a/neatlogs/prompt/client.py
+++ b/neatlogs/prompt/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import re
 import threading
 import time as _time
@@ -46,6 +47,12 @@ class _CacheEntry:
 
     def is_expired(self) -> bool:
         return (_time.monotonic() - self.fetched_at) >= self.ttl_seconds
+
+
+@dataclass
+class _SyncFetchFlight:
+    event: threading.Event = field(default_factory=threading.Event)
+    error: Optional[BaseException] = None
 
 
 class PromptCache:
@@ -206,6 +213,8 @@ class PromptClient:
         self.api_key = api_key
         self._session = session or requests.Session()
         self._cache = PromptCache(default_ttl=cache_ttl_seconds)
+        self._cold_fetch_lock = threading.Lock()
+        self._cold_fetches: Dict[str, _SyncFetchFlight] = {}
 
     def get_prompt(
         self,
@@ -246,10 +255,55 @@ class PromptClient:
             )
             return entry.value
 
-        # Cold miss — must fetch synchronously
-        handle = self._fetch_prompt(name, label=label, version=version)
-        self._cache.set(cache_key, handle, cache_ttl_seconds)
-        return handle
+        return self._coalesced_cold_fetch(
+            cache_key,
+            name,
+            label=label,
+            version=version,
+            ttl=cache_ttl_seconds,
+        )
+
+    def _coalesced_cold_fetch(
+        self,
+        cache_key: str,
+        name: str,
+        *,
+        label: Optional[str],
+        version: Optional[int],
+        ttl: Optional[float],
+    ) -> PromptHandle:
+        """Let one thread perform a cold network fetch for each cache key."""
+        with self._cold_fetch_lock:
+            cached = self._cache.get(cache_key)
+            if cached is not None:
+                return cached.value
+            flight = self._cold_fetches.get(cache_key)
+            leader = flight is None
+            if flight is None:
+                flight = _SyncFetchFlight()
+                self._cold_fetches[cache_key] = flight
+
+        if not leader:
+            flight.event.wait()
+            if flight.error is not None:
+                raise flight.error
+            cached = self._cache.get(cache_key)
+            if cached is None:
+                raise PromptClientError("Coalesced prompt fetch completed without a result")
+            return cached.value
+
+        try:
+            handle = self._fetch_prompt(name, label=label, version=version)
+            self._cache.set(cache_key, handle, ttl)
+            return handle
+        except BaseException as error:
+            flight.error = error
+            raise
+        finally:
+            flight.event.set()
+            with self._cold_fetch_lock:
+                if self._cold_fetches.get(cache_key) is flight:
+                    self._cold_fetches.pop(cache_key, None)
 
     def _fetch_prompt(
         self,
@@ -259,23 +313,16 @@ class PromptClient:
         version: Optional[int] = None,
     ) -> PromptHandle:
         """Fetch prompt from backend (no cache involved)."""
+        path = f"/api/v1/prompts/{quote(name, safe='')}/fetch"
+        params: Dict[str, Any]
         if label is not None:
-            return PromptHandle(self.fetch_prompt(name, label=label))
-
-        listing = self.list_prompts(name=name)
-        items = listing.get("items", [])
-
-        if not items:
-            raise PromptNotFoundError(f"No versions found for prompt '{name}'")
-
-        if version is not None:
-            for item in items:
-                if item.get("version") == version:
-                    return PromptHandle(_normalize_prompt_object(item))
-            raise PromptNotFoundError(f"Prompt '{name}' version {version} not found")
-
-        latest = max(items, key=lambda x: x.get("createdAt") or x.get("created_at") or "")
-        return PromptHandle(_normalize_prompt_object(latest))
+            params = {"label": label}
+        elif version is not None:
+            params = {"version": version}
+        else:
+            params = {"latest": "true"}
+        payload = self._request_json(method="GET", path=path, params=params)
+        return PromptHandle(_normalize_prompt_object(payload))
 
     def _background_refresh(
         self,
@@ -399,15 +446,7 @@ class PromptClient:
                 "new_labels is required. Specify at least one label, e.g. new_labels=['production']."
             )
 
-        listing = self.list_prompts(name=name)
-        prompt_id: Optional[str] = None
-        for item in listing.get("items", []):
-            if item.get("version") == version:
-                prompt_id = item.get("id")
-                break
-
-        if not prompt_id:
-            raise PromptNotFoundError(f"Prompt '{name}' version {version} not found")
+        prompt_id = self._fetch_prompt(name, version=version).id
 
         path = f"/api/managed-prompts/{quote(prompt_id, safe='')}/labels"
         last_response: Dict[str, Any] = {}
@@ -424,15 +463,7 @@ class PromptClient:
         """
         Soft-delete a specific prompt version via DELETE /api/managed-prompts/:promptId.
         """
-        listing = self.list_prompts(name=name)
-        prompt_id: Optional[str] = None
-        for item in listing.get("items", []):
-            if item.get("version") == version:
-                prompt_id = item.get("id")
-                break
-
-        if not prompt_id:
-            raise PromptNotFoundError(f"Prompt '{name}' version {version} not found")
+        prompt_id = self._fetch_prompt(name, version=version).id
 
         path = f"/api/managed-prompts/{quote(prompt_id, safe='')}"
         return self._request_json(method="DELETE", path=path)
@@ -446,15 +477,7 @@ class PromptClient:
         """
         Remove a tag from a prompt version via DELETE /api/managed-prompts/:promptId/tags.
         """
-        listing = self.list_prompts(name=name)
-        prompt_id: Optional[str] = None
-        for item in listing.get("items", []):
-            if item.get("version") == version:
-                prompt_id = item.get("id")
-                break
-
-        if not prompt_id:
-            raise PromptNotFoundError(f"Prompt '{name}' version {version} not found")
+        prompt_id = self._fetch_prompt(name, version=version).id
 
         path = f"/api/managed-prompts/{quote(prompt_id, safe='')}/tags"
         return self._request_json(method="DELETE", path=path, json_body={"tag": tag})
@@ -779,6 +802,7 @@ class AsyncPromptClient:
             },
         )
         self._cache = PromptCache(default_ttl=cache_ttl_seconds)
+        self._cold_fetches: Dict[str, asyncio.Task[PromptHandle]] = {}
 
     async def get_prompt(
         self,
@@ -804,9 +828,37 @@ class AsyncPromptClient:
             )
             return entry.value
 
-        # Cold miss — must fetch
+        task = self._cold_fetches.get(cache_key)
+        if task is None:
+            task = asyncio.create_task(
+                self._fetch_and_cache(
+                    cache_key,
+                    name,
+                    label=label,
+                    version=version,
+                    ttl=cache_ttl_seconds,
+                )
+            )
+            self._cold_fetches[cache_key] = task
+
+            def clear_flight(completed: asyncio.Task[PromptHandle]) -> None:
+                if self._cold_fetches.get(cache_key) is completed:
+                    self._cold_fetches.pop(cache_key, None)
+
+            task.add_done_callback(clear_flight)
+        return await asyncio.shield(task)
+
+    async def _fetch_and_cache(
+        self,
+        cache_key: str,
+        name: str,
+        *,
+        label: Optional[str],
+        version: Optional[int],
+        ttl: Optional[float],
+    ) -> PromptHandle:
         handle = await self._fetch_prompt(name, label=label, version=version)
-        self._cache.set(cache_key, handle, cache_ttl_seconds)
+        self._cache.set(cache_key, handle, ttl)
         return handle
 
     async def _fetch_prompt(
@@ -816,26 +868,16 @@ class AsyncPromptClient:
         label: Optional[str] = None,
         version: Optional[int] = None,
     ) -> PromptHandle:
+        path = f"/api/v1/prompts/{quote(name, safe='')}/fetch"
+        params: Dict[str, Any]
         if label is not None:
-            path = f"/api/v1/prompts/{quote(name, safe='')}/fetch"
-            payload = await self._request_json(method="GET", path=path, params={"label": label})
-            return PromptHandle(_normalize_prompt_object(payload))
-
-        params: Dict[str, Any] = {"limit": 100, "offset": 0, "name": name}
-        listing = await self._request_json(method="GET", path="/api/managed-prompts", params=params)
-        items = listing.get("items", [])
-
-        if not items:
-            raise PromptNotFoundError(f"No versions found for prompt '{name}'")
-
-        if version is not None:
-            for item in items:
-                if item.get("version") == version:
-                    return PromptHandle(_normalize_prompt_object(item))
-            raise PromptNotFoundError(f"Prompt '{name}' version {version} not found")
-
-        latest = max(items, key=lambda x: x.get("createdAt") or x.get("created_at") or "")
-        return PromptHandle(_normalize_prompt_object(latest))
+            params = {"label": label}
+        elif version is not None:
+            params = {"version": version}
+        else:
+            params = {"latest": "true"}
+        payload = await self._request_json(method="GET", path=path, params=params)
+        return PromptHandle(_normalize_prompt_object(payload))
 
     def _background_refresh(
         self,
@@ -848,8 +890,6 @@ class AsyncPromptClient:
     ) -> None:
         if not self._cache.mark_refreshing(cache_key):
             return
-
-        import asyncio
 
         async def _refresh():
             try:

--- a/tests/unit/test_prompt_client_fetch.py
+++ b/tests/unit/test_prompt_client_fetch.py
@@ -1,0 +1,188 @@
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import AsyncMock, Mock, call
+
+import pytest
+
+from neatlogs.prompt.client import AsyncPromptClient, PromptClient, PromptHandle
+
+PROMPT = {
+    "id": "00000000-0000-4000-8000-000000000001",
+    "name": "support prompt",
+    "version": 123,
+    "content": "Hello {{name}}",
+    "messages": None,
+    "config": {},
+    "labels": [],
+    "updatedAt": "2026-09-02T00:00:00.000Z",
+}
+
+
+@pytest.mark.parametrize(
+    ("version", "expected_params"),
+    [(123, {"version": 123}), (None, {"latest": "true"})],
+)
+def test_sync_fetch_uses_one_exact_endpoint(version, expected_params):
+    client = PromptClient(base_url="https://example.test", api_key="test-key")
+    client._request_json = Mock(return_value=PROMPT)
+
+    handle = client._fetch_prompt("support prompt", version=version)
+
+    assert handle.version == 123
+    client._request_json.assert_called_once_with(
+        method="GET",
+        path="/api/v1/prompts/support%20prompt/fetch",
+        params=expected_params,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("version", "expected_params"),
+    [(123, {"version": 123}), (None, {"latest": "true"})],
+)
+async def test_async_fetch_uses_one_exact_endpoint(version, expected_params):
+    client = AsyncPromptClient(base_url="https://example.test", api_key="test-key")
+    client._request_json = AsyncMock(return_value=PROMPT)
+    try:
+        handle = await client._fetch_prompt("support prompt", version=version)
+    finally:
+        await client.close()
+
+    assert handle.version == 123
+    client._request_json.assert_awaited_once_with(
+        method="GET",
+        path="/api/v1/prompts/support%20prompt/fetch",
+        params=expected_params,
+    )
+
+
+def test_sync_cold_cache_miss_is_coalesced():
+    client = PromptClient(base_url="https://example.test", api_key="test-key")
+    calls = 0
+
+    def fetch(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        time.sleep(0.05)
+        return PromptHandle(client_prompt())
+
+    client._fetch_prompt = fetch
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        handles = list(executor.map(lambda _: client.get_prompt("support prompt"), range(2)))
+
+    assert calls == 1
+    assert [handle.version for handle in handles] == [123, 123]
+
+
+def test_sync_coalesced_failure_wakes_all_waiters():
+    client = PromptClient(base_url="https://example.test", api_key="test-key")
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def fetch(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        started.set()
+        release.wait(timeout=1)
+        raise RuntimeError("backend unavailable")
+
+    client._fetch_prompt = fetch
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        leader = executor.submit(client.get_prompt, "support prompt")
+        assert started.wait(timeout=1)
+        follower = executor.submit(client.get_prompt, "support prompt")
+        release.set()
+
+        with pytest.raises(RuntimeError, match="backend unavailable"):
+            leader.result()
+        with pytest.raises(RuntimeError, match="backend unavailable"):
+            follower.result()
+
+    assert calls == 1
+
+
+def test_mutation_resolves_exact_version_without_listing_history():
+    client = PromptClient(base_url="https://example.test", api_key="test-key")
+    client._request_json = Mock(side_effect=[PROMPT, {"deleted": True}])
+
+    result = client.delete_prompt("support prompt", 123)
+
+    assert result == {"deleted": True}
+    assert client._request_json.call_args_list == [
+        call(
+            method="GET",
+            path="/api/v1/prompts/support%20prompt/fetch",
+            params={"version": 123},
+        ),
+        call(
+            method="DELETE",
+            path="/api/managed-prompts/00000000-0000-4000-8000-000000000001",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_cold_cache_miss_is_coalesced():
+    client = AsyncPromptClient(base_url="https://example.test", api_key="test-key")
+    calls = 0
+
+    async def fetch(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.05)
+        return PromptHandle(client_prompt())
+
+    client._fetch_prompt = fetch
+    try:
+        handles = await asyncio.gather(
+            client.get_prompt("support prompt"),
+            client.get_prompt("support prompt"),
+        )
+    finally:
+        await client.close()
+
+    assert calls == 1
+    assert [handle.version for handle in handles] == [123, 123]
+
+
+@pytest.mark.asyncio
+async def test_async_caller_cancellation_does_not_cancel_shared_fetch():
+    client = AsyncPromptClient(base_url="https://example.test", api_key="test-key")
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def fetch(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return PromptHandle(client_prompt())
+
+    client._fetch_prompt = fetch
+    try:
+        cancelled_caller = asyncio.create_task(client.get_prompt("support prompt"))
+        await started.wait()
+        surviving_caller = asyncio.create_task(client.get_prompt("support prompt"))
+
+        cancelled_caller.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled_caller
+
+        release.set()
+        handle = await surviving_caller
+    finally:
+        await client.close()
+
+    assert calls == 1
+    assert handle.version == 123
+
+
+def client_prompt():
+    from neatlogs.prompt.client import _normalize_prompt_object
+
+    return _normalize_prompt_object(PROMPT)

--- a/tests/unit/test_prompt_client_fetch.py
+++ b/tests/unit/test_prompt_client_fetch.py
@@ -6,7 +6,13 @@ from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
-from neatlogs.prompt.client import AsyncPromptClient, PromptClient, PromptHandle
+from neatlogs.prompt.client import (
+    AsyncPromptClient,
+    PromptApiError,
+    PromptClient,
+    PromptHandle,
+    PromptNotFoundError,
+)
 
 PROMPT = {
     "id": "00000000-0000-4000-8000-000000000001",
@@ -57,6 +63,29 @@ async def test_async_fetch_uses_one_exact_endpoint(version, expected_params):
         path="/api/v1/prompts/support%20prompt/fetch",
         params=expected_params,
     )
+
+
+@pytest.mark.parametrize("version", [123, None])
+def test_sync_exact_fetch_preserves_not_found_error(version):
+    client = PromptClient(base_url="https://example.test", api_key="test-key")
+    client._request_json = Mock(side_effect=PromptApiError("GET failed (404)", status_code=404))
+
+    with pytest.raises(PromptNotFoundError, match="not found"):
+        client._fetch_prompt("support prompt", version=version)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("version", [123, None])
+async def test_async_exact_fetch_preserves_not_found_error(version):
+    client = AsyncPromptClient(base_url="https://example.test", api_key="test-key")
+    client._request_json = AsyncMock(
+        side_effect=PromptApiError("GET failed (404)", status_code=404)
+    )
+    try:
+        with pytest.raises(PromptNotFoundError, match="not found"):
+            await client._fetch_prompt("support prompt", version=version)
+    finally:
+        await client.close()
 
 
 def test_sync_cold_cache_miss_is_coalesced():


### PR DESCRIPTION
## Problem

The Python SDK resolved latest and exact managed-prompt versions by listing only the first 100 history rows. Concurrent cold-cache callers also performed duplicate HTTP requests for the same prompt key.

## What changed

- Uses the exact backend prompt endpoint for label, version, and latest selectors.
- Uses the same exact lookup before update-label, delete, and remove-tag mutations instead of listing prompt history.
- Coalesces concurrent synchronous cold misses per cache key.
- Coalesces asynchronous cold misses into one shielded task so cancelling one caller does not cancel the shared fetch.
- Propagates one shared fetch failure to every waiting synchronous caller and clears the flight for a later retry.

## Resulting behavior

Prompt-history size no longer affects correctness. A burst of callers asking for the same uncached prompt produces one backend request instead of one request per caller.

## Contract and rollout notes

- No public Python method signature changed.
- No migration, data rewrite, deployment, or live database query.
- Requires the companion backend exact-selector route to be released first.

## Test plan

- Complete SDK unit suite with the OpenAI extra: 388 passed, 1 skipped.
- Focused exact-fetch and coalescing suite: 9 passed.
- `black --check`
- `isort --check-only`
- `python -m compileall -q neatlogs`
- `git diff --check`

## Tracking

- [Linear NL-1728](https://linear.app/neatlogs/issue/NL-1728/phase-6-frontend-and-ai-service-query-review)
- [Living Phase 6 status](https://app.notion.com/p/3c230dad43af8118a78fd29896c44ffd)

## Mandatory self-review update — 2 September 2026

Both required review workflows were applied to the exact SDK diff. The review found that switching latest/version resolution to the exact endpoint changed missing-prompt failures from the exported `PromptNotFoundError` to generic `PromptApiError`, and that keeping the new concurrency state inside the already-large client would leave it at the 1,000-line boundary. Commit `e0d4f0f` preserves `PromptNotFoundError` for exact 404s and moves synchronous/asynchronous single-flight ownership into a focused private module; `client.py` is 987 lines.

Final verification: 13 focused exact-fetch/single-flight tests passed; the full SDK suite passed 392 tests with 1 skip; Black, isort, compileall, and diff checks passed. No API signature, migration, deployment, or live backend/database operation was performed.
