### PR TITLE
Keep Google ADK spans on the SDK provider

### DIFF
--- a/neatlogs/google_adk.py
+++ b/neatlogs/google_adk.py
@@ -11,29 +11,21 @@ Usage:
 import time
 from typing import Any
 
-from opentelemetry import context as otel_context
 from opentelemetry.trace import StatusCode
 
 from ._wrap_utils import attach_as_current, detach, get_tracer, serialize
-
-_ADK_HOOKS_INSTALLED = False
-
-# The inner `generate_content` span (trace_inference_result) only receives the
-# response, not the request. We stash the most recent request's structured messages
-# in a plain module global so the inner span can reuse them. Calls are effectively
-# sequential per agent turn, and we set it both at use_inference_span entry (which
-# DOES receive llm_request) and in trace_call_llm — whichever fires first wins.
-_LAST_REQUEST_MESSAGES: list = []
 
 
 def wrap_google_adk(runner: Any) -> Any:
     """
     Wrap a Google ADK Runner instance. Patches run() and run_async() to emit the
-    user-facing WORKFLOW span, and installs hooks on ADK's own telemetry helpers
-    so its native per-call spans carry neatlogs I/O + kind.
+    user-facing WORKFLOW span and activates ADK's official OpenInference
+    instrumentor on the current Neatlogs tracer provider.
     Returns the same runner instance.
     """
-    _install_adk_telemetry_hooks()
+    from .init import _instrument_library
+
+    _instrument_library("google_adk")
 
     if getattr(runner, "_neatlogs_patched", False):
         return runner
@@ -41,295 +33,6 @@ def wrap_google_adk(runner: Any) -> Any:
     _patch_run(runner)
     _patch_run_async(runner)
     return runner
