### PR TITLE
Route Strands telemetry through the SDK provider

### DIFF
--- a/neatlogs/client.py
+++ b/neatlogs/client.py
@@ -11,6 +11,7 @@ import atexit
 import contextlib
 import math
 import os
+import sys
 import threading
 import time
 from collections.abc import Iterator
@@ -53,6 +54,7 @@ from .core.upload_authority import (
 )
 from .core.upload_authority import uploads_enabled as resolve_uploads_enabled
 from .errors import NeatlogsConfigurationError
+from .instrumentation.preprocessing import ensure_provider_preprocessor
 from .version import __version__
 
 
@@ -153,6 +155,8 @@ class Client:
                 self.tracer_provider._resource = self.tracer_provider.resource.merge(resource)
             except Exception:
                 pass
+
+        ensure_provider_preprocessor(self.tracer_provider)
 
         self._span_processor = NeatlogsSpanProcessor(
             mask=mask,
@@ -399,6 +403,13 @@ class Client:
             )
             if not completed:
                 success = False
+        if "neatlogs.strands" in sys.modules:
+            try:
+                from .strands import release_strands
+
+                release_strands(self.tracer_provider, self)
+            except Exception:
+                pass
         if self._owns_provider:
             completed, _ = bounded_call(
                 self.tracer_provider.shutdown,

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -5,6 +5,7 @@ Neatlogs SDK.
 import atexit
 import functools
 import hashlib
+import importlib.util
 import json
 import math
 import os
@@ -90,6 +91,15 @@ _session_config = {
 def is_debug_enabled() -> bool:
     """Return True if neatlogs was initialized with debug=True."""
     return _debug_mode
+
+
+def _instrument_library(library: str) -> bool:
+    """Activate one library through the current default instrumentation manager."""
+    manager = _instrumentation_manager
+    if manager is None:
+        return False
+    manager.instrument(libraries=[library])
+    return library in manager.instrumented
 
 
 def _trace_sampler(sample_rate: float) -> ParentBased:
@@ -540,6 +550,19 @@ def init(
     from ._wrap_utils import set_neatlogs_provider
 
     set_neatlogs_provider(provider)
+
+    # Strands converts its native GenAI spans in an on_end processor. It must run
+    # before Neatlogs' normalizer and exporter see those spans.
+    if importlib.util.find_spec("strands") is not None:
+        try:
+            from .strands import instrument_strands, prepare_strands
+
+            prepare_strands(provider)
+            if instrumentations and "strands" in instrumentations:
+                instrument_strands(provider)
+        except Exception as exc:
+            if debug:
+                logger.debug("Could not prepare Strands instrumentation: %s", exc)
 
     # NeatlogsSpanProcessor: pure pre-processing (attribute normalization + file logging)
     global _span_processor

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -5,7 +5,6 @@ Neatlogs SDK.
 import atexit
 import functools
 import hashlib
-import importlib.util
 import json
 import math
 import os
@@ -51,6 +50,7 @@ from .core.upload_authority import (
 from .core.upload_authority import uploads_enabled as resolve_uploads_enabled
 from .errors import NeatlogsConfigurationError
 from .instrumentation.manager import InstrumentationManager
+from .instrumentation.preprocessing import ensure_provider_preprocessor
 from .version import __version__
 
 logger = get_logger()
@@ -550,16 +550,21 @@ def init(
     from ._wrap_utils import set_neatlogs_provider
 
     set_neatlogs_provider(provider)
+    ensure_provider_preprocessor(provider)
 
     # Strands converts its native GenAI spans in an on_end processor. It must run
-    # before Neatlogs' normalizer and exporter see those spans.
-    if importlib.util.find_spec("strands") is not None:
+    # before Neatlogs' normalizer and exporter see those spans, but only when
+    # Strands is explicitly selected.
+    strands_module = sys.modules.get("neatlogs.strands")
+    wrapped_strands_agents = bool(
+        strands_module is not None
+        and getattr(strands_module, "has_wrapped_agents", lambda: False)()
+    )
+    if (instrumentations and "strands" in instrumentations) or wrapped_strands_agents:
         try:
-            from .strands import instrument_strands, prepare_strands
+            from .strands import instrument_strands
 
-            prepare_strands(provider)
-            if instrumentations and "strands" in instrumentations:
-                instrument_strands(provider)
+            instrument_strands(provider)
         except Exception as exc:
             if debug:
                 logger.debug("Could not prepare Strands instrumentation: %s", exc)
@@ -1138,6 +1143,15 @@ def _perform_shutdown(
             logger.debug("Instrumentation cleanup failed or timed out: %s", result)
             success = False
         _instrumentation_manager = None
+
+    if "neatlogs.strands" in sys.modules:
+        try:
+            from .strands import release_default_strands
+
+            if tracer_provider is not None:
+                release_default_strands(tracer_provider)
+        except Exception:
+            pass
 
     # Drop the cached wrapper tracer (used by wrap()/trace processors like the
     # OpenAI Agents one) so the next init() rebinds it to the new provider. Also

--- a/neatlogs/instrumentation/manager.py
+++ b/neatlogs/instrumentation/manager.py
@@ -41,7 +41,9 @@ class InstrumentationManager:
 
     def instrument_threading(self) -> None:
         try:
-            ThreadingInstrumentor().instrument()
+            instrumentor = ThreadingInstrumentor()
+            if not instrumentor.is_instrumented_by_opentelemetry:
+                instrumentor.instrument()
             if self.debug:
                 logger.info("✅ Instrumented threading (context propagation)")
         except Exception as e:
@@ -147,6 +149,19 @@ class InstrumentationManager:
         if not self._is_library_installed(library):
             if self.debug:
                 logger.info(f"⏭️  Skipped: {library} (not installed)")
+            return
+
+        if library == "strands":
+            try:
+                from ..strands import instrument_strands
+
+                if instrument_strands(self.provider):
+                    self.instrumented.add(library)
+                    if self.debug:
+                        logger.info("✅ strands (native OpenTelemetry)")
+            except Exception as e:
+                if self.debug:
+                    logger.warning(f"⚠️  strands (native OpenTelemetry): {e}")
             return
 
         info = INSTRUMENTATION_REGISTRY["libraries"].get(library)
@@ -272,6 +287,14 @@ class InstrumentationManager:
         except Exception:
             pass
         for library in list(self.instrumented):
+            if library == "strands":
+                try:
+                    from ..strands import uninstrument_strands
+
+                    uninstrument_strands()
+                except Exception:
+                    pass
+                continue
             info = INSTRUMENTATION_REGISTRY["libraries"].get(library) or {}
             for convention in ("neatlogs", "openinference", "openllmetry"):
                 package_name = info.get(convention)

--- a/neatlogs/instrumentation/manager.py
+++ b/neatlogs/instrumentation/manager.py
@@ -288,12 +288,6 @@ class InstrumentationManager:
             pass
         for library in list(self.instrumented):
             if library == "strands":
-                try:
-                    from ..strands import uninstrument_strands
-
-                    uninstrument_strands()
-                except Exception:
-                    pass
                 continue
             info = INSTRUMENTATION_REGISTRY["libraries"].get(library) or {}
             for convention in ("neatlogs", "openinference", "openllmetry"):

--- a/neatlogs/instrumentation/preprocessing.py
+++ b/neatlogs/instrumentation/preprocessing.py
@@ -1,0 +1,107 @@
+"""Provider-local preprocessing that must run before Neatlogs export."""
+
+import threading
+import weakref
+from typing import Any
+
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.trace import Span
+
+_LOCK = threading.RLock()
+_HUBS: "weakref.WeakKeyDictionary[Any, ProviderPreprocessor]" = weakref.WeakKeyDictionary()
+
+
+class ProviderPreprocessor(SpanProcessor):
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._processors: dict[str, SpanProcessor] = {}
+
+    def add(self, key: str, processor: SpanProcessor) -> SpanProcessor:
+        with self._lock:
+            existing = self._processors.get(key)
+            if existing is not None:
+                processor.shutdown()
+                return existing
+            self._processors[key] = processor
+            return processor
+
+    def remove(self, key: str) -> None:
+        with self._lock:
+            processor = self._processors.pop(key, None)
+        if processor is not None:
+            processor.shutdown()
+
+    def _snapshot(self) -> tuple[SpanProcessor, ...]:
+        with self._lock:
+            return tuple(self._processors.values())
+
+    def is_empty(self) -> bool:
+        with self._lock:
+            return not self._processors
+
+    def on_start(self, span: Span, parent_context=None) -> None:
+        for processor in self._snapshot():
+            processor.on_start(span, parent_context)
+
+    def on_end(self, span: ReadableSpan) -> None:
+        for processor in self._snapshot():
+            processor.on_end(span)
+
+    def shutdown(self) -> None:
+        with self._lock:
+            processors = tuple(self._processors.values())
+            self._processors.clear()
+        for processor in processors:
+            processor.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        succeeded = True
+        for processor in self._snapshot():
+            if processor.force_flush(timeout_millis) is False:
+                succeeded = False
+        return succeeded
+
+
+def ensure_provider_preprocessor(provider: Any) -> ProviderPreprocessor:
+    with _LOCK:
+        existing = _HUBS.get(provider)
+        if existing is not None:
+            return existing
+        hub = ProviderPreprocessor()
+        multi = getattr(provider, "_active_span_processor", None)
+        processors = getattr(multi, "_span_processors", None)
+        lock = getattr(multi, "_lock", None)
+        if processors is None or lock is None:
+            if processors:
+                raise RuntimeError(
+                    "Cannot install provider preprocessing before existing processors"
+                )
+            provider.add_span_processor(hub)
+        else:
+            with lock:
+                multi._span_processors = (hub,) + tuple(multi._span_processors)
+        _HUBS[provider] = hub
+        return hub
+
+
+def add_provider_preprocessor(provider: Any, key: str, processor: SpanProcessor) -> SpanProcessor:
+    return ensure_provider_preprocessor(provider).add(key, processor)
+
+
+def remove_provider_preprocessor(provider: Any, key: str) -> None:
+    with _LOCK:
+        hub = _HUBS.get(provider)
+        if hub is None:
+            return
+        hub.remove(key)
+        if not hub.is_empty():
+            return
+        _HUBS.pop(provider, None)
+        multi = getattr(provider, "_active_span_processor", None)
+        processors = getattr(multi, "_span_processors", None)
+        lock = getattr(multi, "_lock", None)
+        if processors is not None and lock is not None:
+            with lock:
+                multi._span_processors = tuple(
+                    processor for processor in multi._span_processors if processor is not hub
+                )

--- a/neatlogs/instrumentation/registry.py
+++ b/neatlogs/instrumentation/registry.py
@@ -318,7 +318,7 @@ INSTRUMENTATION_REGISTRY = {
         },
         "strands": {
             "openllmetry": None,
-            "openinference": "openinference.instrumentation.strands",
+            "openinference": "openinference.instrumentation.strands_agents",
             "default_span_kind": "AGENT",
         },
         "pipecat": {

--- a/neatlogs/strands.py
+++ b/neatlogs/strands.py
@@ -1,188 +1,138 @@
-"""
-Neatlogs Strands Agents integration.
+"""Neatlogs integration for Strands Agents."""
 
-Usage:
-    >>> import neatlogs
-    >>> from strands import Agent
-    >>> neatlogs.init(api_key="...", workflow_name="...")   # registers the OTel tracer
-    >>> agent = neatlogs.strands_hooks(Agent(model=model))  # installs the I/O hook
-    >>> response = agent("Hello")
+import copy
+import threading
+import weakref
+from typing import Any, Optional
 
-The Strands Agents SDK emits its OWN OpenTelemetry spans (invoke_agent,
-execute_tool, model `chat` calls) as soon as a global tracer provider exists —
-which ``neatlogs.init()`` registers. Those spans flow into neatlogs automatically
-and the attribute mapper classifies them as AGENT / TOOL / LLM, with token usage
-from the gen_ai.usage.* attributes.
+from openinference.instrumentation.strands_agents import (
+    StrandsAgentsToOpenInferenceProcessor,
+)
 
-However, Strands puts prompt/response CONTENT on span EVENTS (gen_ai.user.message,
-gen_ai.system.message, gen_ai.choice, …) per the OTel GenAI convention — NOT on
-span attributes. neatlogs renders I/O from span attributes, so without help those
-native spans would show tokens but no input/output. ``strands_hooks()`` installs a
-single class-level hook on Strands' own ``Tracer._add_event`` chokepoint: whenever
-Strands records a gen_ai message/choice event, we ALSO set input.value/output.value
-(+ span kind) on the same span. We do NOT create our own spans — Strands' native
-tracing stays the source of truth; we only enrich it.
-"""
+from .instrumentation.openinference_isolation import provider_for_openinference
 
-from typing import Any
+_LOCK = threading.RLock()
+_ACTIVE_PROVIDER: Optional[Any] = None
+_ACTIVE_TRACER: Optional[Any] = None
+_PREVIOUS_TRACER: Optional[Any] = None
+_WRAPPED_AGENTS: list[tuple[Any, Any]] = []
+_PROVIDER_PROCESSORS: "weakref.WeakKeyDictionary[Any, Any]" = weakref.WeakKeyDictionary()
 
-from ._wrap_utils import serialize
 
-_HOOK_INSTALLED = False
+class _NeatlogsStrandsProcessor(StrandsAgentsToOpenInferenceProcessor):
+    def on_end(self, span: Any) -> None:
+        status = span.status
+        interrupted = bool(
+            (getattr(span, "attributes", None) or {}).get("neatlogs.trace.interrupted")
+        )
+        super().on_end(span)
+        if interrupted:
+            # The upstream converter marks non-error spans OK. An interrupted
+            # Neatlogs span deliberately retains the framework's prior status.
+            span._status = status
+
+
+def prepare_strands(provider: Any) -> bool:
+    """Install the Strands-to-OpenInference processor before export processors."""
+    with _LOCK:
+        try:
+            if provider in _PROVIDER_PROCESSORS:
+                return True
+        except TypeError:
+            pass
+
+        processor = _NeatlogsStrandsProcessor()
+        provider.add_span_processor(processor)
+        try:
+            _PROVIDER_PROCESSORS[provider] = processor
+        except TypeError:
+            pass
+    return True
+
+
+def instrument_strands(provider: Any) -> bool:
+    """Route future Strands agents through the current Neatlogs provider."""
+    from strands.telemetry import tracer as tracer_module
+    from strands.telemetry.tracer import Tracer
+
+    prepare_strands(provider)
+    oi_provider = provider_for_openinference(provider)
+
+    global _ACTIVE_PROVIDER, _ACTIVE_TRACER, _PREVIOUS_TRACER
+    with _LOCK:
+        if (
+            _ACTIVE_PROVIDER is provider
+            and _ACTIVE_TRACER is not None
+            and tracer_module._tracer_instance is _ACTIVE_TRACER
+        ):
+            return True
+
+        _restore_strands_locked(tracer_module)
+        previous = tracer_module._tracer_instance
+        tracer = copy.copy(previous) if previous is not None else Tracer()
+        tracer.tracer_provider = oi_provider
+        tracer.tracer = oi_provider.get_tracer(tracer.service_name)
+        tracer_module._tracer_instance = tracer
+
+        _PREVIOUS_TRACER = previous
+        _ACTIVE_TRACER = tracer
+        _ACTIVE_PROVIDER = provider
+    return True
 
 
 def strands_hooks(agent: Any) -> Any:
-    """
-    Install the Strands telemetry I/O hook (idempotent, class-level) and return the
-    agent unchanged. Strands self-instruments via native OTel; this hook only adds
-    input/output content (which Strands keeps on span events) to the span attributes
-    neatlogs renders.
-    """
-    _install_event_hook()
-    try:
-        setattr(agent, "_neatlogs_patched", True)
-    except Exception:
-        pass
+    """Route an existing Strands agent through Neatlogs and return it unchanged."""
+    from .init import _instrument_library
+
+    _instrument_library("strands")
+    with _LOCK:
+        tracer = _ACTIVE_TRACER
+        if tracer is not None and getattr(agent, "tracer", None) is not tracer:
+            _remember_agent(agent, getattr(agent, "tracer", None))
+            agent.tracer = tracer
+        try:
+            setattr(agent, "_neatlogs_patched", True)
+        except Exception:
+            pass
     return agent
 
 
-def _install_event_hook() -> None:
-    global _HOOK_INSTALLED
-    if _HOOK_INSTALLED:
-        return
+def uninstrument_strands() -> None:
+    """Restore the Strands singleton and explicitly wrapped agents."""
     try:
-        from strands.telemetry.tracer import Tracer
+        from strands.telemetry import tracer as tracer_module
     except Exception:
         return
 
-    orig_add_event = getattr(Tracer, "_add_event", None)
-    if orig_add_event is None or getattr(orig_add_event, "_neatlogs_wrapped", False):
-        _HOOK_INSTALLED = True
+    with _LOCK:
+        _restore_strands_locked(tracer_module)
+
+
+def _remember_agent(agent: Any, previous_tracer: Any) -> None:
+    for reference, _ in _WRAPPED_AGENTS:
+        if reference() is agent:
+            return
+    try:
+        reference = weakref.ref(agent)
+    except TypeError:
+        reference = lambda: agent
+    _WRAPPED_AGENTS.append((reference, previous_tracer))
+
+
+def _restore_strands_locked(tracer_module: Any) -> None:
+    global _ACTIVE_PROVIDER, _ACTIVE_TRACER, _PREVIOUS_TRACER
+    active = _ACTIVE_TRACER
+    if active is None:
         return
 
-    def patched_add_event(self, span, event_name, event_attributes=None, *args, **kwargs):
-        orig_add_event(self, span, event_name, event_attributes, *args, **kwargs)
-        try:
-            if span is None or not getattr(span, "is_recording", lambda: False)():
-                return
-            ev_attrs = event_attributes or {}
-            # Classify the span from strands' own gen_ai.operation.name (set at span
-            # creation): chat → llm, execute_tool → tool, invoke_agent → agent, else
-            # chain. We DON'T set neatlogs.span.kind (the mapper does that from the
-            # span name); we only use the op to write I/O under the RIGHT namespace,
-            # because the generic {span_kind}.input mapping can't resolve the kind in
-            # time for these natively-created spans.
-            op = ""
-            try:
-                op = str((span.attributes or {}).get("gen_ai.operation.name", "")).lower()
-            except Exception:
-                op = ""
-            is_tool = op == "execute_tool" or "gen_ai.tool.name" in (
-                getattr(span, "attributes", {}) or {}
-            )
-            in_key = "neatlogs.tool.input" if is_tool else None
-            out_key = "neatlogs.tool.output" if is_tool else None
+    if tracer_module._tracer_instance is active:
+        tracer_module._tracer_instance = _PREVIOUS_TRACER
 
-            # Input-side messages: gen_ai.{system,user,assistant,tool}.message
-            if event_name.startswith("gen_ai.") and event_name.endswith(".message"):
-                role = event_name[len("gen_ai.") : -len(".message")]
-                content = _strands_event_text(ev_attrs.get("content"))
-                if content:
-                    if is_tool:
-                        span.set_attribute("input.value", content)
-                        span.set_attribute("neatlogs.tool.input", content)
-                    else:
-                        _append_input_message(span, role, content)
-            # Output: gen_ai.choice (legacy) or the new latest-convention details event.
-            elif event_name in ("gen_ai.choice", "gen_ai.client.inference.operation.details"):
-                key = "message" if event_name == "gen_ai.choice" else "gen_ai.output.messages"
-                out = _strands_event_text(ev_attrs.get(key))
-                if out:
-                    span.set_attribute("output.value", out)
-                    if is_tool:
-                        span.set_attribute("neatlogs.tool.output", out)
-                    else:
-                        span.set_attribute("neatlogs.llm.output_messages.0.role", "assistant")
-                        span.set_attribute("neatlogs.llm.output_messages.0.content", out)
-                        span.set_attribute(
-                            "neatlogs.llm.output", serialize({"role": "assistant", "content": out})
-                        )
-        except Exception:
-            pass
-
-    patched_add_event._neatlogs_wrapped = True
-    Tracer._add_event = patched_add_event
-    _HOOK_INSTALLED = True
-
-
-# Per-span running index for input messages (kept on the span object itself so
-# concurrent spans don't collide).
-def _append_input_message(span: Any, role: str, content: str) -> None:
-    idx = getattr(span, "_neatlogs_in_idx", 0)
-    span.set_attribute(f"neatlogs.llm.input_messages.{idx}.role", role)
-    span.set_attribute(f"neatlogs.llm.input_messages.{idx}.content", content)
-    try:
-        setattr(span, "_neatlogs_in_idx", idx + 1)
-    except Exception:
-        pass
-    # Maintain a flat input.value blob (latest wins; cheap to overwrite).
-    existing = getattr(span, "_neatlogs_in_msgs", [])
-    existing.append({"role": role, "content": content})
-    try:
-        setattr(span, "_neatlogs_in_msgs", existing)
-    except Exception:
-        pass
-    blob = serialize({"messages": existing})
-    span.set_attribute("input.value", blob)
-    # Flat LLM input the backend reads directly (namespace-correct without relying
-    # on the {span_kind} mapping, which can't resolve the kind for native spans).
-    span.set_attribute("neatlogs.llm.input", blob)
-
-
-def _strands_event_text(content: Any) -> str:
-    """
-    Flatten Strands/Bedrock content into readable text. Content arrives as a JSON
-    string or list of blocks: [{"text": "..."}], [{"toolUse": {...}}],
-    [{"toolResult": {...}}], or [{"role","parts","finish_reason"}].
-    """
-    if content is None:
-        return ""
-    val = content
-    if isinstance(val, str):
-        s = val.strip()
-        if not (s.startswith("[") or s.startswith("{")):
-            return val  # already plain text
-        try:
-            import json
-
-            val = json.loads(s)
-        except Exception:
-            return val
-    return _flatten_blocks(val)
-
-
-def _flatten_blocks(val: Any) -> str:
-    out = []
-    items = val if isinstance(val, list) else [val]
-    for item in items:
-        if isinstance(item, str):
-            out.append(item)
-            continue
-        if not isinstance(item, dict):
-            out.append(str(item))
-            continue
-        if "text" in item:
-            out.append(str(item["text"]))
-        elif "toolUse" in item:
-            tu = item["toolUse"] or {}
-            out.append(f"{tu.get('name', 'tool')}({serialize(tu.get('input', {}))})")
-        elif "toolResult" in item:
-            tr = item["toolResult"] or {}
-            out.append(_flatten_blocks(tr.get("content", tr)))
-        elif "parts" in item:
-            out.append(_flatten_blocks(item["parts"]))
-        elif "content" in item:
-            out.append(_flatten_blocks(item["content"]))
-        else:
-            out.append(serialize(item))
-    return "\n".join(s for s in out if s)
+    for reference, previous in _WRAPPED_AGENTS:
+        agent = reference()
+        if agent is not None and getattr(agent, "tracer", None) is active:
+            agent.tracer = previous
+    _WRAPPED_AGENTS.clear()
+    _ACTIVE_PROVIDER = None
+    _ACTIVE_TRACER = None
+    _PREVIOUS_TRACER = None

--- a/neatlogs/strands.py
+++ b/neatlogs/strands.py
@@ -9,14 +9,23 @@ from openinference.instrumentation.strands_agents import (
     StrandsAgentsToOpenInferenceProcessor,
 )
 
+from ._wrap_utils import get_active_client, get_neatlogs_provider
 from .instrumentation.openinference_isolation import provider_for_openinference
+from .instrumentation.preprocessing import (
+    add_provider_preprocessor,
+    remove_provider_preprocessor,
+)
 
 _LOCK = threading.RLock()
-_ACTIVE_PROVIDER: Optional[Any] = None
-_ACTIVE_TRACER: Optional[Any] = None
+_DEFAULT_OWNER = object()
+_CONTEXTUAL_TRACER: Optional[Any] = None
 _PREVIOUS_TRACER: Optional[Any] = None
-_WRAPPED_AGENTS: list[tuple[Any, Any]] = []
+_WRAPPED_AGENTS: "weakref.WeakKeyDictionary[Any, tuple[Any, Any]]" = weakref.WeakKeyDictionary()
+_PROVIDER_TRACERS: "weakref.WeakKeyDictionary[Any, weakref.ReferenceType[Any]]" = (
+    weakref.WeakKeyDictionary()
+)
 _PROVIDER_PROCESSORS: "weakref.WeakKeyDictionary[Any, Any]" = weakref.WeakKeyDictionary()
+_PROVIDER_OWNERS: "weakref.WeakKeyDictionary[Any, set[Any]]" = weakref.WeakKeyDictionary()
 
 
 class _NeatlogsStrandsProcessor(StrandsAgentsToOpenInferenceProcessor):
@@ -27,74 +36,151 @@ class _NeatlogsStrandsProcessor(StrandsAgentsToOpenInferenceProcessor):
         )
         super().on_end(span)
         if interrupted:
-            # The upstream converter marks non-error spans OK. An interrupted
-            # Neatlogs span deliberately retains the framework's prior status.
             span._status = status
 
 
-def prepare_strands(provider: Any) -> bool:
-    """Install the Strands-to-OpenInference processor before export processors."""
-    with _LOCK:
-        try:
-            if provider in _PROVIDER_PROCESSORS:
-                return True
-        except TypeError:
-            pass
+class _ContextualStrandsTracer:
+    def __init__(self, fallback: Any) -> None:
+        self._fallback = fallback
 
-        processor = _NeatlogsStrandsProcessor()
-        provider.add_span_processor(processor)
-        try:
-            _PROVIDER_PROCESSORS[provider] = processor
-        except TypeError:
-            pass
+    def _current(self) -> Any:
+        provider = get_neatlogs_provider()
+        if provider is None:
+            if self._fallback is not None:
+                return self._fallback
+            from strands.telemetry.tracer import Tracer
+
+            return Tracer()
+        return _tracer_for_provider(provider, self._fallback)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._current(), name)
+
+
+def _current_owner() -> Any:
+    return get_active_client() or _DEFAULT_OWNER
+
+
+def prepare_strands(provider: Any, owner: Any = None) -> bool:
+    """Install Strands conversion before Neatlogs normalization and export."""
+    with _LOCK:
+        owner = _current_owner() if owner is None else owner
+        owners = _PROVIDER_OWNERS.setdefault(provider, set())
+        owners.add(owner)
+        if provider not in _PROVIDER_PROCESSORS:
+            processor = _NeatlogsStrandsProcessor()
+            installed = add_provider_preprocessor(provider, "strands", processor)
+            _PROVIDER_PROCESSORS[provider] = installed
     return True
 
 
-def instrument_strands(provider: Any) -> bool:
-    """Route future Strands agents through the current Neatlogs provider."""
-    from strands.telemetry import tracer as tracer_module
-    from strands.telemetry.tracer import Tracer
-
-    prepare_strands(provider)
-    oi_provider = provider_for_openinference(provider)
-
-    global _ACTIVE_PROVIDER, _ACTIVE_TRACER, _PREVIOUS_TRACER
+def _tracer_for_provider(provider: Any, fallback: Any = None) -> Any:
     with _LOCK:
-        if (
-            _ACTIVE_PROVIDER is provider
-            and _ACTIVE_TRACER is not None
-            and tracer_module._tracer_instance is _ACTIVE_TRACER
-        ):
-            return True
+        existing_ref = _PROVIDER_TRACERS.get(provider)
+        existing = existing_ref() if existing_ref is not None else None
+        if existing is not None:
+            prepare_strands(provider)
+            return existing
 
-        _restore_strands_locked(tracer_module)
-        previous = tracer_module._tracer_instance
-        tracer = copy.copy(previous) if previous is not None else Tracer()
+        from strands.telemetry.tracer import Tracer
+
+        prepare_strands(provider)
+        base = fallback if fallback is not None else _PREVIOUS_TRACER
+        tracer = copy.copy(base) if base is not None else Tracer()
+        oi_provider = provider_for_openinference(provider)
         tracer.tracer_provider = oi_provider
         tracer.tracer = oi_provider.get_tracer(tracer.service_name)
-        tracer_module._tracer_instance = tracer
+        _PROVIDER_TRACERS[provider] = weakref.ref(tracer)
+        return tracer
 
-        _PREVIOUS_TRACER = previous
-        _ACTIVE_TRACER = tracer
-        _ACTIVE_PROVIDER = provider
+
+def _ensure_contextual_tracer_locked() -> Any:
+    from strands.telemetry import tracer as tracer_module
+
+    global _CONTEXTUAL_TRACER, _PREVIOUS_TRACER
+    if _CONTEXTUAL_TRACER is None:
+        _PREVIOUS_TRACER = tracer_module._tracer_instance
+        _CONTEXTUAL_TRACER = _ContextualStrandsTracer(_PREVIOUS_TRACER)
+    if tracer_module._tracer_instance is not _CONTEXTUAL_TRACER:
+        tracer_module._tracer_instance = _CONTEXTUAL_TRACER
+    return _CONTEXTUAL_TRACER
+
+
+def instrument_strands(provider: Any, owner: Any = _DEFAULT_OWNER) -> bool:
+    """Route Strands telemetry through the provider active for each invocation."""
+    with _LOCK:
+        prepare_strands(provider, owner)
+        _ensure_contextual_tracer_locked()
+        for agent, (previous, current_owner) in list(_WRAPPED_AGENTS.items()):
+            if current_owner is None:
+                _WRAPPED_AGENTS[agent] = (previous, owner)
     return True
+
+
+def has_wrapped_agents() -> bool:
+    with _LOCK:
+        return bool(_WRAPPED_AGENTS)
 
 
 def strands_hooks(agent: Any) -> Any:
     """Route an existing Strands agent through Neatlogs and return it unchanged."""
-    from .init import _instrument_library
-
-    _instrument_library("strands")
     with _LOCK:
-        tracer = _ACTIVE_TRACER
-        if tracer is not None and getattr(agent, "tracer", None) is not tracer:
-            _remember_agent(agent, getattr(agent, "tracer", None))
+        tracer = _ensure_contextual_tracer_locked()
+        provider = get_neatlogs_provider()
+        owner = _current_owner() if provider is not None else None
+        if provider is not None:
+            prepare_strands(provider, owner)
+        try:
+            if agent not in _WRAPPED_AGENTS:
+                previous = getattr(agent, "tracer", None)
+                if previous is tracer:
+                    previous = _PREVIOUS_TRACER
+                _WRAPPED_AGENTS[agent] = (previous, owner)
+        except TypeError:
+            pass
+        if getattr(agent, "tracer", None) is not tracer:
             agent.tracer = tracer
         try:
             setattr(agent, "_neatlogs_patched", True)
         except Exception:
             pass
     return agent
+
+
+def release_strands(provider: Any, owner: Any) -> None:
+    try:
+        from strands.telemetry import tracer as tracer_module
+    except Exception:
+        return
+
+    global _CONTEXTUAL_TRACER, _PREVIOUS_TRACER
+    with _LOCK:
+        contextual = _CONTEXTUAL_TRACER
+        for agent, (previous, agent_owner) in list(_WRAPPED_AGENTS.items()):
+            if agent_owner is owner:
+                if getattr(agent, "tracer", None) is contextual:
+                    agent.tracer = previous
+                _WRAPPED_AGENTS.pop(agent, None)
+
+        owners = _PROVIDER_OWNERS.get(provider)
+        if owners is not None:
+            owners.discard(owner)
+            if not owners:
+                _PROVIDER_OWNERS.pop(provider, None)
+                _PROVIDER_TRACERS.pop(provider, None)
+                _PROVIDER_PROCESSORS.pop(provider, None)
+                remove_provider_preprocessor(provider, "strands")
+
+        if _PROVIDER_OWNERS or _WRAPPED_AGENTS:
+            return
+        if contextual is not None and tracer_module._tracer_instance is contextual:
+            tracer_module._tracer_instance = _PREVIOUS_TRACER
+        _CONTEXTUAL_TRACER = None
+        _PREVIOUS_TRACER = None
+
+
+def release_default_strands(provider: Any) -> None:
+    release_strands(provider, _DEFAULT_OWNER)
 
 
 def uninstrument_strands() -> None:
@@ -104,35 +190,19 @@ def uninstrument_strands() -> None:
     except Exception:
         return
 
+    global _CONTEXTUAL_TRACER, _PREVIOUS_TRACER
     with _LOCK:
-        _restore_strands_locked(tracer_module)
-
-
-def _remember_agent(agent: Any, previous_tracer: Any) -> None:
-    for reference, _ in _WRAPPED_AGENTS:
-        if reference() is agent:
-            return
-    try:
-        reference = weakref.ref(agent)
-    except TypeError:
-        reference = lambda: agent
-    _WRAPPED_AGENTS.append((reference, previous_tracer))
-
-
-def _restore_strands_locked(tracer_module: Any) -> None:
-    global _ACTIVE_PROVIDER, _ACTIVE_TRACER, _PREVIOUS_TRACER
-    active = _ACTIVE_TRACER
-    if active is None:
-        return
-
-    if tracer_module._tracer_instance is active:
-        tracer_module._tracer_instance = _PREVIOUS_TRACER
-
-    for reference, previous in _WRAPPED_AGENTS:
-        agent = reference()
-        if agent is not None and getattr(agent, "tracer", None) is active:
-            agent.tracer = previous
-    _WRAPPED_AGENTS.clear()
-    _ACTIVE_PROVIDER = None
-    _ACTIVE_TRACER = None
-    _PREVIOUS_TRACER = None
+        contextual = _CONTEXTUAL_TRACER
+        if contextual is not None and tracer_module._tracer_instance is contextual:
+            tracer_module._tracer_instance = _PREVIOUS_TRACER
+        for agent, (previous, _) in list(_WRAPPED_AGENTS.items()):
+            if getattr(agent, "tracer", None) is contextual:
+                agent.tracer = previous
+        _WRAPPED_AGENTS.clear()
+        _PROVIDER_TRACERS.clear()
+        for provider in list(_PROVIDER_PROCESSORS):
+            remove_provider_preprocessor(provider, "strands")
+        _PROVIDER_PROCESSORS.clear()
+        _PROVIDER_OWNERS.clear()
+        _CONTEXTUAL_TRACER = None
+        _PREVIOUS_TRACER = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dependencies = [
     "openinference-instrumentation-google-adk>=0.1.8",
     "openinference-instrumentation-autogen-agentchat>=0.1.6",
     "openinference-instrumentation-llama-index>=4.3.9",
+    "openinference-instrumentation-strands-agents>=0.1.7",
 ]
 
 [project.optional-dependencies]
@@ -173,6 +174,9 @@ vertex-ai = [
 ]
 autogen-agentchat = [
     "autogen-agentchat>=0.4.0",
+]
+strands = [
+    "strands-agents>=1.19.0",
 ]
 milvus = [
     # pymilvus and milvus-lite must be the same minor version to avoid a gRPC hang

--- a/tests/unit/test_strands_private_instrumentation.py
+++ b/tests/unit/test_strands_private_instrumentation.py
@@ -1,0 +1,370 @@
+import asyncio
+
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+import neatlogs
+
+pytest.importorskip("strands")
+pytest.importorskip("openinference.instrumentation.strands_agents")
+
+
+def _local_agent(
+    name: str,
+    *,
+    with_tool: bool = False,
+    fail: bool = False,
+    started: asyncio.Event | None = None,
+    release: asyncio.Event | None = None,
+):
+    from strands import Agent, tool
+    from strands.models.model import Model
+
+    class LocalModel(Model):
+        def __init__(self) -> None:
+            self.config = {"model_id": f"model-{name}", "context_window_limit": 8192}
+            self.calls = 0
+
+        def update_config(self, **model_config):
+            self.config.update(model_config)
+
+        def get_config(self):
+            return dict(self.config)
+
+        async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+            del tool_specs, system_prompt, kwargs
+            if self.calls == 0:
+                assert messages[-1]["content"][-1]["text"] == f"question-{name}"
+            self.calls += 1
+            if started is not None:
+                started.set()
+            if release is not None:
+                await release.wait()
+            if fail:
+                raise RuntimeError(f"model-failure-{name}")
+            yield {"messageStart": {"role": "assistant"}}
+            if with_tool and self.calls == 1:
+                yield {
+                    "contentBlockStart": {
+                        "start": {
+                            "toolUse": {
+                                "name": "lookup_temperature",
+                                "toolUseId": f"tool-{name}",
+                            }
+                        }
+                    }
+                }
+                yield {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"city":"Paris"}'}}}}
+                yield {"contentBlockStop": {}}
+                yield {"messageStop": {"stopReason": "tool_use"}}
+                yield {
+                    "metadata": {
+                        "usage": {"inputTokens": 9, "outputTokens": 1, "totalTokens": 10},
+                        "metrics": {"latencyMs": 1},
+                    }
+                }
+                return
+            yield {"contentBlockStart": {"start": {}}}
+            yield {"contentBlockDelta": {"delta": {"text": f"answer-{name}"}}}
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "end_turn"}}
+            yield {
+                "metadata": {
+                    "usage": {"inputTokens": 9, "outputTokens": 4, "totalTokens": 13},
+                    "metrics": {"latencyMs": 1},
+                }
+            }
+
+        async def structured_output(self, output_model, prompt, **kwargs):
+            del output_model, prompt, kwargs
+            raise NotImplementedError
+
+    @tool
+    def lookup_temperature(city: str) -> str:
+        """Return deterministic weather for one city."""
+        return f"{city}: 20 C"
+
+    return Agent(
+        model=LocalModel(),
+        name=f"agent-{name}",
+        callback_handler=None,
+        tools=[lookup_temperature] if with_tool else [],
+        retry_strategy=None,
+    )
+
+
+def _providers():
+    foreign_provider = TracerProvider()
+    foreign_exporter = InMemorySpanExporter()
+    foreign_provider.add_span_processor(SimpleSpanProcessor(foreign_exporter))
+    trace_api.set_tracer_provider(foreign_provider)
+
+    private_provider = TracerProvider()
+    private_exporter = InMemorySpanExporter()
+    return private_provider, private_exporter, foreign_provider, foreign_exporter
+
+
+def _semantic_spans(exporter):
+    return [
+        span
+        for span in exporter.get_finished_spans()
+        if span.attributes.get("openinference.span.kind") in {"AGENT", "CHAIN", "LLM", "TOOL"}
+    ]
+
+
+def test_automatic_strands_instrumentation_uses_the_private_provider():
+    private_provider, private_exporter, _, foreign_exporter = _providers()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=private_provider,
+        register_shutdown_handlers=False,
+    )
+    private_provider.add_span_processor(SimpleSpanProcessor(private_exporter))
+
+    result = _local_agent("automatic")("question-automatic")
+
+    assert str(result).strip() == "answer-automatic"
+    private_spans = _semantic_spans(private_exporter)
+    kinds = [span.attributes.get("openinference.span.kind") for span in private_spans]
+    assert kinds.count("AGENT") == 1
+    assert kinds.count("CHAIN") == 1
+    assert kinds.count("LLM") == 1
+    by_kind = {span.attributes.get("openinference.span.kind"): span for span in private_spans}
+    assert by_kind["AGENT"].parent is None
+    assert by_kind["CHAIN"].parent.span_id == by_kind["AGENT"].context.span_id
+    assert by_kind["LLM"].parent.span_id == by_kind["CHAIN"].context.span_id
+    assert by_kind["LLM"].attributes["input.value"] == "question-automatic"
+    assert "answer-automatic" in by_kind["LLM"].attributes["output.value"]
+    assert by_kind["LLM"].attributes["llm.token_count.total"] == 13
+    assert not _semantic_spans(foreign_exporter)
+
+
+def test_strands_tool_call_has_one_complete_private_tool_span():
+    private_provider, private_exporter, _, foreign_exporter = _providers()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=private_provider,
+        register_shutdown_handlers=False,
+    )
+    private_provider.add_span_processor(SimpleSpanProcessor(private_exporter))
+
+    result = _local_agent("tool", with_tool=True)("question-tool")
+
+    assert str(result).strip() == "answer-tool"
+    semantic = _semantic_spans(private_exporter)
+    tools = [span for span in semantic if span.attributes.get("openinference.span.kind") == "TOOL"]
+    llms = [span for span in semantic if span.attributes.get("openinference.span.kind") == "LLM"]
+    assert len(tools) == 1
+    assert len(llms) == 2
+    assert "Paris" in tools[0].attributes["input.value"]
+    assert "20 C" in tools[0].attributes["output.value"]
+    assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_strands_agents_keep_content_on_the_private_provider():
+    private_provider, private_exporter, _, foreign_exporter = _providers()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=private_provider,
+        register_shutdown_handlers=False,
+    )
+    private_provider.add_span_processor(SimpleSpanProcessor(private_exporter))
+    alpha = _local_agent("alpha")
+    beta = _local_agent("beta")
+
+    results = await asyncio.gather(
+        alpha.invoke_async("question-alpha"),
+        beta.invoke_async("question-beta"),
+    )
+
+    assert [str(result).strip() for result in results] == ["answer-alpha", "answer-beta"]
+    llms = [
+        span
+        for span in _semantic_spans(private_exporter)
+        if span.attributes.get("openinference.span.kind") == "LLM"
+    ]
+    assert len(llms) == 2
+    assert {span.attributes["input.value"] for span in llms} == {
+        "question-alpha",
+        "question-beta",
+    }
+    assert not _semantic_spans(foreign_exporter)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_strands_run_finishes_private_interrupted_spans():
+    private_provider, private_exporter, _, foreign_exporter = _providers()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=private_provider,
+        register_shutdown_handlers=False,
+    )
+    private_provider.add_span_processor(SimpleSpanProcessor(private_exporter))
+    started = asyncio.Event()
+    release = asyncio.Event()
+    agent = _local_agent("cancelled", started=started, release=release)
+    task = asyncio.create_task(agent.invoke_async("question-cancelled"))
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert neatlogs.shutdown(termination_reason="cancelled")
+    semantic = _semantic_spans(private_exporter)
+    assert {span.attributes.get("openinference.span.kind") for span in semantic} >= {
+        "AGENT",
+        "CHAIN",
+        "LLM",
+    }
+    assert all(span.status.status_code.name == "UNSET" for span in semantic)
+    assert all(span.attributes["neatlogs.trace.interrupted"] is True for span in semantic)
+    assert all(
+        span.attributes["neatlogs.trace.termination.reason"] == "cancelled" for span in semantic
+    )
+    assert not _semantic_spans(foreign_exporter)
+
+
+def test_strands_model_failure_is_exported_once_as_an_error():
+    private_provider, private_exporter, _, foreign_exporter = _providers()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=private_provider,
+        register_shutdown_handlers=False,
+    )
+    private_provider.add_span_processor(SimpleSpanProcessor(private_exporter))
+
+    with pytest.raises(RuntimeError, match="model-failure-error"):
+        _local_agent("error", fail=True)("question-error")
+
+    error_spans = [
+        span
+        for span in _semantic_spans(private_exporter)
+        if span.status.status_code.name == "ERROR"
+    ]
+    assert {span.attributes.get("openinference.span.kind") for span in error_spans} >= {
+        "AGENT",
+        "CHAIN",
+        "LLM",
+    }
+    assert not _semantic_spans(foreign_exporter)
+
+
+def test_repeated_strands_hooks_do_not_duplicate_semantic_spans():
+    private_provider, private_exporter, _, foreign_exporter = _providers()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=private_provider,
+        register_shutdown_handlers=False,
+    )
+    private_provider.add_span_processor(SimpleSpanProcessor(private_exporter))
+    agent = _local_agent("repeated")
+
+    assert neatlogs.strands_hooks(agent) is agent
+    assert neatlogs.strands_hooks(agent) is agent
+    result = agent("question-repeated")
+
+    assert str(result).strip() == "answer-repeated"
+    kinds = [
+        span.attributes.get("openinference.span.kind") for span in _semantic_spans(private_exporter)
+    ]
+    assert kinds.count("AGENT") == 1
+    assert kinds.count("CHAIN") == 1
+    assert kinds.count("LLM") == 1
+    assert not _semantic_spans(foreign_exporter)
+
+
+def test_precreated_strands_agent_is_redirected_when_explicitly_wrapped():
+    private_provider, private_exporter, _, foreign_exporter = _providers()
+    agent = _local_agent("precreated")
+    old_tracer = agent.tracer
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        tracer_provider=private_provider,
+        register_shutdown_handlers=False,
+    )
+    private_provider.add_span_processor(SimpleSpanProcessor(private_exporter))
+
+    assert neatlogs.strands_hooks(agent) is agent
+    result = agent("question-precreated")
+
+    assert str(result).strip() == "answer-precreated"
+    assert agent.tracer is not old_tracer
+    assert {
+        span.attributes.get("openinference.span.kind") for span in _semantic_spans(private_exporter)
+    } >= {
+        "AGENT",
+        "CHAIN",
+        "LLM",
+    }
+    assert not _semantic_spans(foreign_exporter)
+
+    assert neatlogs.shutdown()
+    from strands.telemetry import tracer as tracer_module
+
+    assert agent.tracer is old_tracer
+    assert tracer_module._tracer_instance is old_tracer
+
+
+def test_strands_shutdown_and_reinitialize_bind_to_the_new_private_provider():
+    first_provider, first_exporter, _, _ = _providers()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=first_provider,
+        register_shutdown_handlers=False,
+    )
+    first_provider.add_span_processor(SimpleSpanProcessor(first_exporter))
+    _local_agent("first")("question-first")
+    assert neatlogs.shutdown()
+
+    second_provider = TracerProvider()
+    second_exporter = InMemorySpanExporter()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=second_provider,
+        register_shutdown_handlers=False,
+    )
+    second_provider.add_span_processor(SimpleSpanProcessor(second_exporter))
+    _local_agent("second")("question-second")
+
+    assert (
+        len(
+            [
+                span
+                for span in _semantic_spans(first_exporter)
+                if span.attributes.get("openinference.span.kind") == "LLM"
+            ]
+        )
+        == 1
+    )
+    assert (
+        len(
+            [
+                span
+                for span in _semantic_spans(second_exporter)
+                if span.attributes.get("openinference.span.kind") == "LLM"
+            ]
+        )
+        == 1
+    )

