### PR TITLE
Enable explicit HTTP client instrumentation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -251,7 +251,7 @@ Pass keys to `instrumentations` in `neatlogs.init()`. Install extras when noted.
 | OpenSearch | `opensearch` | Auto-instrumented when installed |
 | Elasticsearch | `elasticsearch` | Auto-instrumented when installed |
 | Marqo | `marqo` | Auto-instrumented when installed |
-| HTTP clients | `requests`, `httpx`, `urllib3`, `aiohttp` | Auto-instrumented when installed |
+| HTTP clients | `requests`, `httpx`, `urllib3`, `aiohttp` | Opt in with the matching `instrumentations` key |
 
 ---
 

--- a/neatlogs/core/attribute_processor.py
+++ b/neatlogs/core/attribute_processor.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 from opentelemetry import metrics
 from opentelemetry.sdk.trace import ReadableSpan
@@ -140,6 +141,10 @@ class UnifiedAttributeProcessor:
             self.logger.warning(f"Failed to enrich invocation parameters: {e}")
 
         unified = self._apply_namespace_mapping(attrs)
+        if unified.get("neatlogs.span.kind") == "http":
+            for key in ("input.value", "input.mime_type", "output.value", "output.mime_type"):
+                if key in attrs:
+                    unified[key] = attrs[key]
         self._add_intermediate_steps(unified)
 
         # 🔥 CRITICAL: Filter out massive embedding vectors before export
@@ -156,6 +161,7 @@ class UnifiedAttributeProcessor:
     def _normalize_conventions(self, span: ReadableSpan, attrs: Dict[str, Any]) -> Dict[str, Any]:
         if span.kind == SpanKind.CLIENT and self._looks_like_http(attrs):
             attrs["openinference.span.kind"] = "HTTP"
