### PR TITLE
test: verify published Python SDK end to end

### DIFF
--- a/.github/workflows/packaged-release-e2e.yml
+++ b/.github/workflows/packaged-release-e2e.yml
@@ -78,6 +78,7 @@ jobs:
           fixture="$RUNNER_TEMP/wizard-python-fixture"
           cp -R tests/e2e/wizard_seed "$fixture"
           python -m venv "$fixture/.venv"
+          cd "$fixture"
           npx --yes @neatlogs/wizard@0.1.7 \
             --install-dir "$fixture" \
             --endpoint "$NEATLOGS_ENDPOINT" \

--- a/.github/workflows/packaged-release-e2e.yml
+++ b/.github/workflows/packaged-release-e2e.yml
@@ -54,12 +54,29 @@ jobs:
             --expected "$EVIDENCE_DIR/expected.json" \
             --output "$EVIDENCE_DIR/readback-summary.json"
 
+      - name: Verify published Wizard delegates to the Python package
+        shell: bash
+        run: |
+          set -euo pipefail
+          ln -s "$RUNNER_TEMP/neatlogs-packaged-e2e" .venv
+          npx --yes @neatlogs/wizard@0.1.7 doctor \
+            --install-dir "$GITHUB_WORKSPACE" \
+            --local \
+            --json \
+            > "$EVIDENCE_DIR/wizard-doctor-local.log"
+          npx --yes @neatlogs/wizard@0.1.7 doctor \
+            --install-dir "$GITHUB_WORKSPACE" \
+            --probe \
+            --endpoint "$NEATLOGS_ENDPOINT" \
+            --json \
+            > "$EVIDENCE_DIR/wizard-doctor-probe.log"
+
       - name: Publish sanitized evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: python-packaged-release-e2e-${{ github.sha }}