--- a/tests/unit/test_strands_private_instrumentation.py
+++ b/tests/unit/test_strands_private_instrumentation.py
@@ -1,12 +1,26 @@
 import asyncio
+import gc
+import weakref
 
 import pytest
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 import neatlogs
+
+
+class _SnapshotExporter(SpanExporter):
+    def __init__(self):
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(
+            {"name": span.name, "attributes": dict(span.attributes or {})} for span in spans
+        )
+        return SpanExportResult.SUCCESS
+
 
 pytest.importorskip("strands")
 pytest.importorskip("openinference.instrumentation.strands_agents")
@@ -115,6 +129,20 @@ def _semantic_spans(exporter):
     ]
 
 
+def _processor_names(provider):
+    return [
+        type(processor).__name__ for processor in provider._active_span_processor._span_processors
+    ]
+
+
+def _llm_spans(exporter):
+    return [
+        span
+        for span in _semantic_spans(exporter)
+        if span.attributes.get("openinference.span.kind") == "LLM"
+    ]
+
+
 def test_automatic_strands_instrumentation_uses_the_private_provider():
     private_provider, private_exporter, _, foreign_exporter = _providers()
     neatlogs.init(
@@ -142,6 +170,176 @@ def test_automatic_strands_instrumentation_uses_the_private_provider():
     assert "answer-automatic" in by_kind["LLM"].attributes["output.value"]
     assert by_kind["LLM"].attributes["llm.token_count.total"] == 13
     assert not _semantic_spans(foreign_exporter)
+
+
+def test_strands_processors_are_installed_only_when_strands_is_selected():
+    unselected_provider, _, _, _ = _providers()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=[],
+        tracer_provider=unselected_provider,
+        register_shutdown_handlers=False,
+    )
+
+    assert "_NeatlogsStrandsProcessor" not in _processor_names(unselected_provider)
+
+    assert neatlogs.shutdown()
+    selected_provider = TracerProvider()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=selected_provider,
+        register_shutdown_handlers=False,
+    )
+
+    assert _processor_names(selected_provider)[:2] == [
+        "ProviderPreprocessor",
+        "NeatlogsSpanProcessor",
+    ]
+    hub = selected_provider._active_span_processor._span_processors[0]
+    assert type(hub._processors["strands"]).__name__ == "_NeatlogsStrandsProcessor"
+
+
+def test_active_client_routes_explicit_strands_wrap_to_client_provider():
+    default_provider, default_exporter, _, foreign_exporter = _providers()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=default_provider,
+        register_shutdown_handlers=False,
+    )
+    default_provider.add_span_processor(SimpleSpanProcessor(default_exporter))
+
+    client_provider = TracerProvider()
+    client_exporter = _SnapshotExporter()
+    client = neatlogs.Client(
+        api_key="client-key",
+        workflow_name="client-workflow",
+        disable_export=True,
+        tracer_provider=client_provider,
+    )
+    client_provider.add_span_processor(SimpleSpanProcessor(client_exporter))
+
+    with client.activate():
+        agent = neatlogs.strands_hooks(_local_agent("client"))
+        result = agent("question-client")
+
+    assert str(result).strip() == "answer-client"
+    client_llm = [
+        span
+        for span in client_exporter.spans
+        if span["attributes"].get("openinference.span.kind") == "LLM"
+    ]
+    assert len(client_llm) == 1
+    assert not _llm_spans(default_exporter)
+    assert not _semantic_spans(foreign_exporter)
+    assert client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_active_clients_keep_strands_spans_isolated():
+    default_provider, default_exporter, _, foreign_exporter = _providers()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=default_provider,
+        register_shutdown_handlers=False,
+    )
+    default_provider.add_span_processor(SimpleSpanProcessor(default_exporter))
+
+    first_provider = TracerProvider()
+    second_provider = TracerProvider()
+    first = neatlogs.Client(
+        api_key="first-key",
+        workflow_name="first-workflow",
+        disable_export=True,
+        tracer_provider=first_provider,
+    )
+    second = neatlogs.Client(
+        api_key="second-key",
+        workflow_name="second-workflow",
+        disable_export=True,
+        tracer_provider=second_provider,
+    )
+    first_exporter = InMemorySpanExporter()
+    second_exporter = InMemorySpanExporter()
+    first_provider.add_span_processor(SimpleSpanProcessor(first_exporter))
+    second_provider.add_span_processor(SimpleSpanProcessor(second_exporter))
+    first_agent = _local_agent("first-client")
+    second_agent = _local_agent("second-client")
+
+    async def invoke(client, agent, prompt):
+        with client.activate():
+            return await agent.invoke_async(prompt)
+
+    try:
+        results = await asyncio.gather(
+            invoke(first, first_agent, "question-first-client"),
+            invoke(second, second_agent, "question-second-client"),
+        )
+    finally:
+        first.shutdown()
+        second.shutdown()
+
+    assert [str(result).strip() for result in results] == [
+        "answer-first-client",
+        "answer-second-client",
+    ]
+    first_inputs = {span.attributes.get("input.value") for span in _llm_spans(first_exporter)}
+    second_inputs = {span.attributes.get("input.value") for span in _llm_spans(second_exporter)}
+    assert first_inputs == {"question-first-client"}
+    assert second_inputs == {"question-second-client"}
+    assert not _llm_spans(default_exporter)
+    assert not _semantic_spans(foreign_exporter)
+
+
+def test_strands_hooks_before_init_binds_when_neatlogs_initializes():
+    private_provider, private_exporter, _, foreign_exporter = _providers()
+    agent = _local_agent("deferred")
+    old_tracer = agent.tracer
+
+    assert neatlogs.strands_hooks(agent) is agent
+    assert agent.tracer is not old_tracer
+
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        tracer_provider=private_provider,
+        register_shutdown_handlers=False,
+    )
+    private_provider.add_span_processor(SimpleSpanProcessor(private_exporter))
+    result = agent("question-deferred")
+
+    assert str(result).strip() == "answer-deferred"
+    assert agent.tracer is not old_tracer
+    assert len(_llm_spans(private_exporter)) == 1
+    assert not _semantic_spans(foreign_exporter)
+
+
+def test_wrapped_strands_agent_retention_is_bounded_after_gc():
+    from neatlogs import strands as strands_module
+
+    private_provider, _, _, _ = _providers()
+    neatlogs.init(
+        api_key="test-key",
+        disable_export=True,
+        tracer_provider=private_provider,
+        register_shutdown_handlers=False,
+    )
+
+    agent = neatlogs.strands_hooks(_local_agent("gc"))
+    ref = weakref.ref(agent)
+    assert len(strands_module._WRAPPED_AGENTS) == 1
+
+    del agent
+    gc.collect()
+
+    assert ref() is None
+    assert len(strands_module._WRAPPED_AGENTS) == 0
 
 
 def test_strands_tool_call_has_one_complete_private_tool_span():