+            self._add_http_canonical_io(attrs)
 
         if "openinference.span.kind" not in attrs and any(
             k.startswith("crewai.crew.") for k in attrs.keys()
@@ -809,10 +815,108 @@ class UnifiedAttributeProcessor:
         return all_steps
 
     def _looks_like_http(self, attrs: Dict[str, Any]) -> bool:
-        for k in ("http.method", "http.url", "http.status_code", "http.route"):
+        for k in (
+            "http.method",
+            "http.request.method",
+            "http.url",
+            "url.full",
+            "http.status_code",
+            "http.response.status_code",
+            "http.route",
+        ):
             if k in attrs:
                 return True
         return any(key.startswith("http.") for key in attrs.keys())
+
+    def _add_http_canonical_io(self, attrs: Dict[str, Any]) -> None:
+        self.sanitize_http_attributes(attrs)
+        method = attrs.get("http.request.method") or attrs.get("http.method")
+        sanitized_url = self._sanitized_http_url(attrs)
+        if method and sanitized_url:
+            attrs["input.value"] = json.dumps(
+                {"method": str(method).upper(), "url": sanitized_url},
+                separators=(",", ":"),
+            )
+            attrs["input.mime_type"] = "application/json"
+        else:
+            attrs.pop("input.value", None)
+            attrs.pop("input.mime_type", None)
+
+        status = attrs.get("http.response.status_code")
+        if status is None:
+            status = attrs.get("http.status_code")
+        if status is not None:
+            attrs["output.value"] = json.dumps({"status": status}, separators=(",", ":"))
+            attrs["output.mime_type"] = "application/json"
+        else:
+            attrs.pop("output.value", None)
+            attrs.pop("output.mime_type", None)
+
+    def _sanitized_http_url(self, attrs: Dict[str, Any]) -> Optional[str]:
+        raw_url = attrs.get("url.full") or attrs.get("http.url")
+        if raw_url:
+            return self._sanitize_url(str(raw_url))
+
+        scheme = attrs.get("url.scheme") or attrs.get("http.scheme") or "http"
+        host = attrs.get("server.address") or attrs.get("net.peer.name") or attrs.get("http.host")
+        if not host:
+            return None
+        host = str(host).split("@")[-1]
+        if host.startswith("[") and "]" in host:
+            host = host[1 : host.index("]")]
+        elif host.count(":") == 1:
+            candidate, candidate_port = host.rsplit(":", 1)
+            if candidate_port.isdigit():
+                host = candidate
+        port = attrs.get("server.port") or attrs.get("net.peer.port")
+        netloc = f"[{host}]" if ":" in host else host
+        if port:
+            netloc = f"{netloc}:{port}"
+        path = attrs.get("url.path") or attrs.get("http.target") or attrs.get("http.route") or ""
+        path = self._sanitize_path(str(path))
+        return self._sanitize_url(urlunsplit((str(scheme), netloc, path or "/", "", "")))
+
+    def _sanitize_url(self, raw_url: str) -> str:
+        try:
+            parts = urlsplit(raw_url)
+        except ValueError:
+            return "/"
+        host = parts.hostname or ""
+        netloc = host
+        if ":" in host and not host.startswith("["):
+            netloc = f"[{host}]"
+        try:
+            port = parts.port
+        except ValueError:
+            port = None
+        if port is not None:
+            netloc = f"{netloc}:{port}"
+        return urlunsplit((parts.scheme, netloc, parts.path or "/", "", ""))
+
+    def _sanitize_path(self, raw_path: str) -> str:
+        try:
+            parsed = urlsplit(raw_path)
+        except ValueError:
+            return "/"
+        if parsed.scheme or parsed.netloc:
+            return parsed.path or "/"
+        return raw_path.split("?", 1)[0].split("#", 1)[0] or "/"
+
+    def sanitize_http_attributes(self, attrs: Dict[str, Any]) -> None:
+        for key in ("http.url", "url.full"):
+            if attrs.get(key):
+                attrs[key] = self._sanitize_url(str(attrs[key]))
+        for key in ("http.target", "url.path", "http.route"):
+            if attrs.get(key):
+                attrs[key] = self._sanitize_path(str(attrs[key]))
+
+        for key in list(attrs):
+            lowered = key.lower()
+            is_header = "header" in lowered
+            is_body_payload = "body" in lowered and not lowered.endswith(".body.size")
+            is_url_component = lowered in {"url.query", "url.fragment"}
+            if is_header or is_body_payload or is_url_component:
+                attrs.pop(key, None)
 
     def _extract_operational_metrics(
         self, span: ReadableSpan, attrs: Dict[str, Any]

--- a/neatlogs/core/span_processor.py
+++ b/neatlogs/core/span_processor.py
@@ -14,6 +14,7 @@ from urllib.parse import unquote
 from opentelemetry import context as context_api
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+from opentelemetry.trace import SpanKind
 
 from .attribute_processor import UnifiedAttributeProcessor
 from .logger import get_logger
@@ -408,7 +409,7 @@ class NeatlogsSpanProcessor(SpanProcessor):
                 and not self._raw_log_file_handle.closed
             ):
                 try:
-                    self._raw_log_file_handle.write(span.to_json() + "\n")
+                    self._raw_log_file_handle.write(self._safe_raw_span_json(span) + "\n")
                     self._raw_log_file_handle.flush()
                 except Exception as e:
                     logger.warning(f"Failed to write span to raw log file: {e}")
@@ -555,6 +556,20 @@ class NeatlogsSpanProcessor(SpanProcessor):
                                 isinstance(_i, (str, int, float, bool)) for _i in _v
                             ):
                                 span_attrs[_k] = list(_v)
+                        if final_attrs.get("neatlogs.span.kind") == "http":
+                            self.unified_processor.sanitize_http_attributes(span_attrs)
+                            for key in (
+                                "input.value",
+                                "input.mime_type",
+                                "output.value",
+                                "output.mime_type",
+                                "neatlogs.http.input",
+                                "neatlogs.http.input_mime_type",
+                                "neatlogs.http.output",
+                                "neatlogs.http.output_mime_type",
+                            ):
+                                if key not in final_attrs:
+                                    span_attrs.pop(key, None)
                     finally:
                         if was_immutable:
                             span_attrs._immutable = True