-
-
-def _install_adk_telemetry_hooks() -> None:
-    """
-    ADK self-instruments (like the Vercel AI SDK): it emits its own OTel spans
-    (`call_llm`, `execute_tool`, `invoke_agent`, …) via google.adk.telemetry.tracing,
-    classifying them with the gen_ai.* semantic conventions and stashing request/
-    response content under `gcp.vertex.agent.*`. neatlogs' generic mapper reads
-    `input.value`/`output.value` + `neatlogs.span.kind`, which ADK does NOT set — so
-    those native spans would show no I/O and no kind.
-
-    Rather than teach the shared processor about ADK's vendor-specific attributes,
-    we map them HERE, in the ADK wrapper: wrap ADK's telemetry helpers so that after
-    ADK populates its own span we additionally set the neatlogs keys on the SAME span
-    from the request/response objects ADK already hands us. All ADK-specific knowledge
-    stays in this module.
-    """
-    global _ADK_HOOKS_INSTALLED
-    if _ADK_HOOKS_INSTALLED:
-        return
-
-    try:
-        from google.adk.telemetry import tracing as adk_tracing
-    except Exception:
-        return
-
-    from opentelemetry import trace as otel_trace
-
-    # --- LLM calls: trace_call_llm(invocation_context, event_id, llm_request, llm_response, span=None)
-    orig_call_llm = getattr(adk_tracing, "trace_call_llm", None)
-    if orig_call_llm is not None and not getattr(orig_call_llm, "_neatlogs_wrapped", False):
-
-        def patched_trace_call_llm(*args, **kwargs):
-            orig_call_llm(*args, **kwargs)
-            try:
-                # positional: (invocation_context, event_id, llm_request, llm_response, span?)
-                llm_request = args[2] if len(args) > 2 else kwargs.get("llm_request")
-                llm_response = args[3] if len(args) > 3 else kwargs.get("llm_response")
-                span = (
-                    args[4] if len(args) > 4 else kwargs.get("span")
-                ) or otel_trace.get_current_span()
-                if span is not None:
-                    span.set_attribute("neatlogs.span.kind", "llm")
-                    # Emit PROPERLY-ROLED indexed messages (system / user / assistant /
-                    # tool), like the other wrappers — NOT one flattened blob. The backend
-                    # LLM finalizer reads neatlogs.llm.input_messages.<i>.role/content per
-                    # role; a single jumbled string makes it mis-extract (e.g. "City: Paris").
-                    msgs = _adk_request_messages(llm_request)
-                    for i, m in enumerate(msgs):
-                        span.set_attribute(f"neatlogs.llm.input_messages.{i}.role", m["role"])
-                        span.set_attribute(f"neatlogs.llm.input_messages.{i}.content", m["content"])
-                    if msgs:
-                        span.set_attribute("input.value", serialize({"messages": msgs}))
-                        # Stash for the inner generate_content span (same turn).
-                        global _LAST_REQUEST_MESSAGES
-                        _LAST_REQUEST_MESSAGES = msgs
-                    out_text = _adk_llm_response_text(llm_response)
-                    if out_text:
-                        span.set_attribute("output.value", out_text)
-                        span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
-                        span.set_attribute("neatlogs.llm.output_messages.0.content", out_text)
-            except Exception:
-                pass
-
-        patched_trace_call_llm._neatlogs_wrapped = True
-        _rebind_adk_symbol("trace_call_llm", patched_trace_call_llm, adk_tracing)
-
-    # --- use_inference_span(llm_request, ctx, event): async CM that opens the inner
-    #     `generate_content` span. It receives llm_request FIRST (before
-    #     trace_inference_result fires), so stash the request messages here to avoid a
-    #     first-turn race where the inner span has no input yet.
-    orig_use_inf = getattr(adk_tracing, "use_inference_span", None)
-    if orig_use_inf is not None and not getattr(orig_use_inf, "_neatlogs_wrapped", False):
-
-        def patched_use_inference_span(*args, **kwargs):
-            try:
-                llm_request = args[0] if args else kwargs.get("llm_request")
-                msgs = _adk_request_messages(llm_request)
-                if msgs:
-                    global _LAST_REQUEST_MESSAGES
-                    _LAST_REQUEST_MESSAGES = msgs
-            except Exception:
-                pass
-            return orig_use_inf(*args, **kwargs)
-
-        patched_use_inference_span._neatlogs_wrapped = True
-        _rebind_adk_symbol("use_inference_span", patched_use_inference_span, adk_tracing)
-
-    # --- Inference result on the inner `generate_content` span:
-    #     trace_inference_result(span, llm_response). ADK creates BOTH a `call_llm`
-    #     (outer) and a `generate_content` (inner) LLM span per call; the inner one
-    #     only carries tokens + a gen_ai.choice EVENT (no I/O attribute), so it would
-    #     render empty. Enrich it with the same neatlogs I/O so neither LLM span is blank.
-    orig_inf_result = getattr(adk_tracing, "trace_inference_result", None)
-    if orig_inf_result is not None and not getattr(orig_inf_result, "_neatlogs_wrapped", False):
-
-        def patched_trace_inference_result(*args, **kwargs):
-            orig_inf_result(*args, **kwargs)
-            try:
-                span = args[0] if args else kwargs.get("span")
-                # ADK may pass a GenerateContentSpan wrapper — unwrap to the real
-                # OTel span (`.span`); set_attribute on the wrapper would no-op.
-                inner = getattr(span, "span", None)
-                if inner is not None:
-                    span = inner
-                llm_response = args[1] if len(args) > 1 else kwargs.get("llm_response")
-                # Skip partial streaming chunks — wait for the final/non-partial one.
-                if llm_response is not None and getattr(llm_response, "partial", False):
-                    return
-                if span is not None:
-                    span.set_attribute("neatlogs.span.kind", "llm")
-                    # input: reuse the request captured on the parent call_llm turn.
-                    in_msgs = _LAST_REQUEST_MESSAGES
-                    if in_msgs:
-                        for i, m in enumerate(in_msgs):
-                            span.set_attribute(f"neatlogs.llm.input_messages.{i}.role", m["role"])
-                            span.set_attribute(
-                                f"neatlogs.llm.input_messages.{i}.content", m["content"]
-                            )
-                        span.set_attribute("input.value", serialize({"messages": in_msgs}))
-                    out_text = _adk_llm_response_text(llm_response)
-                    if out_text:
-                        span.set_attribute("output.value", out_text)
-                        span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
-                        span.set_attribute("neatlogs.llm.output_messages.0.content", out_text)
-            except Exception:
-                pass
-
-        patched_trace_inference_result._neatlogs_wrapped = True
-        _rebind_adk_symbol("trace_inference_result", patched_trace_inference_result, adk_tracing)
-
-    # --- Tool calls: trace_tool_call(tool, args, function_response_event)
-    orig_tool_call = getattr(adk_tracing, "trace_tool_call", None)
-    if orig_tool_call is not None and not getattr(orig_tool_call, "_neatlogs_wrapped", False):
-
-        def patched_trace_tool_call(*args, **kwargs):
-            orig_tool_call(*args, **kwargs)
-            try:
-                span = otel_trace.get_current_span()
-                tool_args = args[1] if len(args) > 1 else kwargs.get("args")
-                resp_event = args[2] if len(args) > 2 else kwargs.get("function_response_event")
-                if span is not None:
-                    span.set_attribute("neatlogs.span.kind", "tool")
-                    if tool_args is not None:
-                        span.set_attribute("input.value", serialize(tool_args))
-                    out_text = _adk_tool_response_text(resp_event)
-                    if out_text:
-                        span.set_attribute("output.value", out_text)
-            except Exception:
-                pass
-
-        patched_trace_tool_call._neatlogs_wrapped = True
-        _rebind_adk_symbol("trace_tool_call", patched_trace_tool_call, adk_tracing)
-
-    # --- Agent invocation: trace_agent_invocation(span, agent, ctx)
-    orig_agent_inv = getattr(adk_tracing, "trace_agent_invocation", None)
-    if orig_agent_inv is not None and not getattr(orig_agent_inv, "_neatlogs_wrapped", False):
-
-        def patched_trace_agent_invocation(*args, **kwargs):
-            orig_agent_inv(*args, **kwargs)
-            try:
-                span = args[0] if args else kwargs.get("span")
-                agent = args[1] if len(args) > 1 else kwargs.get("agent")
-                ctx = args[2] if len(args) > 2 else kwargs.get("ctx")
-                if span is not None:
-                    span.set_attribute("neatlogs.span.kind", "agent")
-                    # Agent system prompt = the agent's instruction.
-                    instruction = getattr(agent, "instruction", None)
-                    if instruction and isinstance(instruction, str):
-                        span.set_attribute("neatlogs.llm.input_messages.0.role", "system")
-                        span.set_attribute("neatlogs.llm.input_messages.0.content", instruction)
-                    # User input for this invocation.
-                    user_text = (
-                        _content_to_text(getattr(ctx, "user_content", None))
-                        if ctx is not None
-                        else ""
-                    )
-                    if user_text:
-                        span.set_attribute("input.value", user_text)
-                    name = getattr(agent, "name", None)
-                    if name:
-                        span.set_attribute("neatlogs.agent.name", str(name))
-            except Exception:
-                pass
-
-        patched_trace_agent_invocation._neatlogs_wrapped = True
-        _rebind_adk_symbol("trace_agent_invocation", patched_trace_agent_invocation, adk_tracing)
-
-    _ADK_HOOKS_INSTALLED = True
-
-
-def _rebind_adk_symbol(name: str, patched: Any, adk_tracing: Any) -> None:
-    """
-    Rebind a telemetry helper everywhere it's used. ADK's flow modules do
-    `from ...telemetry.tracing import trace_call_llm` (a direct name import), so
-    patching only `adk_tracing.<name>` leaves those already-imported references
-    pointing at the original. Patch the source module AND every loaded module
-    that imported the symbol by value.
-    """
-    import sys
-
-    setattr(adk_tracing, name, patched)
-    for mod in list(sys.modules.values()):
-        if mod is None:
-            continue
-        mod_name = getattr(mod, "__name__", "")
-        if not mod_name.startswith("google.adk"):
-            continue
-        if getattr(mod, name, None) is not None and mod is not adk_tracing:
-            try:
-                setattr(mod, name, patched)
-            except Exception:
-                pass
-
-
-def _content_to_text(content: Any) -> str:
-    """Flatten a google.genai Content (or list) into readable text + tool calls."""
-    if content is None:
-        return ""
-    items = content if isinstance(content, list) else [content]
-    out = []
-    for c in items:
-        parts = getattr(c, "parts", None) or []
-        for p in parts:
-            text = getattr(p, "text", None)
-            if text:
-                out.append(text)
-                continue
-            fc = getattr(p, "function_call", None)
-            if fc is not None:
-                out.append(
-                    f"{getattr(fc, 'name', '')}({serialize(dict(getattr(fc, 'args', {}) or {}))})"
-                )
-                continue
-            fr = getattr(p, "function_response", None)
-            if fr is not None:
-                out.append(serialize(getattr(fr, "response", None)))
-    return "\n".join(s for s in out if s)
-
-
-def _adk_request_messages(llm_request: Any) -> list:
-    """
-    Structured, per-role messages from an ADK LlmRequest:
-    [{role: system, content}, {role: user/model/tool, content}, ...].
-    ADK's google.genai content roles are 'user' and 'model'; map 'model'→'assistant'.
-    """
-    if llm_request is None:
-        return []
-    out = []
-    config = getattr(llm_request, "config", None)
-    sys_inst = getattr(config, "system_instruction", None) if config is not None else None
-    if sys_inst:
-        sys_text = sys_inst if isinstance(sys_inst, str) else _content_to_text(sys_inst)
-        if sys_text:
-            out.append({"role": "system", "content": sys_text})
-    contents = getattr(llm_request, "contents", None) or []
-    if not isinstance(contents, list):
-        contents = [contents]
-    for c in contents:
-        role = getattr(c, "role", None) or "user"
-        if role == "model":
-            role = "assistant"
-        # google.genai sends BOTH user turns AND tool/function responses with
-        # role "user". Re-label function-response turns as "tool" so the backend's
-        # "last user message" heuristic picks the real user question, not the tool
-        # result (which would render as e.g. "City: Paris").
-        parts = getattr(c, "parts", None) or []
-        has_fn_response = any(getattr(p, "function_response", None) is not None for p in parts)
-        has_fn_call = any(getattr(p, "function_call", None) is not None for p in parts)
-        if has_fn_response:
-            role = "tool"
-        elif has_fn_call and role == "user":
-            role = "assistant"
-        text = _content_to_text(c)
-        if text:
-            out.append({"role": role, "content": text})
-    return out
-
-
-def _adk_llm_response_text(llm_response: Any) -> str:
-    if llm_response is None:
-        return ""
-    return _content_to_text(getattr(llm_response, "content", None))
-
-
-def _adk_tool_response_text(resp_event: Any) -> str:
-    if resp_event is None:
-        return ""
-    return _content_to_text(getattr(resp_event, "content", None))
 
 
 def _get_runner_attributes(runner: Any) -> dict:
@@ -548,24 +251,26 @@ def _patch_run(runner: Any) -> None:
         span = tracer.start_span(name="google_adk.runner.run", attributes=attrs)
         token = attach_as_current(span)
         start = time.perf_counter()
+        event_attrs = {}
+        failure = None
 
         try:
             events = orig_run(*args, **kwargs)
             collected, event_attrs = _collect_events(events)
-        except Exception as e:
-            span.set_status(StatusCode.ERROR, str(e))
-            span.record_exception(e)
-            span.end()
+        except BaseException as exc:
+            failure = exc
+            span.set_status(StatusCode.ERROR, str(exc))
+            span.record_exception(exc)
             raise
         finally:
             detach(token)
-
-        duration_ms = (time.perf_counter() - start) * 1000
-        for attr_name, value in event_attrs.items():
-            span.set_attribute(attr_name, value)
-        span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
-        span.set_status(StatusCode.OK)
-        span.end()
+            duration_ms = (time.perf_counter() - start) * 1000
+            for attr_name, value in event_attrs.items():
+                span.set_attribute(attr_name, value)
+            span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
+            if failure is None:
+                span.set_status(StatusCode.OK)
+            span.end()
 
         return iter(collected)
 
@@ -610,27 +315,27 @@ def _patch_run_async(runner: Any) -> None:
         start = time.perf_counter()
 
         collected = []
+        failure = None
         try:
             # Stream events to the caller as they arrive (keeps run_async an async
             # generator), buffering them so we can extract span attrs at the end.
             async for event in orig_run_async(*args, **kwargs):
                 collected.append(event)
                 yield event
-        except Exception as e:
-            span.set_status(StatusCode.ERROR, str(e))
-            span.record_exception(e)
-            span.end()
+        except BaseException as exc:
+            failure = exc
+            span.set_status(StatusCode.ERROR, str(exc))
+            span.record_exception(exc)
             raise
         finally:
             detach(token)
-
-        duration_ms = (time.perf_counter() - start) * 1000
-        # Reuse the sync extractor over the buffered events (no awaiting needed).
-        _, event_attrs = _collect_events(iter(collected))
-        for attr_name, value in event_attrs.items():
-            span.set_attribute(attr_name, value)
-        span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
-        span.set_status(StatusCode.OK)
-        span.end()
+            duration_ms = (time.perf_counter() - start) * 1000
+            _, event_attrs = _collect_events(iter(collected))
+            for attr_name, value in event_attrs.items():
+                span.set_attribute(attr_name, value)
+            span.set_attribute("neatlogs.llm.metrics.duration_ms", round(duration_ms, 3))
+            if failure is None:
+                span.set_status(StatusCode.OK)
+            span.end()
 
     runner.run_async = patched_run_async

--- a/neatlogs/google_adk.py
+++ b/neatlogs/google_adk.py
@@ -381,6 +381,8 @@ def _patch_run_async(runner: Any) -> None:
     if not hasattr(runner, "run_async"):
         return
 
+    instance_run_async = vars(runner).get("run_async")
+
     # Must itself be an async GENERATOR (use yield), because callers consume
     # run_async() with `async for`. A plain `async def` would return a coroutine
     # and break iteration. We stream events through, then finalize the span.
@@ -416,7 +418,9 @@ def _patch_run_async(runner: Any) -> None:
         try:
             # Stream events to the caller as they arrive (keeps run_async an async
             # generator), buffering them so we can extract span attrs at the end.
-            run_async = type(runner).run_async.__get__(runner, type(runner))
+            run_async = instance_run_async
+            if run_async is None:
+                run_async = type(runner).run_async.__get__(runner, type(runner))
             async for event in run_async(*args, **kwargs):
                 collected.append(event)
                 yield event

