### PR TITLE
fix: normalize telemetry schema digest across line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Keep the canonical telemetry contract byte-identical on every OS.
+# Without this, Windows checkouts (core.autocrlf=true) convert LF -> CRLF
+# and any raw SHA-256 check on the schema file fails.
+neatlogs/contracts/**/*.json text eol=lf

--- a/neatlogs/__init__.py
+++ b/neatlogs/__init__.py
@@ -79,6 +79,7 @@ from .schema_v2 import (
     TELEMETRY_SCHEMA_VERSION,
     telemetry_schema,
     telemetry_schema_bytes,
+    telemetry_schema_digest,
     verify_telemetry_schema,
 )
 from .version import __version__
@@ -352,5 +353,12 @@ __all__ = [
     "doctor_local_v2",
     "doctor_probe_v2",
     "doctor_semantic_digest",
+    "TELEMETRY_CONTRACT_VERSION",
+    "TELEMETRY_SCHEMA_SHA256",
+    "TELEMETRY_SCHEMA_VERSION",
+    "telemetry_schema",
+    "telemetry_schema_bytes",
+    "telemetry_schema_digest",
+    "verify_telemetry_schema",
     "__version__",
 ]

--- a/neatlogs/schema_v2.py
+++ b/neatlogs/schema_v2.py
@@ -9,7 +9,28 @@ from typing import Any
 
 TELEMETRY_CONTRACT_VERSION = "2.0.0"
 TELEMETRY_SCHEMA_VERSION = 2
+# Digest of the canonical schema bytes normalized to LF line endings. Git's
+# `core.autocrlf` (Windows) checks out the JSON with CRLF, which changes the
+# raw SHA-256 without changing any semantics — so all digest comparisons must
+# go through the normalized form. This value equals the LF blob hash.
 TELEMETRY_SCHEMA_SHA256 = "50bbd9f1e6eaa6c83f08dcb84da3a98867c962fc8c4e1edd629da561fe5fe5a8"
+
+
+def _normalize_schema_bytes(data: bytes) -> bytes:
+    """Normalize line endings so the digest is identical on every OS."""
+
+    return data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
+def telemetry_schema_digest(data: bytes | None = None) -> str:
+    """Return the canonical SHA-256 of the telemetry schema.
+
+    Normalizes CRLF/CR to LF before hashing so Windows checkouts
+    (`core.autocrlf=true`), LF checkouts, and sdists/wheels all agree.
+    """
+
+    raw = data if data is not None else telemetry_schema_bytes()
+    return hashlib.sha256(_normalize_schema_bytes(raw)).hexdigest()
 
 
 def telemetry_schema_bytes() -> bytes:
@@ -29,9 +50,12 @@ def telemetry_schema() -> dict[str, Any]:
 
 
 def verify_telemetry_schema() -> None:
-    """Fail if packaging or a local edit changed the frozen contract bytes."""
+    """Fail if packaging or a local edit changed the frozen contract bytes.
 
-    actual = hashlib.sha256(telemetry_schema_bytes()).hexdigest()
+    Compares the LF-normalized digest so the check is OS-independent.
+    """
+
+    actual = telemetry_schema_digest()
     if actual != TELEMETRY_SCHEMA_SHA256:
         raise RuntimeError(
             "NeatLogs telemetry schema v2 digest mismatch: "

--- a/tests/unit/test_telemetry_schema_v2.py
+++ b/tests/unit/test_telemetry_schema_v2.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 
 from jsonschema import Draft202012Validator
@@ -23,7 +22,10 @@ EXPECTED_PRECEDENCE = [
 def test_canonical_telemetry_schema_is_packaged_verbatim():
     schema_bytes = neatlogs.telemetry_schema_bytes()
 
-    assert hashlib.sha256(schema_bytes).hexdigest() == neatlogs.TELEMETRY_SCHEMA_SHA256
+    # Hash the LF-normalized form: Windows checkouts (core.autocrlf) store
+    # this file with CRLF, which must not count as a contract change.
+    assert neatlogs.telemetry_schema_digest(schema_bytes) == neatlogs.TELEMETRY_SCHEMA_SHA256
+    assert neatlogs.telemetry_schema_digest() == neatlogs.TELEMETRY_SCHEMA_SHA256
     assert json.loads(schema_bytes) == neatlogs.telemetry_schema()
     neatlogs.verify_telemetry_schema()
 


### PR DESCRIPTION
## Summary
Makes the telemetry schema v2 integrity check OS-independent by hashing LF-normalized bytes, updates the packaging test to use the normalized digest, and enforces LF checkouts for contract JSON via .gitattributes.

## Why
test_canonical_telemetry_schema_is_packaged_verbatim failed on Windows checkouts (core.autocrlf=true): the schema file is stored as CRLF on disk while TELEMETRY_SCHEMA_SHA256 pins the LF-blob hash, so the raw SHA-256 never matched despite identical semantics.

## Files affected
- neatlogs/schema_v2.py
- neatlogs/__init__.py
- tests/unit/test_telemetry_schema_v2.py
- .gitattributes

## Tests ran
- tests/unit/test_telemetry_schema_v2.py: 5 passed
- Full unit suite (pytest, tests/unit): 453 passed