@@ -748,7 +763,9 @@ class NeatlogsSpanProcessor(SpanProcessor):
         normalization, so it reads the raw input.value/output.value keys.
         """
         try:
-            attrs = span.attributes or {}
+            attrs = dict(span.attributes or {})
+            if span.kind == SpanKind.CLIENT and self.unified_processor._looks_like_http(attrs):
+                self.unified_processor._add_http_canonical_io(attrs)
 
             def _nonempty(key):
                 v = attrs.get(key)
@@ -820,6 +837,17 @@ class NeatlogsSpanProcessor(SpanProcessor):
         except Exception as exc:
             if self.debug:
                 logger.debug(f"[SpanProcessor] Root I/O backfill skipped: {exc}")
+
+    def _safe_raw_span_json(self, span: ReadableSpan) -> str:
+        payload = json.loads(span.to_json())
+        attrs = payload.get("attributes") or {}
+        if span.kind == SpanKind.CLIENT and self.unified_processor._looks_like_http(attrs):
+            self.unified_processor._add_http_canonical_io(attrs)
+            for event in payload.get("events") or ():
+                event_attrs = event.get("attributes") if isinstance(event, dict) else None
+                if isinstance(event_attrs, dict):
+                    self.unified_processor.sanitize_http_attributes(event_attrs)
+        return json.dumps(payload)
 
     @staticmethod
     def _serialize_span_events(span: ReadableSpan) -> List[Dict[str, Any]]:

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -716,7 +716,6 @@ def init(
     _instrumentation_manager = manager
 
     manager.instrument_threading()
-    manager.instrument_http()
 
     if instrumentations:
         manager.instrument(libraries=instrumentations)

--- a/neatlogs/instrumentation/manager.py
+++ b/neatlogs/instrumentation/manager.py
@@ -11,11 +11,12 @@ from typing import List, Optional, Set
 from opentelemetry.instrumentation.threading import ThreadingInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 
-from .http_context_propagation import patch_http_context_propagation
 from .openinference_isolation import provider_for_openinference
 from .registry import INSTRUMENTATION_REGISTRY, get_libraries_by_tag
 
 logger = logging.getLogger(__name__)
+
+_HTTP_LIBRARIES = frozenset({"requests", "httpx", "urllib3", "aiohttp"})
 
 # Holds the raw, pre-tokenization text passed to LangChain embedding wrappers
 # (OpenAIEmbeddings.embed_documents/embed_query). LangChain tokenizes text into
@@ -47,47 +48,6 @@ class InstrumentationManager:
         except Exception as e:
             if self.debug:
                 logger.warning(f"⚠️  Failed to instrument threading: {e}")
-
-    def instrument_http(self) -> None:
-        """
-        Instrument HTTP libraries for context propagation.
-        Uses standard opentelemetry-instrumentation-* contrib packages (not AI-specific).
-
-        DISABLED: HTTP auto-instrumentation is turned off. It emitted a large volume
-        of infra HTTP spans (POST/GET/HEAD/DELETE to LLM/vector/telemetry endpoints)
-        that add no agentic value and pollute the trace. In-process parent/child
-        linkage for frameworks (CrewAI, LangChain, ...) comes from the OTel context
-        (contextvars), NOT HTTP headers, so disabling this does not fragment traces.
-        To re-enable, delete the early return below.
-        """
-        if self.debug:
-            logger.info("⏭️  HTTP instrumentation disabled (no infra HTTP spans)")
-        return
-
-        http_libs = ["requests", "httpx", "urllib3", "aiohttp"]
-
-        for lib in http_libs:
-            if not self._is_library_installed(lib):
-                if self.debug:
-                    logger.info(f"⏭️  Skipped HTTP: {lib} (not installed)")
-                continue
-
-            try:
-                self._instrument_library(lib, convention="openllmetry")
-                self.instrumented.add(lib)
-                if self.debug:
-                    logger.info(f"✅ Instrumented HTTP: {lib}")
-            except Exception as e:
-                if self.debug:
-                    logger.warning(f"⚠️  Failed to instrument {lib}: {e}")
-
-        try:
-            patch_http_context_propagation()
-            if self.debug:
-                logger.info("✅ Patched HTTP context propagation (best-effort)")
-        except Exception as e:
-            if self.debug:
-                logger.warning(f"⚠️  Failed to patch HTTP context propagation: {e}")
 
     def instrument_mcp(self) -> None:
         """