--- a/neatlogs/google_adk.py
+++ b/neatlogs/google_adk.py
@@ -8,12 +8,65 @@ Usage:
     >>> # runner.run() / runner.run_async() are now traced
 """
 
+import threading
 import time
 from typing import Any
 
 from opentelemetry.trace import StatusCode
 
 from ._wrap_utils import attach_as_current, detach, get_tracer, serialize
+
+_ADK_BIND_LOCK = threading.RLock()
+_ADK_BOUND = False
+
+
+class _ContextualGoogleADKTracer:
+    def __init__(self, scope: str, version: str | None, schema_url: str | None, attributes: Any):
+        self._scope = scope
+        self._version = version
+        self._schema_url = schema_url
+        self._attributes = attributes
+
+    def _tracer(self):
+        from opentelemetry import trace as trace_api
+
+        from ._wrap_utils import get_neatlogs_provider
+        from .instrumentation.openinference_isolation import provider_for_openinference
+
+        provider = get_neatlogs_provider()
+        if provider is None:
+            return trace_api.NoOpTracerProvider().get_tracer(self._scope)
+        return provider_for_openinference(provider).get_tracer(
+            self._scope,
+            self._version,
+            self._schema_url,
+            self._attributes,
+        )
+
+    def start_span(self, *args: Any, **kwargs: Any):
+        return self._tracer().start_span(*args, **kwargs)
+
+    def start_as_current_span(self, *args: Any, **kwargs: Any):
+        return self._tracer().start_as_current_span(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._tracer(), name)
+
+
+class _ContextualGoogleADKProvider:
+    def get_tracer(
+        self,
+        instrumenting_module_name: str,
+        instrumenting_library_version: str | None = None,
+        schema_url: str | None = None,
+        attributes: Any = None,
+    ) -> _ContextualGoogleADKTracer:
+        return _ContextualGoogleADKTracer(
+            instrumenting_module_name,
+            instrumenting_library_version,
+            schema_url,
+            attributes,
+        )
 
 
 def wrap_google_adk(runner: Any) -> Any:
@@ -23,9 +76,7 @@ def wrap_google_adk(runner: Any) -> Any:
     instrumentor on the current Neatlogs tracer provider.
     Returns the same runner instance.
     """
-    from .init import _instrument_library
-
-    _instrument_library("google_adk")
+    _ensure_google_adk_bound()
 
     if getattr(runner, "_neatlogs_patched", False):
         return runner
@@ -33,6 +84,52 @@ def wrap_google_adk(runner: Any) -> Any:
     _patch_run(runner)
     _patch_run_async(runner)
     return runner
+
+
+def _ensure_google_adk_bound() -> bool:
+    """Bind ADK OpenInference instrumentation to the provider active now."""
+    from opentelemetry.sdk.trace import TracerProvider
+
+    from ._wrap_utils import get_neatlogs_provider
+    from .instrumentation.openinference_isolation import provider_for_openinference
+
+    provider = get_neatlogs_provider()
+    if not isinstance(provider, TracerProvider):
+        return False
+
+    global _ADK_BOUND
+    with _ADK_BIND_LOCK:
+        if _ADK_BOUND:
+            return True
+
+        try:
+            from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+        except Exception:
+            return False
+
+        instrumentor = GoogleADKInstrumentor()
+        if getattr(instrumentor, "_is_instrumented_by_opentelemetry", False):
+            instrumentor.uninstrument()
+        instrumentor.instrument(
+            tracer_provider=provider_for_openinference(_ContextualGoogleADKProvider())
+        )
+        _ADK_BOUND = True
+        return True
+
+
+def _reset_google_adk_binding() -> None:
+    """Clear ADK provider binding state after SDK shutdown."""
+    global _ADK_BOUND
+    with _ADK_BIND_LOCK:
+        if not _ADK_BOUND:
+            return
+        try:
+            from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+
+            GoogleADKInstrumentor().uninstrument()
+        except Exception:
+            pass
+        _ADK_BOUND = False
 
 
 def _get_runner_attributes(runner: Any) -> dict:
@@ -227,6 +324,7 @@ def _patch_run(runner: Any) -> None:
     orig_run = runner.run
 
     def patched_run(*args, **kwargs):
+        _ensure_google_adk_bound()
         tracer = get_tracer()
         attrs = _get_runner_attributes(runner)
 
@@ -283,12 +381,11 @@ def _patch_run_async(runner: Any) -> None:
     if not hasattr(runner, "run_async"):
         return
 
-    orig_run_async = runner.run_async
-
     # Must itself be an async GENERATOR (use yield), because callers consume
     # run_async() with `async for`. A plain `async def` would return a coroutine
     # and break iteration. We stream events through, then finalize the span.
     async def patched_run_async(*args, **kwargs):
+        _ensure_google_adk_bound()
         tracer = get_tracer()
         attrs = _get_runner_attributes(runner)
 
@@ -319,7 +416,8 @@ def _patch_run_async(runner: Any) -> None:
         try:
             # Stream events to the caller as they arrive (keeps run_async an async
             # generator), buffering them so we can extract span attrs at the end.
-            async for event in orig_run_async(*args, **kwargs):
+            run_async = type(runner).run_async.__get__(runner, type(runner))
+            async for event in run_async(*args, **kwargs):
                 collected.append(event)
                 yield event
         except BaseException as exc:

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -92,6 +92,15 @@ def is_debug_enabled() -> bool:
     return _debug_mode
 
 
