### PR TITLE
fix(doctor): report actionable probe failures

### DIFF
--- a/neatlogs/doctor_v2.py
+++ b/neatlogs/doctor_v2.py
@@ -64,6 +64,11 @@ _REMEDIATION = {
     "CREDENTIAL_MISSING": "SET_CREDENTIAL",
     "AUTH_FAILED": "CHECK_INGEST_CREDENTIAL",
     "BACKEND_PROBE_UNAVAILABLE": "CHECK_TRACE_ENDPOINT",
+    "TRACE_READBACK_TIMEOUT": "WAIT_FOR_TRACE",
+    "INGESTION_PIPELINE_FAILED": "CONTACT_SUPPORT",
+    "BACKEND_HTTP_ERROR": "CHECK_TRACE_ENDPOINT",
+    "BACKEND_CONNECTION_FAILED": "CHECK_TRACE_ENDPOINT",
+    "TRACE_READBACK_INVALID": "CONTACT_SUPPORT",
     "ENDPOINT_INVALID": "SET_ENDPOINT",
     "PROVIDER_OWNERSHIP_AMBIGUOUS": "USE_PRIVATE_PROVIDER",
     "TRACE_ID_INVALID": "RECREATE_TRACE",
@@ -842,6 +847,18 @@ _SAFE_FAILURE_CODE = re.compile(r"^[A-Z0-9_]{1,64}$")
 _MAX_READBACK_BYTES = 1 << 20
 
 
+class _ProbeReadbackError(RuntimeError):
+    def __init__(
+        self,
+        reason_code: str,
+        message: str,
+        details: Mapping[str, str | bool] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.details = dict(details) if details else None
+
+
 def _ingestion_diagnostic_details(value: Any) -> dict[str, str | bool] | None:
     diagnostics = _record(_record(value).get("ingestionDiagnostics"))
     current_stage = diagnostics.get("currentStage")
@@ -1204,45 +1221,125 @@ def doctor_probe_v2(
         deadline = time.monotonic() + timeout_seconds
         trace_data: dict[str, Any] | None = None
         while time.monotonic() < deadline:
-            response = requests.get(
-                readback_url,
-                headers={"x-api-key": key, "x-neatlogs-doctor": "v1"},
-                timeout=min(5.0, max(0.1, deadline - time.monotonic())),
-                allow_redirects=False,
-                stream=True,
-            )
+            remaining = deadline - time.monotonic()
+            try:
+                response = requests.get(
+                    readback_url,
+                    headers={"x-api-key": key, "x-neatlogs-doctor": "v1"},
+                    timeout=min(5.0, max(0.001, remaining)),
+                    allow_redirects=False,
+                    stream=True,
+                )
+            except requests.Timeout as exc:
+                reason_code = (
+                    "TRACE_READBACK_TIMEOUT"
+                    if time.monotonic() >= deadline
+                    else "BACKEND_CONNECTION_FAILED"
+                )
+                raise _ProbeReadbackError(
+                    reason_code,
+                    (
+                        "Timed out waiting for the exact Doctor trace"
+                        if reason_code == "TRACE_READBACK_TIMEOUT"
+                        else "Could not connect to the existing trace read path"
+                    ),
+                    last_diagnostics,
+                ) from exc
+            except requests.RequestException as exc:
+                raise _ProbeReadbackError(
+                    "BACKEND_CONNECTION_FAILED",
+                    "Could not connect to the existing trace read path",
+                    last_diagnostics,
+                ) from exc
             if response.status_code in {401, 403}:
                 _close_response(response)
-                response.raise_for_status()
+                raise _ProbeReadbackError(
+                    "AUTH_FAILED",
+                    "The project key was rejected by the existing trace API",
+                )
             if 200 <= response.status_code < 300 and response.status_code != 202:
-                value = _bounded_response_json(response)
+                try:
+                    value = _bounded_response_json(response)
+                except (ValueError, TypeError, json.JSONDecodeError) as exc:
+                    raise _ProbeReadbackError(
+                        "TRACE_READBACK_INVALID",
+                        "Trace read-back returned an invalid response",
+                    ) from exc
                 if not isinstance(value, dict):
-                    raise ValueError("invalid trace read-back")
+                    raise _ProbeReadbackError(
+                        "TRACE_READBACK_INVALID",
+                        "Trace read-back returned an invalid response",
+                    )
                 trace_data = value
                 last_diagnostics = _ingestion_diagnostic_details(value)
                 break
             if response.status_code in {202, 404, 409}:
                 try:
                     value = _bounded_response_json(response)
-                except (ValueError, TypeError, json.JSONDecodeError):
+                except (ValueError, TypeError, json.JSONDecodeError) as exc:
+                    if response.status_code == 409:
+                        raise _ProbeReadbackError(
+                            "TRACE_READBACK_INVALID",
+                            "Trace read-back returned an invalid terminal receipt",
+                        ) from exc
                     value = None
                 current_diagnostics = _ingestion_diagnostic_details(value)
                 if response.status_code == 409:
-                    last_diagnostics = current_diagnostics
-                    response.raise_for_status()
+                    if (
+                        current_diagnostics is None
+                        or current_diagnostics["ingestion_state"] != "failed"
+                    ):
+                        raise _ProbeReadbackError(
+                            "TRACE_READBACK_INVALID",
+                            "Trace read-back returned an invalid terminal receipt",
+                        )
+                    raise _ProbeReadbackError(
+                        "INGESTION_PIPELINE_FAILED",
+                        "Trace ingestion reported a terminal pipeline failure",
+                        current_diagnostics,
+                    )
                 if current_diagnostics:
                     last_diagnostics = current_diagnostics
             else:
                 _close_response(response)
-                if 300 <= response.status_code < 400:
-                    raise requests.HTTPError(
-                        "trace read-back redirects are disabled", response=response
-                    )
-                response.raise_for_status()
+                raise _ProbeReadbackError(
+                    "BACKEND_HTTP_ERROR",
+                    "The existing trace read path returned an unexpected HTTP status",
+                    last_diagnostics if response.status_code >= 500 else None,
+                )
             time.sleep(min(1.0, max(0, deadline - time.monotonic())))
         if trace_data is None:
-            raise requests.Timeout("timed out waiting for exact Doctor trace")
+            raise _ProbeReadbackError(
+                "TRACE_READBACK_TIMEOUT",
+                "Timed out waiting for the exact Doctor trace",
+                last_diagnostics,
+            )
         return _persisted_probe_result(local, trace_data, last_diagnostics)
+    except _ProbeReadbackError as exc:
+        failure = {
+            "format_version": DOCTOR_V2_FORMAT_VERSION,
+            "mode": "probe",
+            "status": "fail",
+            "first_failure": exc.reason_code,
+            "runtime": {
+                "language": "python",
+                "sdk_version": __version__,
+                "schema_version": str(TELEMETRY_SCHEMA_VERSION),
+                "transport": "otlp_http_protobuf",
+            },
+            "checks": [
+                _check(
+                    "probe",
+                    "fail",
+                    exc.reason_code,
+                    str(exc),
+                    exc.details,
+                )
+            ],
+        }
+        if capture is not None:
+            failure["capture"] = capture
+        return failure
     except (
         requests.RequestException,
         RuntimeError,
@@ -1250,16 +1347,7 @@ def doctor_probe_v2(
         TypeError,
         json.JSONDecodeError,
     ) as exc:
-        error_response = getattr(exc, "response", None)
-        response_status = getattr(error_response, "status_code", None)
-        reason_code = (
-            "AUTH_FAILED" if response_status in {401, 403} else "BACKEND_PROBE_UNAVAILABLE"
-        )
-        retain_diagnostics = bool(
-            response_status == 409
-            or (isinstance(response_status, int) and response_status >= 500)
-            or (isinstance(exc, requests.RequestException) and response_status is None)
-        )
+        reason_code = "BACKEND_PROBE_UNAVAILABLE"
         failure = {
             "format_version": DOCTOR_V2_FORMAT_VERSION,
             "mode": "probe",
@@ -1276,12 +1364,7 @@ def doctor_probe_v2(
                     "probe",
                     "fail",
                     reason_code,
-                    (
-                        "The project key was rejected by the existing trace API"
-                        if reason_code == "AUTH_FAILED"
-                        else "The existing trace ingestion or read path is unavailable"
-                    ),
-                    last_diagnostics if retain_diagnostics else None,
+                    "The Doctor probe could not complete before trace read-back",
                 )
             ],
         }

--- a/neatlogs/doctor_v2.py
+++ b/neatlogs/doctor_v2.py
@@ -1285,10 +1285,23 @@ def doctor_probe_v2(
                     value = None
                 current_diagnostics = _ingestion_diagnostic_details(value)
                 if response.status_code == 409:
-                    if (
-                        current_diagnostics is None
-                        or current_diagnostics["ingestion_state"] != "failed"
-                    ):
+                    terminal_value = value if isinstance(value, dict) else {}
+                    if terminal_value.get("finalizationStatus") == "dlq":
+                        diagnostics_present = "ingestionDiagnostics" in terminal_value
+                        valid_terminal = (
+                            isinstance(terminal_value.get("error"), str)
+                            and (
+                                "message" not in terminal_value
+                                or isinstance(terminal_value["message"], str)
+                            )
+                            and (not diagnostics_present or current_diagnostics is not None)
+                        )
+                    else:
+                        valid_terminal = (
+                            current_diagnostics is not None
+                            and current_diagnostics["ingestion_state"] == "failed"
+                        )
+                    if not valid_terminal:
                         raise _ProbeReadbackError(
                             "TRACE_READBACK_INVALID",
                             "Trace read-back returned an invalid terminal receipt",

--- a/tests/unit/test_doctor_v2.py
+++ b/tests/unit/test_doctor_v2.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import json
+import time
 from pathlib import Path
 
 import requests
@@ -886,7 +887,7 @@ def test_probe_never_treats_processing_readback_as_success(monkeypatch):
         _exporter=exporter,
     )
     assert result["status"] == "fail"
-    assert result["first_failure"] == "BACKEND_PROBE_UNAVAILABLE"
+    assert result["first_failure"] == "TRACE_READBACK_TIMEOUT"
     assert result["checks"][-1]["details"] == {
         "ingestion_state": "processing",
         "current_stage": "raw_durable",
@@ -917,6 +918,7 @@ def test_probe_retains_safe_diagnostics_from_not_found_until_timeout(monkeypatch
         timeout_seconds=0.01,
         _exporter=exporter,
     )
+    assert result["first_failure"] == "TRACE_READBACK_TIMEOUT"
     assert result["checks"][-1]["details"] == {
         "ingestion_state": "processing",
         "current_stage": "raw_durable",
@@ -953,7 +955,7 @@ def test_probe_stops_on_terminal_stage_receipt_with_safe_details(monkeypatch):
         _exporter=exporter,
     )
     assert result["status"] == "fail"
-    assert result["first_failure"] == "BACKEND_PROBE_UNAVAILABLE"
+    assert result["first_failure"] == "INGESTION_PIPELINE_FAILED"
     assert result["checks"][-1]["details"] == {
         "ingestion_state": "failed",
         "current_stage": "pii_redaction",
@@ -1007,7 +1009,7 @@ def test_probe_refuses_cross_origin_redirect_without_forwarding_credentials(monk
         timeout_seconds=1,
         _exporter=exporter,
     )
-    assert result["first_failure"] == "BACKEND_PROBE_UNAVAILABLE"
+    assert result["first_failure"] == "BACKEND_HTTP_ERROR"
     assert len(calls) == 1
     assert calls[0][1]["allow_redirects"] is False
     assert calls[0][1]["stream"] is True
@@ -1015,7 +1017,12 @@ def test_probe_refuses_cross_origin_redirect_without_forwarding_credentials(monk
 
 
 def test_probe_caps_all_readback_status_bodies(monkeypatch):
-    for status_code in (200, 202, 409):
+    expected_reasons = {
+        200: "TRACE_READBACK_INVALID",
+        202: "TRACE_READBACK_TIMEOUT",
+        409: "TRACE_READBACK_INVALID",
+    }
+    for status_code, reason_code in expected_reasons.items():
         exporter = Exporter()
         oversized = json.dumps(
             {
@@ -1044,7 +1051,7 @@ def test_probe_caps_all_readback_status_bodies(monkeypatch):
             timeout_seconds=0.01,
             _exporter=exporter,
         )
-        assert result["first_failure"] == "BACKEND_PROBE_UNAVAILABLE"
+        assert result["first_failure"] == reason_code
         assert all("details" not in check for check in result["checks"])
 
 
@@ -1083,8 +1090,10 @@ def test_probe_success_uses_only_final_response_diagnostics(monkeypatch):
     assert all("details" not in check for check in result["checks"])
 
 
-def test_probe_retains_diagnostics_only_on_network_and_server_failures(monkeypatch):
-    for terminal in ("network", "server", "auth", "redirect", "client"):
+def test_probe_classifies_terminal_readback_failures_and_retains_only_safe_details(
+    monkeypatch,
+):
+    for terminal in ("network", "timeout", "server", "auth", "redirect", "client"):
         exporter = Exporter()
         calls = 0
 
@@ -1106,6 +1115,8 @@ def test_probe_retains_diagnostics_only_on_network_and_server_failures(monkeypat
                 )
             if terminal == "network":
                 raise requests.ConnectionError("network unavailable")
+            if terminal == "timeout":
+                raise requests.Timeout("request timed out")
             response = requests.Response()
             response.status_code = {
                 "auth": 403,
@@ -1126,6 +1137,17 @@ def test_probe_retains_diagnostics_only_on_network_and_server_failures(monkeypat
             _exporter=exporter,
         )
         failure = next(check for check in result["checks"] if check["status"] == "fail")
+        assert (
+            failure["reason_code"]
+            == {
+                "network": "BACKEND_CONNECTION_FAILED",
+                "timeout": "BACKEND_CONNECTION_FAILED",
+                "server": "BACKEND_HTTP_ERROR",
+                "auth": "AUTH_FAILED",
+                "redirect": "BACKEND_HTTP_ERROR",
+                "client": "BACKEND_HTTP_ERROR",
+            }[terminal]
+        )
         expected = (
             {
                 "ingestion_state": "processing",
@@ -1133,10 +1155,29 @@ def test_probe_retains_diagnostics_only_on_network_and_server_failures(monkeypat
                 "last_successful_stage": "kafka_published",
                 "retryable": False,
             }
-            if terminal in {"network", "server"}
+            if terminal in {"network", "timeout", "server"}
             else None
         )
         assert failure.get("details") == expected
+
+
+def test_probe_classifies_request_that_exhausts_deadline_as_readback_timeout(
+    monkeypatch,
+):
+    exporter = Exporter()
+
+    def get(*_args, **kwargs):
+        time.sleep(kwargs["timeout"])
+        raise requests.Timeout("request timed out")
+
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.get", get)
+    result = doctor_probe_v2(
+        api_key="local-key",
+        endpoint="http://localhost:4100",
+        timeout_seconds=0.01,
+        _exporter=exporter,
+    )
+    assert result["first_failure"] == "TRACE_READBACK_TIMEOUT"
 
 
 def test_probe_does_not_retain_stale_details_for_malformed_terminal_receipt(monkeypatch):
@@ -1169,6 +1210,7 @@ def test_probe_does_not_retain_stale_details_for_malformed_terminal_receipt(monk
         _exporter=exporter,
     )
     failure = next(check for check in reversed(result["checks"]) if check["status"] == "fail")
+    assert failure["reason_code"] == "TRACE_READBACK_INVALID"
     assert failure.get("details") is None
 
 

--- a/tests/unit/test_doctor_v2.py
+++ b/tests/unit/test_doctor_v2.py
@@ -968,6 +968,55 @@ def test_probe_stops_on_terminal_stage_receipt_with_safe_details(monkeypatch):
     assert "secret" not in json.dumps(result)
 
 
+def test_probe_classifies_dlq_without_optional_diagnostics_as_pipeline_failure(
+    monkeypatch,
+):
+    exporter = Exporter()
+
+    def get(*_args, **_kwargs):
+        return _json_response(
+            {
+                "error": "Trace processing failed",
+                "finalizationStatus": "dlq",
+                "message": "We couldn't finish preparing this trace. Please retry or contact support.",
+            },
+            409,
+        )
+
+    monkeypatch.setattr("neatlogs.doctor_v2.requests.get", get)
+    result = doctor_probe_v2(
+        api_key="local-key",
+        endpoint="http://localhost:4100",
+        timeout_seconds=1,
+        _exporter=exporter,
+    )
+
+    failure = next(check for check in result["checks"] if check["status"] == "fail")
+    assert result["first_failure"] == "INGESTION_PIPELINE_FAILED"
+    assert failure["reason_code"] == "INGESTION_PIPELINE_FAILED"
+    assert failure.get("details") is None
+
+
+def test_probe_rejects_dlq_without_required_error(monkeypatch):
+    exporter = Exporter()
+    monkeypatch.setattr(
+        "neatlogs.doctor_v2.requests.get",
+        lambda *_args, **_kwargs: _json_response(
+            {"finalizationStatus": "dlq"},
+            409,
+        ),
+    )
+
+    result = doctor_probe_v2(
+        api_key="local-key",
+        endpoint="http://localhost:4100",
+        timeout_seconds=1,
+        _exporter=exporter,
+    )
+
+    assert result["first_failure"] == "TRACE_READBACK_INVALID"
+
+
 def test_probe_ignores_unknown_or_malformed_stage_diagnostics(monkeypatch):
     exporter = Exporter()
 
@@ -1199,7 +1248,14 @@ def test_probe_does_not_retain_stale_details_for_malformed_terminal_receipt(monk
                 },
                 202,
             )
-        return _json_response({"ingestionDiagnostics": {"protocolVersion": "v2"}}, 409)
+        return _json_response(
+            {
+                "error": "Trace processing failed",
+                "finalizationStatus": "dlq",
+                "ingestionDiagnostics": {"protocolVersion": "v2"},
+            },
+            409,
+        )
 
     monkeypatch.setattr("neatlogs.doctor_v2.requests.get", get)
     monkeypatch.setattr("neatlogs.doctor_v2.time.sleep", lambda *_: None)


### PR DESCRIPTION
## What changed

- Classify authentication, timeout, pipeline, HTTP, connection, and invalid-readback failures separately.
- Preserve only allowlisted ingestion receipt fields in Doctor JSON.
- Return a direct remediation code and message for each failure.
- Reserve BACKEND_PROBE_UNAVAILABLE for failures that happen before trace readback can be classified.

## Why

Doctor previously collapsed most probe failures into BACKEND_PROBE_UNAVAILABLE. A user could not tell whether the project key failed, the trace was still processing, the pipeline reported a terminal failure, or the read API returned an invalid response.

The new result identifies the failed boundary without exposing response bodies, credentials, URLs, or server exception text.

## Compatibility

- Uses the existing POST /v1/traces ingestion route.
- Uses the existing GET /api/traces/v3/:traceId read route.
- Adds no endpoint, store, migration, or telemetry path.
- Keeps the Doctor v2 result contract and safe primitive details.

## Validation

- python -m neatlogs doctor --local --json: passed with four captured spans and successful flush.
- tests/unit/test_doctor_v2.py: 35 passed.
- Full Python suite: 454 passed.