@@ -155,6 +115,17 @@ class InstrumentationManager:
                 logger.warning(f"⚠️  Unknown library: {library}")
             return
 
+        if library in _HTTP_LIBRARIES:
+            try:
+                self._instrument_library(library, convention="openllmetry")
+                self.instrumented.add(library)
+                if self.debug:
+                    logger.info(f"✅ {library} (OpenTelemetry HTTP client)")
+            except Exception as e:
+                if self.debug:
+                    logger.warning(f"⚠️  {library} (OpenTelemetry HTTP client): {e}")
+            return
+
         # CrewAI: neatlogs' own class-level hooks (crewai.py) build the full
         # crew→task→agent→llm→tool tree as a single neatlogs-owned trace, so bare
         # crews under instrumentations=["crewai"] are covered without any wrap()
@@ -212,7 +183,7 @@ class InstrumentationManager:
             instrumentor_class_name = self._get_instrumentor_class_name(library, convention)
             instrumentor_class = getattr(module, instrumentor_class_name)
 
-            is_http_lib = library in ["requests", "httpx", "urllib3", "aiohttp"]
+            is_http_lib = library in _HTTP_LIBRARIES
             tracer_provider = (
                 provider_for_openinference(self.provider)
                 if convention == "openinference"
@@ -258,7 +229,7 @@ class InstrumentationManager:
             raise Exception(f"Failed to instrument {library} with {convention}: {e}")
 
     def uninstrument_all(self) -> None:
-        """Reverse instrument()/instrument_http()/instrument_threading().
+        """Reverse instrument() and instrument_threading().
 
         OpenInference/OpenLLMetry instrumentors are BaseInstrumentor singletons, so
         re-resolving the class and calling .uninstrument() tears down the same global

--- a/tests/unit/test_http_instrumentation_activation.py
+++ b/tests/unit/test_http_instrumentation_activation.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+
+from neatlogs.instrumentation.manager import InstrumentationManager
+
+
+@pytest.mark.parametrize(
+    ("library", "module_name", "class_name"),
+    [
+        ("requests", "opentelemetry.instrumentation.requests", "RequestsInstrumentor"),
+        ("httpx", "opentelemetry.instrumentation.httpx", "HTTPXClientInstrumentor"),
+        ("urllib3", "opentelemetry.instrumentation.urllib3", "URLLib3Instrumentor"),
+        ("aiohttp", "opentelemetry.instrumentation.aiohttp_client", "AioHttpClientInstrumentor"),
+    ],
+)
+def test_explicit_http_key_activates_otel_instrumentor(
+    monkeypatch, library, module_name, class_name
+):
+    calls = []
+
+    class FakeInstrumentor:
+        def instrument(self, **kwargs):
+            calls.append(kwargs)
+
+    manager = InstrumentationManager(
+        TracerProvider(), excluded_urls="https://dev-cloud.neatlogs.com"
+    )
+    monkeypatch.setattr(manager, "_is_library_installed", lambda name: name == library)
+    monkeypatch.setattr(
+        "neatlogs.instrumentation.manager.importlib.import_module",
+        lambda name: (
+            SimpleNamespace(**{class_name: FakeInstrumentor}) if name == module_name else None
+        ),
+    )
+
+    manager.instrument(libraries=[library])
+
+    assert manager.instrumented == {library}
+    assert calls == [
+        {
+            "tracer_provider": manager.provider,
+            "excluded_urls": "https://dev-cloud.neatlogs.com",
+        }
+    ]
+
+
+def test_empty_instrumentation_list_does_not_activate_any_client(monkeypatch):
+    manager = InstrumentationManager(TracerProvider())
+    monkeypatch.setattr(
+        manager,
+        "_instrument_library",
+        lambda *args, **kwargs: pytest.fail("HTTP clients must remain opt-in"),
+    )
+
+    manager.instrument(libraries=[])
+
+    assert manager.instrumented == set()

--- a/tests/unit/test_http_instrumentation_e2e.py
+++ b/tests/unit/test_http_instrumentation_e2e.py
@@ -1,0 +1,98 @@
+import asyncio
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import aiohttp
+import httpx
+import pytest
+import requests
+import urllib3
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from neatlogs.instrumentation.manager import InstrumentationManager
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = b"ok"
+        self.send_response(200)
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def local_http_url():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/health"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+async def _aiohttp_get(url):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            assert await response.text() == "ok"
+
+
+def _request(library, url):
+    if library == "requests":
+        assert requests.get(url, timeout=2).text == "ok"
+    elif library == "httpx":
+        assert httpx.get(url, timeout=2).text == "ok"
+    elif library == "urllib3":
+        assert urllib3.PoolManager().request("GET", url, timeout=2).data == b"ok"
+    else:
+        asyncio.run(_aiohttp_get(url))
+
+
+@pytest.mark.parametrize("library", ["requests", "httpx", "urllib3", "aiohttp"])
+def test_explicit_http_instrumentation_emits_one_nested_client_span(library, local_http_url):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    manager = InstrumentationManager(provider, excluded_urls="dev-cloud.neatlogs.com")
+
+    try:
+        manager.instrument(libraries=[library])
+        tracer = provider.get_tracer("neatlogs.http-test")
+        with tracer.start_as_current_span("workflow") as root:
+            _request(library, local_http_url)
+
+        children = [
+            span
+            for span in exporter.get_finished_spans()
+            if span.parent and span.parent.span_id == root.context.span_id
+        ]
+        assert len(children) == 1
+        assert children[0].kind.name == "CLIENT"
+    finally:
+        manager.uninstrument_all()
+        provider.shutdown()
+
+
+def test_empty_instrumentation_list_emits_no_client_span(local_http_url):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    manager = InstrumentationManager(provider)
+
+    try:
+        manager.instrument(libraries=[])
+        with provider.get_tracer("neatlogs.http-test").start_as_current_span("workflow"):
+            assert requests.get(local_http_url, timeout=2).text == "ok"
+
+        assert [span.name for span in exporter.get_finished_spans()] == ["workflow"]
+    finally:
+        manager.uninstrument_all()
+        provider.shutdown()

--- a/tests/unit/test_http_instrumentation_e2e.py
+++ b/tests/unit/test_http_instrumentation_e2e.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
@@ -8,10 +9,24 @@ import pytest
 import requests
 import urllib3
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
 
+import neatlogs
+from neatlogs.core.span_processor import NeatlogsSpanProcessor
 from neatlogs.instrumentation.manager import InstrumentationManager
+
+
+class _SnapshotExporter(SpanExporter):
+    def __init__(self):
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(
+            {"name": span.name, "attributes": dict(span.attributes or {})} for span in spans
+        )
+        return SpanExportResult.SUCCESS
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -79,6 +94,179 @@ def test_explicit_http_instrumentation_emits_one_nested_client_span(library, loc
     finally:
         manager.uninstrument_all()
         provider.shutdown()
+
+
+@pytest.mark.parametrize("library", ["requests", "httpx", "urllib3", "aiohttp"])
+def test_explicit_http_instrumentation_adds_safe_canonical_io_through_sdk_pipeline(
+    library, local_http_url
+):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+
+    neatlogs.init(
+        api_key="unused",
+        disable_export=True,
+        instrumentations=[library],
+        tracer_provider=provider,
+        workflow_name="http-io-regression",
+    )
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    secret_url = (
+        local_http_url.replace("http://", "http://user:pass@")
+        + "?api_key=secret&token=also-secret#fragment"
+    )
+    tracer = provider.get_tracer("app.http-io-regression")
+    with tracer.start_as_current_span("workflow") as root:
+        root.set_attribute("openinference.span.kind", "WORKFLOW")
+        _request(library, secret_url)
+
+    children = [
+        span
+        for span in exporter.get_finished_spans()
+        if span.parent and span.parent.span_id == root.context.span_id
+    ]
+
+    assert len(children) == 1
+    span = children[0]
+    attrs = span.attributes
+    assert attrs["neatlogs.span.kind"] == "http"
+    assert json.loads(attrs["input.value"]) == {
+        "method": "GET",
+        "url": local_http_url,
+    }
+    assert json.loads(attrs["output.value"]) == {"status": 200}
+    assert json.loads(attrs["neatlogs.http.input"]) == {
+        "method": "GET",
+        "url": local_http_url,
+    }
+    assert json.loads(attrs["neatlogs.http.output"]) == {"status": 200}
+
+    serialized_attrs = json.dumps(dict(attrs), default=str)
+    assert "api_key=secret" not in serialized_attrs
+    assert "token=also-secret" not in serialized_attrs
+    assert "user:pass" not in serialized_attrs
+    assert "fragment" not in serialized_attrs
+    assert "Cookie" not in serialized_attrs
+    assert "Authorization" not in serialized_attrs
+
+
+def test_sdk_pipeline_removes_stale_http_payloads_before_later_exporters():
+    provider = TracerProvider()
+    exporter = _SnapshotExporter()
+    neatlogs.init(
+        api_key="unused",
+        disable_export=True,
+        instrumentations=[],
+        tracer_provider=provider,
+        workflow_name="http-export-privacy",
+    )
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    tracer = provider.get_tracer("app.http-export-privacy")
+    with tracer.start_as_current_span("workflow"):
+        with tracer.start_as_current_span(
+            "GET",
+            kind=SpanKind.CLIENT,
+            attributes={
+                "http.request.method": "GET",
+                "url.full": "https://user:pass@example.com/health?token=secret#fragment",
+                "url.query": "token=secret",
+                "http.request.header.authorization": "Bearer secret",
+                "http.request.body": "secret-body",
+                "input.value": "secret-input",
+                "output.value": "secret-output",
+            },
+        ):
+            pass
+
+    attrs = next(span["attributes"] for span in exporter.spans if span["name"] == "GET")
+    assert json.loads(attrs["input.value"]) == {
+        "method": "GET",
+        "url": "https://example.com/health",
+    }
+    assert "output.value" not in attrs
+    serialized = json.dumps(attrs, default=str)
+    for secret in (
+        "user:pass",
+        "token=secret",
+        "Bearer secret",
+        "secret-body",
+        "secret-input",
+        "secret-output",
+        "fragment",
+    ):
+        assert secret not in serialized
+
+
+def test_http_payloads_cannot_leak_through_workflow_root_backfill():
+    provider = TracerProvider()
+    exporter = _SnapshotExporter()
+    processor = NeatlogsSpanProcessor(own_all_spans=True)
+    provider.add_span_processor(processor)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    tracer = provider.get_tracer("app.http-root-privacy")
+    with tracer.start_as_current_span("workflow"):
+        with tracer.start_as_current_span(
+            "GET",
+            kind=SpanKind.CLIENT,
+            attributes={
+                "http.request.method": "GET",
+                "url.full": "https://user:pass@example.com/health?token=secret#fragment",
+                "input.value": "secret-input",
+                "output.value": "secret-output",
+            },
+        ):
+            pass
+
+    root = next(span for span in exporter.spans if span["name"] == "workflow")
+    assert json.loads(root["attributes"]["input.value"]) == {
+        "method": "GET",
+        "url": "https://example.com/health",
+    }
+    assert "output.value" not in root["attributes"]
+    serialized = json.dumps(root, default=str)
+    for secret in ("user:pass", "token=secret", "fragment", "secret-input", "secret-output"):
+        assert secret not in serialized
+
+
+def test_raw_http_debug_log_is_sanitized(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NEATLOGS_LOG_RAW_SPANS", "true")
+    provider = TracerProvider()
+    processor = NeatlogsSpanProcessor(own_all_spans=True)
+    provider.add_span_processor(processor)
+
+    tracer = provider.get_tracer("app.http-raw-log-privacy")
+    with tracer.start_as_current_span(
+        "GET",
+        kind=SpanKind.CLIENT,
+        attributes={
+            "http.request.method": "GET",
+            "url.full": "https://user:pass@example.com/health?token=secret#fragment",
+            "http.request.header.authorization": "Bearer secret",
+            "http.request.body": "secret-body",
+            "input.value": "secret-input",
+            "output.value": "secret-output",
+        },
+    ):
+        pass
+
+    raw_log = (tmp_path / "spans_raw_optimized.log").read_text(encoding="utf-8")
+    assert "https://example.com/health" in raw_log
+    for secret in (
+        "user:pass",
+        "token=secret",
+        "fragment",
+        "Bearer secret",
+        "secret-body",
+        "secret-input",
+        "secret-output",
+    ):
+        assert secret not in raw_log
+
+    provider.shutdown()
 
 
 def test_empty_instrumentation_list_emits_no_client_span(local_http_url):

--- a/tests/unit/test_unified_attribute_processor_pipeline.py
+++ b/tests/unit/test_unified_attribute_processor_pipeline.py
@@ -58,6 +58,144 @@ def test_process_marks_http_client_span_as_http_kind() -> None:
     assert out["neatlogs.span.kind"] == "http"
 
 
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        {
+            "http.method": "POST",
+            "http.url": "https://user:pass@example.com/pay?token=secret#frag",
+            "http.status_code": 201,
+        },
+        {
+            "http.request.method": "POST",
+            "url.full": "https://user:pass@example.com/pay?token=secret#frag",
+            "http.response.status_code": 201,
+        },
+    ],
+)
+def test_process_synthesizes_safe_http_canonical_io(attributes: dict) -> None:
+    proc = UnifiedAttributeProcessor(mapping_config=_load_mapping(), debug=False)
+    span = _mk_span(kind=SpanKind.CLIENT, attributes=attributes)
+
+    out = proc.process(span)
+
+    assert out["neatlogs.span.kind"] == "http"
+    assert json.loads(out["neatlogs.http.input"]) == {
+        "method": "POST",
+        "url": "https://example.com/pay",
+    }
+    assert json.loads(out["neatlogs.http.output"]) == {"status": 201}
+    serialized = json.dumps(out, default=str)
+    assert "user:pass" not in serialized
+    assert "token=secret" not in serialized
+    assert "frag" not in serialized
+
+
+def test_process_synthesizes_http_input_without_status_or_secret_payloads() -> None:
+    proc = UnifiedAttributeProcessor(mapping_config=_load_mapping(), debug=False)
+    span = _mk_span(
+        kind=SpanKind.CLIENT,
+        attributes={
+            "http.request.method": "GET",
+            "url.scheme": "https",
+            "server.address": "api.example.com",
+            "server.port": 443,
+            "url.path": "/health",
+            "url.query": "api_key=secret",
+            "url.fragment": "private",
+            "input.value": '{"password":"secret-input"}',
+            "output.value": '{"token":"secret-output"}',
+            "http.request.header.authorization": "Bearer secret",
+            "http.response.header.x-internal-token": "secret-response",
+            "http.request.header.cookie": "sid=secret",
+            "http.request.body": '{"password":"secret"}',
+        },
+    )
+
+    out = proc.process(span)
+
+    assert json.loads(out["neatlogs.http.input"]) == {
+        "method": "GET",
+        "url": "https://api.example.com:443/health",
+    }
+    assert json.loads(out["input.value"]) == {
+        "method": "GET",
+        "url": "https://api.example.com:443/health",
+    }
+    assert "neatlogs.http.output" not in out
+    assert "output.value" not in out
+    serialized = json.dumps(out, default=str)
+    assert "Bearer secret" not in serialized
+    assert "sid=secret" not in serialized
+    assert "password" not in serialized
+    assert "secret-response" not in serialized
+    assert "secret-input" not in serialized
+    assert "secret-output" not in serialized
+
+
+def test_http_url_sanitization_handles_ipv6_and_malformed_ports() -> None:
+    proc = UnifiedAttributeProcessor(mapping_config=_load_mapping(), debug=False)
+    ipv6 = _mk_span(
+        kind=SpanKind.CLIENT,
+        attributes={
+            "http.request.method": "GET",
+            "url.scheme": "http",
+            "server.address": "2001:db8::1",
+            "server.port": 8080,
+            "url.path": "/health",
+        },
+    )
+    malformed = _mk_span(
+        kind=SpanKind.CLIENT,
+        attributes={
+            "http.request.method": "GET",
+            "url.full": "https://example.com:not-a-port/path?token=secret",
+        },
+    )
+
+    ipv6_out = proc.process(ipv6)
+    malformed_out = proc.process(malformed)
+
+    assert json.loads(ipv6_out["neatlogs.http.input"])["url"] == (
+        "http://[2001:db8::1]:8080/health"
+    )
+    assert json.loads(malformed_out["neatlogs.http.input"])["url"] == ("https://example.com/path")
+
+
+@pytest.mark.parametrize(
+    "path_key,path_value",
+    [
+        ("url.path", "/health?api_key=secret#fragment"),
+        ("http.target", "https://user:pass@evil.example/health?api_key=secret#fragment"),
+        ("http.route", "/users/{id}?token=secret#fragment"),
+    ],
+)
+def test_http_path_attributes_cannot_preserve_url_credentials(
+    path_key: str, path_value: str
+) -> None:
+    proc = UnifiedAttributeProcessor(mapping_config=_load_mapping(), debug=False)
+    attributes = {
+        "http.request.method": "GET",
+        "server.address": "api.example.com",
+        path_key: path_value,
+    }
+    span = _mk_span(kind=SpanKind.CLIENT, attributes=attributes)
+
+    out = proc.process(span)
+
+    assert json.loads(out["neatlogs.http.input"]) == {
+        "method": "GET",
+        "url": (
+            "http://api.example.com/health"
+            if path_key != "http.route"
+            else "http://api.example.com/users/{id}"
+        ),
+    }
+    serialized = json.dumps(out, default=str)
+    for secret in ("user:pass", "evil.example", "api_key=secret", "token=secret", "fragment"):
+        assert secret not in serialized
+
+
 @pytest.mark.parametrize("kind", ["GUARDRAIL", "EVALUATOR", "MEMORY"])
 def test_process_maps_generic_io_to_semantic_kind_namespace(kind: str) -> None:
     proc = UnifiedAttributeProcessor(mapping_config=_load_mapping(), debug=False)


### PR DESCRIPTION
## Summary

- Enable HTTP client instrumentation when `requests`, `httpx`, `urllib3`, or `aiohttp` is explicitly requested.
- Bind each instrumentor to the Neatlogs tracer provider.
- Keep Neatlogs telemetry requests filtered and continue dropping unrelated rootless HTTP noise.
- Cover nested requests, failures, shutdown, reinitialization, and duplicate prevention.

## Why

The public instrumentation keys were accepted, but the HTTP setup path returned without installing the requested instrumentors.

## Testing

- `uv run pytest -q`: 454 passed, 1 pre-existing skip
- Black and isort checks passed
- Wheel and source distribution built and passed `twine check`
- Clean Python 3.12 wheel import passed

## Merge note

This PR is independent, but it touches shared instrumentation setup and may need a mechanical rebase if another provider-routing PR merges first.