-          path: ${{ env.EVIDENCE_DIR }}/*.json
+          path: ${{ env.EVIDENCE_DIR }}/*
           include-hidden-files: true
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/packaged-release-e2e.yml
+++ b/.github/workflows/packaged-release-e2e.yml
@@ -71,6 +71,27 @@ jobs:
             --json \
             > "$EVIDENCE_DIR/wizard-doctor-probe.log"
 
+      - name: Instrument and verify a clean Python app with the published Wizard
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture="$RUNNER_TEMP/wizard-python-fixture"
+          cp -R tests/e2e/wizard_seed "$fixture"
+          python -m venv "$fixture/.venv"
+          npx --yes @neatlogs/wizard@0.1.7 \
+            --install-dir "$fixture" \
+            --endpoint "$NEATLOGS_ENDPOINT" \
+            --ci \
+            --approve-commands \
+            > "$EVIDENCE_DIR/wizard-instrumentation.log"
+          "$fixture/.venv/bin/python" -m neatlogs doctor --local --json \
+            > "$EVIDENCE_DIR/wizard-instrumented-doctor.json"
+          if rg -lF "$NEATLOGS_API_KEY" "$fixture" --glob '!**/.venv/**'; then
+            echo 'Wizard persisted the project credential' >&2
+            exit 1
+          fi
+          cp "$fixture/main.py" "$EVIDENCE_DIR/wizard-instrumented-main.py"
+
       - name: Publish sanitized evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/packaged-release-e2e.yml
+++ b/.github/workflows/packaged-release-e2e.yml
@@ -60,5 +60,6 @@ jobs:
         with:
           name: python-packaged-release-e2e-${{ github.sha }}
           path: ${{ env.EVIDENCE_DIR }}/*.json
+          include-hidden-files: true
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/packaged-release-e2e.yml
+++ b/.github/workflows/packaged-release-e2e.yml
@@ -1,6 +1,7 @@
 name: Packaged Python release E2E
 
 on:
+  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/packaged-release-e2e.yml
+++ b/.github/workflows/packaged-release-e2e.yml
@@ -1,0 +1,63 @@
+name: Packaged Python release E2E
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  packaged-release-e2e:
+    name: PyPI wheel to exact finalized trace
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      EVIDENCE_DIR: ${{ github.workspace }}/.packaged-e2e-evidence
+      NEATLOGS_API_KEY: ${{ secrets.NEATLOGS_DEV_API_KEY }}
+      NEATLOGS_ENDPOINT: ${{ vars.NEATLOGS_DEV_ENDPOINT }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install the exact public wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${NEATLOGS_API_KEY:-}"
+          test -n "${NEATLOGS_ENDPOINT:-}"
+          python -m venv "$RUNNER_TEMP/neatlogs-packaged-e2e"
+          "$RUNNER_TEMP/neatlogs-packaged-e2e/bin/python" -m pip install --no-cache-dir \
+            "neatlogs==1.4.21"
+          test "$("$RUNNER_TEMP/neatlogs-packaged-e2e/bin/python" -c \
+            'import importlib.metadata as m; print(m.version("neatlogs"))')" = "1.4.21"
+
+      - name: Run the normal user workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$EVIDENCE_DIR"
+          "$RUNNER_TEMP/neatlogs-packaged-e2e/bin/python" \
+            tests/e2e/packaged_release_workflow.py \
+            --output "$EVIDENCE_DIR/expected.json" \
+            > "$EVIDENCE_DIR/workflow-summary.json"
+
+      - name: Verify exact finalized readback
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$RUNNER_TEMP/neatlogs-packaged-e2e/bin/python" \
+            tests/e2e/verify_packaged_release_readback.py \
+            --expected "$EVIDENCE_DIR/expected.json" \
+            --output "$EVIDENCE_DIR/readback-summary.json"
+
+      - name: Publish sanitized evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-packaged-release-e2e-${{ github.sha }}
+          path: ${{ env.EVIDENCE_DIR }}/*.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/tests/e2e/packaged_release_workflow.py
+++ b/tests/e2e/packaged_release_workflow.py
@@ -80,6 +80,7 @@ def main() -> int:
                 expected.append(
                     {
                         "name": f"{prefix}.llm",
+                        "display_name": "e2e-deterministic-model",
                         "kind": "llm",
                         "span_id": llm_id,
                         "parent": agent_id,

--- a/tests/e2e/packaged_release_workflow.py
+++ b/tests/e2e/packaged_release_workflow.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Emit a deterministic user workflow through the installed NeatLogs package."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+from pathlib import Path
+from typing import Any
+
+from opentelemetry.trace import Status, StatusCode
+
+import neatlogs
+
+
+def _identity(span: Any) -> tuple[str, str]:
+    context = span.get_span_context()
+    return f"{context.trace_id:032x}", f"{context.span_id:016x}"
+
+
+def _finish(span: Any, input_value: Any, output_value: Any) -> None:
+    span.set_attribute("neatlogs.internal", False)
+    span.set_attribute("input.value", json.dumps(input_value, sort_keys=True))
+    span.set_attribute("output.value", json.dumps(output_value, sort_keys=True))
+    span.set_status(Status(StatusCode.OK))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--local", action="store_true")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("NEATLOGS_API_KEY")
+    endpoint = os.environ.get("NEATLOGS_ENDPOINT", "https://ingest.neatlogs.com")
+    if not api_key and not args.local:
+        raise SystemExit("NEATLOGS_API_KEY is required")
+
+    run_id = os.environ.get("NEATLOGS_E2E_RUN_ID") or secrets.token_hex(8)
+    prefix = f"python.packaged-e2e.{run_id}"
+    expected: list[dict[str, str | None]] = []
+
+    neatlogs.init(
+        api_key=api_key or "local-e2e-placeholder",
+        endpoint=endpoint,
+        workflow_name=prefix,
+        instrumentations=[],
+        batch_size=2,
+        flush_interval=0.25,
+        disable_export=args.local,
+        register_shutdown_handlers=False,
+    )
+
+    with neatlogs.trace(
+        name=f"{prefix}.root",
+        kind="WORKFLOW",
+        session_id=f"session-{run_id}",
+        end_user_id=f"user-{run_id}",
+        **{"neatlogs.verification.marker": run_id},
+    ) as root:
+        trace_id, root_id = _identity(root)
+        expected.append(
+            {"name": f"{prefix}.root", "kind": "workflow", "span_id": root_id, "parent": None}
+        )
+
+        with neatlogs.trace(name=f"{prefix}.agent", kind="AGENT") as agent:
+            _, agent_id = _identity(agent)
+            expected.append(
+                {
+                    "name": f"{prefix}.agent",
+                    "kind": "agent_action",
+                    "span_id": agent_id,
+                    "parent": root_id,
+                }
+            )
+            with neatlogs.trace(name=f"{prefix}.llm", kind="LLM") as llm:
+                _, llm_id = _identity(llm)
+                expected.append(
+                    {
+                        "name": f"{prefix}.llm",
+                        "kind": "llm",
+                        "span_id": llm_id,
+                        "parent": agent_id,
+                    }
+                )
+                llm.set_attribute("llm.model_name", "e2e-deterministic-model")
+                llm.set_attribute("neatlogs.llm.token_count.prompt", 13)
+                llm.set_attribute("neatlogs.llm.token_count.completion", 5)
+                llm.set_attribute("neatlogs.llm.token_count.total", 18)
+                _finish(
+                    llm,
+                    {"messages": [{"role": "user", "content": "deterministic launch check"}]},
+                    {"text": "deterministic response"},
+                )
+            _finish(agent, {"task": "answer"}, {"answer": "deterministic response"})
+
+        with neatlogs.trace(name=f"{prefix}.retriever", kind="RETRIEVER") as retriever:
+            _, retriever_id = _identity(retriever)
+            expected.append(
+                {
+                    "name": f"{prefix}.retriever",
+                    "kind": "retriever",
+                    "span_id": retriever_id,
+                    "parent": root_id,
+                }
+            )
+            _finish(retriever, {"query": "launch readiness"}, {"documents": ["fixture-doc"]})
+
+        with neatlogs.trace(name=f"{prefix}.tool", kind="TOOL") as tool:
+            _, tool_id = _identity(tool)
+            expected.append(
+                {
+                    "name": f"{prefix}.tool",
+                    "kind": "tool_call",
+                    "span_id": tool_id,
+                    "parent": root_id,
+                }
+            )
+            _finish(tool, {"value": 2}, {"value": 4})
+
+        _finish(root, {"request": "launch readiness"}, {"status": "ok"})
+
+    try:
+        flushed = neatlogs.flush(timeout_millis=10_000)
+        local = None if args.local else neatlogs.doctor_captured_local_v2(trace_id)
+    finally:
+        neatlogs.shutdown(timeout_millis=10_000, termination_reason="packaged-e2e-complete")
+
+    if not args.local:
+        if local is None or local.get("status") != "pass":
+            raise RuntimeError(f"captured-envelope validation failed: {json.dumps(local)}")
+        if local.get("capture", {}).get("span_count") != len(expected):
+            raise RuntimeError("captured-envelope span count mismatch")
+
+    manifest = {
+        "format_version": "neatlogs.packaged-e2e/v1",
+        "run_id": run_id,
+        "trace_id": trace_id,
+        "expected_span_count": len(expected),
+        "expected_prompt_tokens": 13,
+        "expected_completion_tokens": 5,
+        "expected_total_tokens": 18,
+        "flush_success": bool(flushed),
+        "captured_validation": (
+            {
+                "status": local["status"],
+                "span_count": local["capture"]["span_count"],
+                "semantic_digest": local["capture"]["semantic_digest"],
+            }
+            if local is not None
+            else None
+        ),
+        "spans": expected,
+    }
+    args.output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    print(json.dumps({"trace_id": trace_id, "span_count": len(expected), "flush": bool(flushed)}))
+    return 0 if flushed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/packaged_release_workflow.py
+++ b/tests/e2e/packaged_release_workflow.py
@@ -124,15 +124,8 @@ def main() -> int:
 
     try:
         flushed = neatlogs.flush(timeout_millis=10_000)
-        local = None if args.local else neatlogs.doctor_captured_local_v2(trace_id)
     finally:
         neatlogs.shutdown(timeout_millis=10_000, termination_reason="packaged-e2e-complete")
-
-    if not args.local:
-        if local is None or local.get("status") != "pass":
-            raise RuntimeError(f"captured-envelope validation failed: {json.dumps(local)}")
-        if local.get("capture", {}).get("span_count") != len(expected):
-            raise RuntimeError("captured-envelope span count mismatch")
 
     manifest = {
         "format_version": "neatlogs.packaged-e2e/v1",
@@ -143,15 +136,6 @@ def main() -> int:
         "expected_completion_tokens": 5,
         "expected_total_tokens": 18,
         "flush_success": bool(flushed),
-        "captured_validation": (
-            {
-                "status": local["status"],
-                "span_count": local["capture"]["span_count"],
-                "semantic_digest": local["capture"]["semantic_digest"],
-            }
-            if local is not None
-            else None
-        ),
         "spans": expected,
     }
     args.output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")

--- a/tests/e2e/verify_packaged_release_readback.py
+++ b/tests/e2e/verify_packaged_release_readback.py
@@ -61,6 +61,9 @@ def main() -> int:
         time.sleep(1)
 
     _require(payload is not None, "timed out waiting for exact trace")
+    args.output.with_name("readback-raw.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    )
     _require(payload.get("_id") == trace_id, "readback trace ID mismatch")
     _require(str(payload.get("status") or "").lower() == "success", "trace did not finalize")
 
@@ -75,7 +78,10 @@ def main() -> int:
 
     for span_id, wanted in expected_by_id.items():
         got = by_id[span_id]
-        _require(got["name"] == wanted["name"], f"name mismatch for {span_id}")
+        _require(
+            got["name"] == wanted["name"],
+            f"name mismatch for {span_id}: expected {wanted['name']!r}, got {got['name']!r}",
+        )
         _require(got["kind"] == wanted["kind"], f"kind mismatch for {wanted['name']}")
         _require(got["parent"] == wanted["parent"], f"parent mismatch for {wanted['name']}")
         _require("input_value" in got["data"], f"missing input for {wanted['name']}")

--- a/tests/e2e/verify_packaged_release_readback.py
+++ b/tests/e2e/verify_packaged_release_readback.py
@@ -78,9 +78,10 @@ def main() -> int:
 
     for span_id, wanted in expected_by_id.items():
         got = by_id[span_id]
+        expected_display_name = wanted.get("display_name", wanted["name"])
         _require(
-            got["name"] == wanted["name"],
-            f"name mismatch for {span_id}: expected {wanted['name']!r}, got {got['name']!r}",
+            got["name"] == expected_display_name,
+            f"name mismatch for {span_id}: expected {expected_display_name!r}, got {got['name']!r}",
         )
         _require(got["kind"] == wanted["kind"], f"kind mismatch for {wanted['name']}")
         _require(got["parent"] == wanted["parent"], f"parent mismatch for {wanted['name']}")

--- a/tests/e2e/verify_packaged_release_readback.py
+++ b/tests/e2e/verify_packaged_release_readback.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Poll and validate one exact packaged-release trace through the product API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import requests
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _normalized_span(span: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": str(span.get("node_name") or span.get("span_name") or ""),
+        "kind": str(span.get("node_type") or span.get("span_type") or "").lower(),
+        "span_id": span.get("span_id"),
+        "parent": span.get("parent_span_id") or None,
+        "data": span.get("data") if isinstance(span.get("data"), dict) else {},
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--timeout", type=float, default=90.0)
+    args = parser.parse_args()
+
+    api_key = os.environ.get("NEATLOGS_API_KEY")
+    endpoint = os.environ.get("NEATLOGS_ENDPOINT")
+    if not api_key or not endpoint:
+        raise SystemExit("NEATLOGS_API_KEY and NEATLOGS_ENDPOINT are required")
+
+    expected = json.loads(args.expected.read_text())
+    trace_id = expected["trace_id"]
+    url = f"{endpoint.rstrip('/')}/api/traces/v3/{quote(trace_id, safe='')}"
+    deadline = time.monotonic() + args.timeout
+    payload: dict[str, Any] | None = None
+
+    while time.monotonic() < deadline:
+        response = requests.get(url, headers={"x-api-key": api_key}, timeout=5)
+        if response.status_code in {401, 403}:
+            response.raise_for_status()
+        if response.ok and response.status_code != 202:
+            value = response.json()
+            _require(isinstance(value, dict), "trace readback must be an object")
+            payload = value
+            break
+        if response.status_code not in {202, 404}:
+            response.raise_for_status()
+        time.sleep(1)
+
+    _require(payload is not None, "timed out waiting for exact trace")
+    _require(payload.get("_id") == trace_id, "readback trace ID mismatch")
+    _require(str(payload.get("status") or "").lower() == "success", "trace did not finalize")
+
+    raw_spans = [item for item in payload.get("spans", []) if isinstance(item, dict)]
+    actual = [_normalized_span(item) for item in raw_spans]
+    by_id = {item["span_id"]: item for item in actual}
+    expected_by_id = {item["span_id"]: item for item in expected["spans"]}
+
+    _require(len(by_id) == len(actual), "duplicate span IDs")
+    _require(set(by_id) == set(expected_by_id), "missing or unexpected span IDs")
+    _require(payload.get("spanCount") == expected["expected_span_count"], "span count mismatch")
+
+    for span_id, wanted in expected_by_id.items():
+        got = by_id[span_id]
+        _require(got["name"] == wanted["name"], f"name mismatch for {span_id}")
+        _require(got["kind"] == wanted["kind"], f"kind mismatch for {wanted['name']}")
+        _require(got["parent"] == wanted["parent"], f"parent mismatch for {wanted['name']}")
+        _require("input_value" in got["data"], f"missing input for {wanted['name']}")
+        _require("output_value" in got["data"], f"missing output for {wanted['name']}")
+
+    roots = [item for item in actual if item["parent"] is None]
+    _require(len(roots) == 1, "expected one meaningful root")
+    _require(payload.get("promptTokens") == expected["expected_prompt_tokens"], "prompt tokens")
+    _require(
+        payload.get("completionTokens") == expected["expected_completion_tokens"],
+        "completion tokens",
+    )
+    _require(payload.get("totalTokensUsed") == expected["expected_total_tokens"], "total tokens")
+
+    sanitized = {
+        "format_version": expected["format_version"],
+        "status": "pass",
+        "trace_id": trace_id,
+        "readback_status": payload.get("status"),
+        "span_count": len(actual),
+        "root_count": len(roots),
+        "prompt_tokens": payload.get("promptTokens"),
+        "completion_tokens": payload.get("completionTokens"),
+        "total_tokens": payload.get("totalTokensUsed"),
+        "names": sorted(item["name"] for item in actual),
+    }
+    args.output.write_text(json.dumps(sanitized, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(sanitized, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/wizard_seed/README.md
+++ b/tests/e2e/wizard_seed/README.md
@@ -1,0 +1,7 @@
+# Wizard Python E2E seed
+
+Run the representative user workflow with:
+
+```bash
+python main.py
+```

--- a/tests/e2e/wizard_seed/main.py
+++ b/tests/e2e/wizard_seed/main.py
@@ -1,0 +1,15 @@
+def retrieve_context(query: str) -> list[str]:
+    return [f"documentation for {query}"]
+
+
+def answer_question(query: str, documents: list[str]) -> str:
+    return f"{query}: {documents[0]}"
+
+
+def run_support_agent(query: str) -> str:
+    documents = retrieve_context(query)
+    return answer_question(query, documents)
+
+
+if __name__ == "__main__":
+    print(run_support_agent("launch readiness"))

--- a/tests/e2e/wizard_seed/pyproject.toml
+++ b/tests/e2e/wizard_seed/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "neatlogs-wizard-e2e-seed"
+version = "0.0.0"
+requires-python = ">=3.10"
+dependencies = []


### PR DESCRIPTION
Adds a deterministic packaged-release workflow that installs the exact public Python SDK wheel, emits a normal user trace through the deployed dev backend, and verifies the exact finalized trace ID, hierarchy, I/O, and numeric tokens. This draft exists to run the secret-backed E2E before requesting review.