@@ -368,3 +566,110 @@ def test_strands_shutdown_and_reinitialize_bind_to_the_new_private_provider():
         )
         == 1
     )
+
+
+def test_default_shutdown_does_not_disable_a_live_client_strands_agent():
+    default_provider, _, _, _ = _providers()
+    neatlogs.init(
+        api_key="default-key",
+        disable_export=True,
+        instrumentations=["strands"],
+        tracer_provider=default_provider,
+        register_shutdown_handlers=False,
+    )
+
+    client_provider = TracerProvider()
+    client_exporter = _SnapshotExporter()
+    client_provider.add_span_processor(SimpleSpanProcessor(client_exporter))
+    client = neatlogs.Client(
+        api_key="client-key",
+        workflow_name="client-workflow",
+        disable_export=True,
+        tracer_provider=client_provider,
+    )
+    agent = _local_agent("live-client")
+    with client.activate():
+        neatlogs.strands_hooks(agent)
+        agent("question-live-client")
+
+    assert neatlogs.shutdown()
+
+    with client.activate():
+        agent("question-live-client")
+
+    llm_spans = [
+        span
+        for span in client_exporter.spans
+        if span["attributes"].get("openinference.span.kind") == "LLM"
+    ]
+    assert len(llm_spans) == 2
+    assert client.shutdown()
+
+
+def test_client_shutdown_removes_only_its_strands_state():
+    from strands.telemetry import tracer as tracer_module
+
+    from neatlogs import strands as strands_module
+
+    provider, _, _, _ = _providers()
+    exporter = _SnapshotExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    client = neatlogs.Client(
+        api_key="client-key",
+        workflow_name="client-workflow",
+        disable_export=True,
+        tracer_provider=provider,
+    )
+    agent = _local_agent("client-shutdown")
+    original_agent_tracer = agent.tracer
+    original_singleton = tracer_module._tracer_instance
+
+    with client.activate():
+        neatlogs.strands_hooks(agent)
+        agent("question-client-shutdown")
+
+    assert client.shutdown()
+    assert agent.tracer is original_agent_tracer
+    assert tracer_module._tracer_instance is original_singleton
+    assert provider not in strands_module._PROVIDER_PROCESSORS
+    assert provider not in strands_module._PROVIDER_TRACERS
+    assert provider not in strands_module._PROVIDER_OWNERS
+
+
+def test_strands_provider_tracer_cache_does_not_retain_provider():
+    from neatlogs import strands as strands_module
+
+    provider = TracerProvider(shutdown_on_exit=False)
+    tracer = strands_module._tracer_for_provider(provider)
+    provider_ref = weakref.ref(provider)
+
+    strands_module.release_default_strands(provider)
+    del tracer
+    del provider
+    gc.collect()
+
+    assert provider_ref() is None
+
+
+def test_strands_conversion_precedes_existing_provider_exporters():
+    provider = TracerProvider()
+    exporter = _SnapshotExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    client = neatlogs.Client(
+        api_key="client-key",
+        workflow_name="client-workflow",
+        disable_export=True,
+        tracer_provider=provider,
+    )
+    agent = _local_agent("existing-exporter")
+
+    with client.activate():
+        neatlogs.strands_hooks(agent)
+        agent("question-existing-exporter")
+
+    assert {span["attributes"].get("openinference.span.kind") for span in exporter.spans} >= {
+        "AGENT",
+        "CHAIN",
+        "LLM",
+    }
+    assert client.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -4287,6 +4287,7 @@ dependencies = [
     { name = "openinference-instrumentation-portkey" },
     { name = "openinference-instrumentation-pydantic-ai" },
     { name = "openinference-instrumentation-smolagents" },
+    { name = "openinference-instrumentation-strands-agents" },
     { name = "openinference-instrumentation-vertexai" },
     { name = "openinference-semantic-conventions" },
     { name = "opentelemetry-api", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-crewai'" },
@@ -4411,6 +4412,9 @@ pydantic-ai = [
 smolagents = [
     { name = "smolagents" },
 ]
+strands = [
+    { name = "strands-agents" },
+]
 vertex-ai = [
     { name = "google-genai" },
 ]
@@ -4500,6 +4504,7 @@ requires-dist = [
     { name = "openinference-instrumentation-portkey", specifier = ">=0.1.7" },
     { name = "openinference-instrumentation-pydantic-ai", specifier = ">=0.1.9" },
     { name = "openinference-instrumentation-smolagents", specifier = ">=0.1.21" },
+    { name = "openinference-instrumentation-strands-agents", specifier = ">=0.1.7" },
     { name = "openinference-instrumentation-vertexai", specifier = ">=0.1.11" },
     { name = "openinference-semantic-conventions", specifier = ">=0.1.13" },
     { name = "opentelemetry-api", specifier = ">=1.35.0" },
@@ -4518,9 +4523,10 @@ requires-dist = [
     { name = "qdrant-client", marker = "extra == 'langchain'", specifier = "<1.16" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "smolagents", marker = "extra == 'smolagents'", specifier = ">=1.0.0" },
+    { name = "strands-agents", marker = "extra == 'strands'", specifier = ">=1.19.0" },
     { name = "wrapt", specifier = ">=1.0.0" },
 ]
-provides-extras = ["azure-ai-inference", "openai", "azure-openai", "anthropic", "langchain", "langgraph", "crewai", "llama-index", "google-adk", "groq", "agno", "bedrock", "dspy", "litellm", "google-genai", "openai-agents", "guardrails", "haystack", "instructor", "mcp", "mistralai", "portkey", "pydantic-ai", "smolagents", "hermes", "vertexai", "vertex-ai", "autogen-agentchat", "milvus"]
+provides-extras = ["azure-ai-inference", "openai", "azure-openai", "anthropic", "langchain", "langgraph", "crewai", "llama-index", "google-adk", "groq", "agno", "bedrock", "dspy", "litellm", "google-genai", "openai-agents", "guardrails", "haystack", "instructor", "mcp", "mistralai", "portkey", "pydantic-ai", "smolagents", "hermes", "vertexai", "vertex-ai", "autogen-agentchat", "strands", "milvus"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5452,6 +5458,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openinference-instrumentation-strands-agents"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-crewai'" },
+    { name = "opentelemetry-api", version = "1.43.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-hermes' or extra != 'extra-8-neatlogs-crewai'" },
+    { name = "opentelemetry-sdk", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-crewai'" },
+    { name = "opentelemetry-sdk", version = "1.43.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-hermes' or extra != 'extra-8-neatlogs-crewai'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.63b1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-crewai'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.64b0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-hermes' or extra != 'extra-8-neatlogs-crewai'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/e5/5d04e5035afd547a1ef74bf7832ec5e8544c0555dc117dbda5cfadf6aa1c/openinference_instrumentation_strands_agents-0.1.7.tar.gz", hash = "sha256:c2fc10898bdf90ff662c18871ecf7577ccf19b42e81cc57f5507ba2db4525a26", size = 15556, upload-time = "2026-08-25T05:32:44.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/ae/54e2886fd21d8849dfdf684999a02317676b3c3c674fe2e89a690c5f2352/openinference_instrumentation_strands_agents-0.1.7-py3-none-any.whl", hash = "sha256:b2c8df548147105802caa17d5227f696d75098c1e7abc63aa56b2b000c184136", size = 17586, upload-time = "2026-08-25T05:32:42.386Z" },
+]
+
+[[package]]
 name = "openinference-instrumentation-vertexai"
 version = "0.1.18"
 source = { registry = "https://pypi.org/simple" }
@@ -5473,11 +5498,11 @@ wheels = [
 
 [[package]]
 name = "openinference-semantic-conventions"
-version = "0.1.32"
+version = "0.1.35"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/5e/13ffdb2ba436312cda9ed842ce3416fa5961e36a205df9a18a67eef7f9b3/openinference_semantic_conventions-0.1.32.tar.gz", hash = "sha256:2a3e6723ddce37abc5c43d38c6c7ac05b0f2efcfbe75cc0f135ab14ceb0730f7", size = 13980, upload-time = "2026-08-07T14:29:21.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/cd/1c26841447249b9fc402e342b9b3c042f8916b5abb485b8eb4e63ea6397c/openinference_semantic_conventions-0.1.35.tar.gz", hash = "sha256:b64864a5961fee7bf37d2e11491499baab223fac18efe671065dede55ccd5a3a", size = 14262, upload-time = "2026-09-04T20:16:04.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/19/2d096333313d45e5f87d08f903cedc3f7298c5690d2e6c4ef236dc22870e/openinference_semantic_conventions-0.1.32-py3-none-any.whl", hash = "sha256:d06c4716faf7537fbabbb6d34e758ec6b3650a18c037661782fc8c3e9fa90f81", size = 11252, upload-time = "2026-08-07T14:29:19.78Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/34/434cedb6f39b14e6eb8f203c33e97cee3907fc7f994d7c3cfcfbd4575787/openinference_semantic_conventions-0.1.35-py3-none-any.whl", hash = "sha256:a418df584fb3ec41d4214ac44562908f596df042c382d1445fafb26df2834cb2", size = 11484, upload-time = "2026-09-04T20:16:03.668Z" },
 ]
 
 [[package]]
@@ -8807,6 +8832,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "strands-agents"
+version = "1.54.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jsonschema" },
+    { name = "mcp", version = "1.28.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-crewai'" },
+    { name = "mcp", version = "1.29.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-hermes' or extra != 'extra-8-neatlogs-crewai'" },
+    { name = "opentelemetry-api", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-crewai'" },
+    { name = "opentelemetry-api", version = "1.43.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-hermes' or extra != 'extra-8-neatlogs-crewai'" },
+    { name = "opentelemetry-instrumentation-threading", version = "0.63b1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-crewai'" },
+    { name = "opentelemetry-instrumentation-threading", version = "0.64b0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-hermes' or extra != 'extra-8-neatlogs-crewai'" },
+    { name = "opentelemetry-sdk", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-crewai'" },
+    { name = "opentelemetry-sdk", version = "1.43.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-hermes' or extra != 'extra-8-neatlogs-crewai'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-crewai'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-neatlogs-hermes' or extra != 'extra-8-neatlogs-crewai'" },
+    { name = "pyyaml" },
+    { name = "typing-extensions" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/3d/1e38d7644293bc31405562807933a68bd734e75a269bf24ad94869f51915/strands_agents-1.54.0.tar.gz", hash = "sha256:8351ae5962a0cf51c0c8d6ae928752ab5331671603393aef9d267d1c435aa3c3", size = 1457826, upload-time = "2026-08-27T20:47:16.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a2/8bdc61000650649ae10e364698d88f3a4279155f834aefd1fb9ded7cf81b/strands_agents-1.54.0-py3-none-any.whl", hash = "sha256:ca37b9001531596a634e9249f97fb03ce70997e216f6a71d4e8f8182818cbf5c", size = 728301, upload-time = "2026-08-27T20:47:14.764Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Install the Strands OpenInference processor on the private Neatlogs tracer provider.
- Route the Strands tracer singleton and explicitly wrapped agents through that provider.
- Restore prior framework state on shutdown and avoid duplicate processors, hooks, and tracers.
- Cover pre-created agents, semantic hierarchy, concurrency, errors, lifecycle, and repeated wrapping.

## Why

Strands runs could retain the outer workflow while losing agent, chain, model, and tool child spans because native framework telemetry was not connected to the SDK provider.

## Testing

- `uv run pytest -q`: 452 passed, 1 pre-existing skip
- Black and isort checks passed
- Wheel and source distribution built and passed `twine check`
- Clean Python 3.12 wheel import passed
- The five Python fixes also passed together: 488 passed, 1 pre-existing skip

## Merge note

This PR is independent, but it touches shared instrumentation and dependency files and may need a mechanical rebase if another provider-routing PR merges first.