+def _instrument_library(library: str) -> bool:
+    """Activate one library through the current default instrumentation manager."""
+    manager = _instrumentation_manager
+    if manager is None:
+        return False
+    manager.instrument(libraries=[library])
+    return library in manager.instrumented
+
+
 def _trace_sampler(sample_rate: float) -> ParentBased:
     """Validate one trace-level rate and preserve the parent's sampling decision."""
     if isinstance(sample_rate, bool) or not isinstance(sample_rate, (int, float)):

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -1135,6 +1135,12 @@ def _perform_shutdown(
         set_neatlogs_provider(None)
     except Exception:
         pass
+    try:
+        from .google_adk import _reset_google_adk_binding
+
+        _reset_google_adk_binding()
+    except Exception:
+        pass
 
     set_default_media_store(None)
     if _media_store is not None:

--- a/neatlogs/instrumentation/manager.py
+++ b/neatlogs/instrumentation/manager.py
@@ -227,6 +227,9 @@ class InstrumentationManager:
 
             # Post-instrument patches for OpenInference libraries
             if convention == "openinference":
+                # Some adapters import helper modules only from instrument().
+                # Refresh their direct OTel function references after that import.
+                provider_for_openinference(self.provider)
                 if library == "openai":
                     self._patch_openinference_openai_request_extras()
                     self._patch_openinference_openai_response_extras()
@@ -1577,6 +1580,7 @@ class InstrumentationManager:
             special_imports = {
                 "google_genai": "google.genai",
                 "google_generativeai": "google.generativeai",
+                "google_adk": "google.adk",
                 # Vertex AI (neatlogs custom) runs through the google-genai SDK in
                 # Vertex mode, not the legacy `vertexai` / google-cloud-aiplatform pkg.
                 "vertex_ai": "google.genai",

--- a/neatlogs/instrumentation/manager.py
+++ b/neatlogs/instrumentation/manager.py
@@ -149,6 +149,19 @@ class InstrumentationManager:
                 logger.info(f"⏭️  Skipped: {library} (not installed)")
             return
 
+        if library == "google_adk":
+            try:
+                from ..google_adk import _ensure_google_adk_bound
+
+                if _ensure_google_adk_bound():
+                    self.instrumented.add(library)
+                    if self.debug:
+                        logger.info("google_adk (OpenInference)")
+            except Exception as e:
+                if self.debug:
+                    logger.warning(f"google_adk (OpenInference): {e}")
+            return
+
         info = INSTRUMENTATION_REGISTRY["libraries"].get(library)
         if not info:
             if self.debug:
@@ -275,6 +288,14 @@ class InstrumentationManager:
         except Exception:
             pass
         for library in list(self.instrumented):
+            if library == "google_adk":
+                try:
+                    from ..google_adk import _reset_google_adk_binding
+
+                    _reset_google_adk_binding()
+                except Exception:
+                    pass
+                continue
             info = INSTRUMENTATION_REGISTRY["libraries"].get(library) or {}
             for convention in ("neatlogs", "openinference", "openllmetry"):
                 package_name = info.get(convention)

--- a/neatlogs/instrumentation/openinference_isolation.py
+++ b/neatlogs/instrumentation/openinference_isolation.py
@@ -25,6 +25,7 @@ from .._wrap_utils import (
 _ISOLATED_MARKER = "_neatlogs_openinference_isolated"
 _ORIGINAL_USE_SPAN = trace_api.use_span
 _ORIGINAL_SET_SPAN_IN_CONTEXT = trace_api.set_span_in_context
+_ORIGINAL_GET_CURRENT_SPAN = trace_api.get_current_span
 _ORIGINAL_SET_VALUE = context_api.set_value
 _PATCHED = False
 
@@ -70,6 +71,13 @@ def _safe_set_span_in_context(
     if not _is_isolated_span(span):
         return _ORIGINAL_SET_SPAN_IN_CONTEXT(span, context)
     return set_neatlogs_span_in_context(span, context, force_owned=True)
+
+
+def _safe_get_current_span(context: Optional[context_api.Context] = None) -> Span:
+    private_span = _current_neatlogs_parent(context)
+    if private_span is not None and _is_isolated_span(private_span):
+        return private_span
+    return _ORIGINAL_GET_CURRENT_SPAN(context)
 
 
 def _safe_set_value(
@@ -148,6 +156,8 @@ def _patch_loaded_openinference_references() -> None:
                 namespace[attr_name] = _safe_use_span
             elif value is _ORIGINAL_SET_SPAN_IN_CONTEXT:
                 namespace[attr_name] = _safe_set_span_in_context
+            elif value is _ORIGINAL_GET_CURRENT_SPAN:
+                namespace[attr_name] = _safe_get_current_span
             elif value is _ORIGINAL_SET_VALUE:
                 namespace[attr_name] = _safe_set_value
 

--- a/tests/unit/test_google_adk_private_instrumentation.py
+++ b/tests/unit/test_google_adk_private_instrumentation.py
@@ -1,0 +1,377 @@
+import asyncio
+
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+
+import neatlogs
+
+pytest.importorskip("google.adk")
+
+
+async def _run_local_adk(
+    *,
+    wrapped: bool,
+    suffix: str = "one",
+    with_tool: bool = False,
+    fail: bool = False,
+    started: asyncio.Event | None = None,
+    release: asyncio.Event | None = None,
+    sync: bool = False,
+) -> str:
+    from google.adk.agents import LlmAgent
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_response import LlmResponse
+    from google.adk.runners import Runner
+    from google.adk.sessions import InMemorySessionService
+    from google.genai import types
+
+    call_count = 0
+
+    class LocalLlm(BaseLlm):
+        async def generate_content_async(self, llm_request, stream=False):
+            nonlocal call_count
+            if call_count == 0:
+                assert llm_request.contents[-1].parts[-1].text == f"question-{suffix}"
+            del stream
+            call_count += 1
+            if started is not None:
+                started.set()
+            if release is not None:
+                await release.wait()
+            if fail:
+                raise RuntimeError(f"model-failure-{suffix}")
+            if with_tool and call_count == 1:
+                yield LlmResponse(
+                    content=types.Content(
+                        role="model",
+                        parts=[
+                            types.Part(
+                                function_call=types.FunctionCall(
+                                    name="lookup_temperature",
+                                    args={"city": "Paris"},
+                                )
+                            )
+                        ],
+                    ),
+                    turn_complete=False,
+                    finish_reason=types.FinishReason.STOP,
+                )
+                return
+            yield LlmResponse(
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text=f"answer-{suffix}")],
+                ),
+                turn_complete=True,
+                finish_reason=types.FinishReason.STOP,
+                usage_metadata=types.GenerateContentResponseUsageMetadata(
+                    prompt_token_count=8,
+                    candidates_token_count=5,
+                    total_token_count=13,
+                ),
+            )
+
+    def lookup_temperature(city: str) -> dict[str, str]:
+        """Return deterministic weather for one city."""
+        return {"city": city, "temperature": "20 C"}
+
+    app_name = f"private-adk-{suffix}"
+    user_id = f"user-{suffix}"
+    session_id = f"session-{suffix}"
+    sessions = InMemorySessionService()
+    await sessions.create_session(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+    )
+    runner = Runner(
+        app_name=app_name,
+        agent=LlmAgent(
+            name=f"agent_{suffix}",
+            model=LocalLlm(model=f"model-{suffix}"),
+            instruction=f"instruction-{suffix}",
+            tools=[lookup_temperature] if with_tool else [],
+        ),
+        session_service=sessions,
+    )
+    if wrapped:
+        runner = neatlogs.wrap(runner)
+
+    message = types.Content(
+        role="user",
+        parts=[types.Part(text=f"question-{suffix}")],
+    )
+
+    def event_text(event) -> str:
+        result = ""
+        for part in getattr(getattr(event, "content", None), "parts", None) or []:
+            result += getattr(part, "text", None) or ""
+        return result
+
+    output = ""
+    if sync:
+        for event in runner.run(
+            user_id=user_id,
+            session_id=session_id,
+            new_message=message,
+        ):
+            output += event_text(event)
+        return output
+
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session_id,
+        new_message=message,
+    ):
+        output += event_text(event)
+    return output
+
+
+def _init_adk(*, automatic: bool):
+    foreign_provider = TracerProvider()
+    foreign_exporter = InMemorySpanExporter()
+    foreign_provider.add_span_processor(SimpleSpanProcessor(foreign_exporter))
+    trace_api.set_tracer_provider(foreign_provider)
+
+    private_provider = TracerProvider()
+    private_exporter = InMemorySpanExporter()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["google_adk"] if automatic else [],
+        tracer_provider=private_provider,
+        register_shutdown_handlers=False,
+    )
+    private_provider.add_span_processor(SimpleSpanProcessor(private_exporter))
+    return private_exporter, foreign_exporter
+
+
+def _semantic_spans(exporter):
+    return [
+        span
+        for span in exporter.get_finished_spans()
+        if span.attributes.get("openinference.span.kind") in {"CHAIN", "AGENT", "LLM", "TOOL"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_automatic_google_adk_uses_private_provider_with_full_hierarchy():
+    private_exporter, foreign_exporter = _init_adk(automatic=True)
+
+    with neatlogs.trace("automatic-workflow", kind="WORKFLOW"):
+        output = await _run_local_adk(wrapped=False, suffix="automatic")
+
+    assert output == "answer-automatic"
+    spans = private_exporter.get_finished_spans()
+    kinds = [span.attributes.get("openinference.span.kind") for span in spans]
+    assert {"CHAIN", "AGENT", "LLM"}.issubset(kinds)
+    assert not _semantic_spans(foreign_exporter)
+
+    by_kind = {
+        span.attributes.get("openinference.span.kind"): span
+        for span in spans
+        if span.attributes.get("openinference.span.kind")
+    }
+    workflow = next(span for span in spans if span.name == "automatic-workflow")
+    assert by_kind["CHAIN"].parent.span_id == workflow.context.span_id
+    assert by_kind["AGENT"].parent.span_id == by_kind["CHAIN"].context.span_id
+    assert by_kind["LLM"].parent.span_id == by_kind["AGENT"].context.span_id
+    assert "question-automatic" in by_kind["LLM"].attributes["input.value"]
+    assert "answer-automatic" in by_kind["LLM"].attributes["output.value"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_google_adk_wrap_activates_the_same_private_instrumentor():
+    private_exporter, foreign_exporter = _init_adk(automatic=False)
+
+    with neatlogs.trace("explicit-workflow", kind="WORKFLOW"):
+        output = await _run_local_adk(wrapped=True, suffix="explicit")
+
+    assert output == "answer-explicit"
+    kinds = {
+        span.attributes.get("openinference.span.kind")
+        for span in private_exporter.get_finished_spans()
+    }
+    assert {"CHAIN", "AGENT", "LLM"}.issubset(kinds)
+    assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_google_adk_sessions_keep_their_content_separate():
+    private_exporter, _ = _init_adk(automatic=True)
+
+    with neatlogs.trace("concurrent-workflow", kind="WORKFLOW"):
+        outputs = await asyncio.gather(
+            _run_local_adk(wrapped=False, suffix="alpha"),
+            _run_local_adk(wrapped=False, suffix="beta"),
+        )
+
+    assert outputs == ["answer-alpha", "answer-beta"]
+    llm_spans = [
+        span
+        for span in private_exporter.get_finished_spans()
+        if span.attributes.get("openinference.span.kind") == "LLM"
+    ]
+    assert len(llm_spans) == 2
+    pairs = {
+        (
+            "question-alpha" in span.attributes["input.value"],
+            "answer-alpha" in span.attributes["output.value"],
+        )
+        for span in llm_spans
+    }
+    assert pairs == {(True, True), (False, False)}
+
+
+@pytest.mark.asyncio
+async def test_google_adk_shutdown_and_reinitialize_do_not_duplicate_spans():
+    first_exporter, _ = _init_adk(automatic=True)
+    await _run_local_adk(wrapped=False, suffix="first")
+    assert neatlogs.shutdown()
+
+    second_provider = TracerProvider()
+    second_exporter = InMemorySpanExporter()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["google_adk"],
+        tracer_provider=second_provider,
+        register_shutdown_handlers=False,
+    )
+    second_provider.add_span_processor(SimpleSpanProcessor(second_exporter))
+    await _run_local_adk(wrapped=False, suffix="second")
+
+    assert len([span for span in _semantic_spans(first_exporter) if span.name == "call_llm"]) == 1
+    assert len([span for span in _semantic_spans(second_exporter) if span.name == "call_llm"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_google_adk_tool_call_keeps_complete_private_hierarchy():
+    private_exporter, foreign_exporter = _init_adk(automatic=True)
+
+    with neatlogs.trace("tool-workflow", kind="WORKFLOW"):
+        output = await _run_local_adk(wrapped=False, suffix="tool", with_tool=True)
+
+    assert output == "answer-tool"
+    semantic = _semantic_spans(private_exporter)
+    kinds = [span.attributes.get("openinference.span.kind") for span in semantic]
+    assert kinds.count("CHAIN") == 1
+    assert kinds.count("AGENT") == 1
+    assert kinds.count("LLM") == 2
+    assert kinds.count("TOOL") == 1
+    tool = next(
+        span for span in semantic if span.attributes.get("openinference.span.kind") == "TOOL"
+    )
+    assert "Paris" in tool.attributes["input.value"]
+    assert "20 C" in tool.attributes["output.value"]
+    assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_automatic_and_explicit_google_adk_instrumentation_do_not_duplicate_spans():
+    private_exporter, foreign_exporter = _init_adk(automatic=True)
+
+    output = await _run_local_adk(wrapped=True, suffix="combined")
+
+    assert output == "answer-combined"
+    semantic = _semantic_spans(private_exporter)
+    assert (
+        len(
+            [span for span in semantic if span.attributes.get("openinference.span.kind") == "CHAIN"]
+        )
+        == 1
+    )
+    assert (
+        len(
+            [span for span in semantic if span.attributes.get("openinference.span.kind") == "AGENT"]
+        )
+        == 1
+    )
+    assert (
+        len([span for span in semantic if span.attributes.get("openinference.span.kind") == "LLM"])
+        == 1
+    )
+    assert (
+        len(
+            [
+                span
+                for span in private_exporter.get_finished_spans()
+                if span.name == "google_adk.runner.run_async"
+            ]
+        )
+        == 1
+    )
+    assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_google_adk_sync_runner_uses_the_private_provider():
+    private_exporter, foreign_exporter = _init_adk(automatic=True)
+
+    output = await _run_local_adk(wrapped=True, suffix="sync", sync=True)
+
+    assert output == "answer-sync"
+    semantic = _semantic_spans(private_exporter)
+    assert (
+        len([span for span in semantic if span.attributes.get("openinference.span.kind") == "LLM"])
+        == 1
+    )
+    assert (
+        len(
+            [
+                span
+                for span in private_exporter.get_finished_spans()
+                if span.name == "google_adk.runner.run"
+            ]
+        )
+        == 1
+    )
+    assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_google_adk_model_failure_finishes_error_spans_on_private_provider():
+    private_exporter, foreign_exporter = _init_adk(automatic=True)
+
+    with pytest.raises(RuntimeError, match="model-failure-error"):
+        await _run_local_adk(wrapped=True, suffix="error", fail=True)
+
+    spans = private_exporter.get_finished_spans()
+    wrapper = next(span for span in spans if span.name == "google_adk.runner.run_async")
+    llm = next(span for span in spans if span.name == "call_llm")
+    assert wrapper.status.status_code == StatusCode.ERROR
+    assert llm.status.status_code == StatusCode.ERROR
+    assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_google_adk_cancellation_finishes_the_wrapper_span():
+    private_exporter, foreign_exporter = _init_adk(automatic=True)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    task = asyncio.create_task(
+        _run_local_adk(
+            wrapped=True,
+            suffix="cancelled",
+            started=started,
+            release=release,
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    wrappers = [
+        span
+        for span in private_exporter.get_finished_spans()
+        if span.name == "google_adk.runner.run_async"
+    ]
+    assert len(wrappers) == 1
+    assert wrappers[0].status.status_code == StatusCode.ERROR
+    assert not _semantic_spans(foreign_exporter)

--- a/tests/unit/test_google_adk_private_instrumentation.py
+++ b/tests/unit/test_google_adk_private_instrumentation.py
@@ -21,6 +21,7 @@ async def _run_local_adk(
     started: asyncio.Event | None = None,
     release: asyncio.Event | None = None,
     sync: bool = False,
+    after_wrap=None,
 ) -> str:
     from google.adk.agents import LlmAgent
     from google.adk.models.base_llm import BaseLlm
@@ -100,6 +101,8 @@ async def _run_local_adk(
     )
     if wrapped:
         runner = neatlogs.wrap(runner)
+    if after_wrap is not None:
+        after_wrap()
 
     message = types.Content(
         role="user",
@@ -198,6 +201,161 @@ async def test_explicit_google_adk_wrap_activates_the_same_private_instrumentor(
     }
     assert {"CHAIN", "AGENT", "LLM"}.issubset(kinds)
     assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_google_adk_wrap_before_init_binds_private_provider_at_invocation():
+    private_provider = TracerProvider()
+    private_exporter = InMemorySpanExporter()
+    foreign_provider = TracerProvider()
+    foreign_exporter = InMemorySpanExporter()
+    foreign_provider.add_span_processor(SimpleSpanProcessor(foreign_exporter))
+    trace_api.set_tracer_provider(foreign_provider)
+
+    def initialize_after_wrap():
+        neatlogs.init(
+            api_key="test-key",
+            disable_export=True,
+            instrumentations=[],
+            tracer_provider=private_provider,
+            register_shutdown_handlers=False,
+        )
+        private_provider.add_span_processor(SimpleSpanProcessor(private_exporter))
+
+    output = await _run_local_adk(
+        wrapped=True,
+        suffix="wrap_before_init",
+        after_wrap=initialize_after_wrap,
+    )
+
+    assert output == "answer-wrap_before_init"
+    spans = private_exporter.get_finished_spans()
+    kinds = {
+        span.attributes.get("openinference.span.kind")
+        for span in spans
+        if span.attributes.get("openinference.span.kind")
+    }
+    assert {"CHAIN", "AGENT", "LLM"}.issubset(kinds)
+    assert any(span.name == "google_adk.runner.run_async" for span in spans)
+    assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_google_adk_client_activation_owns_root_and_semantic_children():
+    default_exporter, foreign_exporter = _init_adk(automatic=True)
+    client_provider = TracerProvider()
+    client_exporter = InMemorySpanExporter()
+    client_provider.add_span_processor(SimpleSpanProcessor(client_exporter))
+    client = neatlogs.Client(
+        api_key="client-key",
+        workflow_name="client-workflow",
+        disable_export=True,
+        tracer_provider=client_provider,
+    )
+
+    try:
+        with client.activate():
+            output = await _run_local_adk(wrapped=True, suffix="client")
+    finally:
+        client.shutdown()
+
+    assert output == "answer-client"
+    client_spans = client_exporter.get_finished_spans()
+    assert any(span.name == "google_adk.runner.run_async" for span in client_spans)
+    kinds = {
+        span.attributes.get("openinference.span.kind")
+        for span in client_spans
+        if span.attributes.get("openinference.span.kind")
+    }
+    assert {"CHAIN", "AGENT", "LLM"}.issubset(kinds)
+
+    wrapper = next(span for span in client_spans if span.name == "google_adk.runner.run_async")
+    chain = next(
+        span for span in client_spans if span.attributes.get("openinference.span.kind") == "CHAIN"
+    )
+    assert chain.parent.span_id == wrapper.context.span_id
+    assert not _semantic_spans(default_exporter)
+    assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_automatic_google_adk_uses_the_active_client_provider():
+    default_exporter, foreign_exporter = _init_adk(automatic=True)
+    client_provider = TracerProvider()
+    client_exporter = InMemorySpanExporter()
+    client_provider.add_span_processor(SimpleSpanProcessor(client_exporter))
+    client = neatlogs.Client(
+        api_key="client-key",
+        workflow_name="client-workflow",
+        disable_export=True,
+        tracer_provider=client_provider,
+    )
+
+    try:
+        with client.activate():
+            with neatlogs.trace("automatic-client-workflow", kind="WORKFLOW"):
+                output = await _run_local_adk(wrapped=False, suffix="automatic_client")
+    finally:
+        client.shutdown()
+
+    assert output == "answer-automatic_client"
+    kinds = {
+        span.attributes.get("openinference.span.kind")
+        for span in client_exporter.get_finished_spans()
+        if span.attributes.get("openinference.span.kind")
+    }
+    assert {"CHAIN", "AGENT", "LLM"}.issubset(kinds)
+    assert not _semantic_spans(default_exporter)
+    assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_google_adk_clients_keep_semantic_children_context_local():
+    _init_adk(automatic=True)
+    first_provider = TracerProvider()
+    second_provider = TracerProvider()
+    first_exporter = InMemorySpanExporter()
+    second_exporter = InMemorySpanExporter()
+    first_provider.add_span_processor(SimpleSpanProcessor(first_exporter))
+    second_provider.add_span_processor(SimpleSpanProcessor(second_exporter))
+    first = neatlogs.Client(
+        api_key="first-key",
+        workflow_name="first-client",
+        disable_export=True,
+        tracer_provider=first_provider,
+    )
+    second = neatlogs.Client(
+        api_key="second-key",
+        workflow_name="second-client",
+        disable_export=True,
+        tracer_provider=second_provider,
+    )
+
+    async def run(client, suffix):
+        with client.activate():
+            return await _run_local_adk(wrapped=True, suffix=suffix)
+
+    try:
+        outputs = await asyncio.gather(run(first, "first_client"), run(second, "second_client"))
+    finally:
+        first.shutdown()
+        second.shutdown()
+
+    assert outputs == ["answer-first_client", "answer-second_client"]
+    first_llm = [
+        span
+        for span in first_exporter.get_finished_spans()
+        if span.attributes.get("openinference.span.kind") == "LLM"
+    ]
+    second_llm = [
+        span
+        for span in second_exporter.get_finished_spans()
+        if span.attributes.get("openinference.span.kind") == "LLM"
+    ]
+    assert len(first_llm) == 1
+    assert len(second_llm) == 1
+    assert "question-first_client" in first_llm[0].attributes["input.value"]
+    assert "question-second_client" in second_llm[0].attributes["input.value"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_google_adk_private_instrumentation.py
+++ b/tests/unit/test_google_adk_private_instrumentation.py
@@ -1,4 +1,5 @@
 import asyncio
+import types
 
 import pytest
 from opentelemetry import trace as trace_api
@@ -21,6 +22,7 @@ async def _run_local_adk(
     started: asyncio.Event | None = None,
     release: asyncio.Event | None = None,
     sync: bool = False,
+    before_wrap=None,
     after_wrap=None,
 ) -> str:
     from google.adk.agents import LlmAgent
@@ -99,6 +101,8 @@ async def _run_local_adk(
         ),
         session_service=sessions,
     )
+    if before_wrap is not None:
+        before_wrap(runner)
     if wrapped:
         runner = neatlogs.wrap(runner)
     if after_wrap is not None:
@@ -487,6 +491,37 @@ async def test_google_adk_sync_runner_uses_the_private_provider():
             ]
         )
         == 1
+    )
+    assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_google_adk_wrap_preserves_instance_async_override():
+    private_exporter, foreign_exporter = _init_adk(automatic=True)
+    override_calls = 0
+
+    def install_override(runner):
+        original = runner.run_async
+
+        async def instance_run_async(self, *args, **kwargs):
+            nonlocal override_calls
+            del self
+            override_calls += 1
+            async for event in original(*args, **kwargs):
+                yield event
+
+        runner.run_async = types.MethodType(instance_run_async, runner)
+
+    output = await _run_local_adk(
+        wrapped=True,
+        suffix="instance_override",
+        before_wrap=install_override,
+    )
+
+    assert output == "answer-instance_override"
+    assert override_calls == 1
+    assert any(
+        span.name == "google_adk.runner.run_async" for span in private_exporter.get_finished_spans()
     )
     assert not _semantic_spans(foreign_exporter)
 

--- a/tests/unit/test_openinference_isolation.py
+++ b/tests/unit/test_openinference_isolation.py
@@ -1,3 +1,6 @@
+import sys
+from types import ModuleType
+
 from openinference.instrumentation import OITracer, TraceConfig
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
@@ -130,3 +133,33 @@ def test_unmarked_openinference_tracer_keeps_standard_otel_behavior():
             )
     finally:
         provider.shutdown()
+
+
+def test_openinference_modules_importing_get_current_span_see_the_private_span():
+    private_provider, _ = _provider_with_exporter()
+    foreign_provider, _ = _provider_with_exporter()
+    set_neatlogs_provider(private_provider)
+    module_name = "openinference.instrumentation._neatlogs_test_getter"
+    adapter = ModuleType(module_name)
+    adapter.get_current_span = trace_api.get_current_span
+    sys.modules[module_name] = adapter
+
+    try:
+        oi_provider = provider_for_openinference(private_provider)
+        oi_tracer = OITracer(
+            oi_provider.get_tracer("openinference.instrumentation.imported-getter"),
+            TraceConfig(),
+        )
+        foreign_tracer = foreign_provider.get_tracer("foreign.imported-getter")
+
+        with foreign_tracer.start_as_current_span("foreign-root") as foreign_root:
+            with oi_tracer.start_as_current_span("private-root") as private_root:
+                assert trace_api.get_current_span() is foreign_root
+                assert adapter.get_current_span().get_span_context().span_id == (
+                    private_root.get_span_context().span_id
+                )
+    finally:
+        sys.modules.pop(module_name, None)
+        set_neatlogs_provider(None)
+        private_provider.shutdown()
+        foreign_provider.shutdown()


### PR DESCRIPTION
## Summary

- Route Google ADK instrumentation through the private Neatlogs OpenInference provider.
- Use the same provider path for automatic activation and explicit runner wrapping.
- Remove shared request-message state that could cross concurrent runs.
- Prevent duplicate semantic spans and restore installed instrumentation during shutdown.

## Why

ADK runs could produce the workflow wrapper while losing the expected agent, model, and tool child spans because framework instrumentation was not consistently bound to the SDK provider.

## Testing

- `uv run pytest -q`: 454 passed, 1 pre-existing skip
- Google ADK hierarchy, tools, errors, concurrency, masking, lifecycle, and duplicate-prevention tests passed
- Black and isort checks passed
- Wheel and source distribution built and passed `twine check`
- Clean Python 3.12 wheel import passed

## Merge note

This PR is independent, but it touches shared provider-isolation setup and may need a mechanical rebase if another provider-routing PR merges first.
