### PR TITLE
fix: align standalone span roots

### DIFF
--- a/neatlogs/_wrap_utils.py
+++ b/neatlogs/_wrap_utils.py
@@ -421,32 +421,96 @@ class _NeatlogsSpanCM:
     children still nest under this span. Parent resolution and foreign-parent
     detachment come from the guard tracer, so the caller passes no ``context``."""
 
-    __slots__ = ("_tracer", "_name", "_kwargs", "_span", "_token")
+    __slots__ = (
+        "_tracer",
+        "_name",
+        "_kwargs",
+        "_span",
+        "_token",
+        "_auto_root_kind",
+        "_auto_root_initializer",
+        "_root",
+        "_root_token",
+    )
 
-    def __init__(self, tracer: otel_trace.Tracer, name: str, **start_kwargs: Any):
+    def __init__(
+        self,
+        tracer: otel_trace.Tracer,
+        name: str,
+        *,
+        auto_root_kind: Optional[str] = None,
+        auto_root_initializer: Optional[Callable[[otel_trace.Span], None]] = None,
+        **start_kwargs: Any,
+    ):
         self._tracer = tracer
         self._name = name
         self._kwargs = start_kwargs
         self._span: Optional[otel_trace.Span] = None
         self._token: Any = None
+        self._auto_root_kind = auto_root_kind
+        self._auto_root_initializer = auto_root_initializer
+        self._root: Optional[otel_trace.Span] = None
+        self._root_token: Any = None
+
+    @property
+    def has_auto_root(self) -> bool:
+        return self._root is not None
 
     def __enter__(self) -> otel_trace.Span:
-        self._span = self._tracer.start_span(self._name, **self._kwargs)
-        self._token = attach_as_current(self._span)
-        return self._span
+        if self._auto_root_kind and _should_auto_root(self._auto_root_kind):
+            self._root = self._tracer.start_span(
+                _resolve_root_workflow_name(),
+                attributes={"neatlogs.span.kind": "workflow", "neatlogs.auto_root": True},
+            )
+            apply_wrap_context_attributes(self._root, is_root=True)
+            if self._auto_root_initializer is not None:
+                try:
+                    self._auto_root_initializer(self._root)
+                except Exception:
+                    pass
+            self._root_token = attach_as_current(self._root)
+        try:
+            self._span = self._tracer.start_span(self._name, **self._kwargs)
+            self._token = attach_as_current(self._span)
+            return self._span
+        except Exception:
+            if self._root_token is not None:
+                detach(self._root_token)
+            if self._root is not None:
+                self._root.end()
+            raise
 
     def __exit__(self, exc_type, exc, tb) -> bool:
         if self._token is not None:
             detach(self._token)
-        if self._span is not None:
-            self._span.end()
+        try:
+            if self._span is not None:
+                self._span.end()
+        finally:
+            if self._root_token is not None:
+                detach(self._root_token)
+            if self._root is not None:
+                self._root.end()
         return False
 
 
-def neatlogs_span(scope: str, name: str, **start_kwargs: Any) -> "_NeatlogsSpanCM":
+def neatlogs_span(
+    scope: str,
+    name: str,
+    *,
+    _auto_root_kind: Optional[str] = None,
+    _auto_root_initializer: Optional[Callable[[otel_trace.Span], None]] = None,
+    **start_kwargs: Any,
+) -> "_NeatlogsSpanCM":
     """Open an internal neatlogs span (decorator / trace() block) that is safe in
     both default and isolated modes. See :class:`_NeatlogsSpanCM`."""
-    return _NeatlogsSpanCM(get_internal_tracer(scope), name, **start_kwargs)
+    return _NeatlogsSpanCM(
+        get_internal_tracer(scope),
+        name,
+        auto_root_kind=_auto_root_kind,
+        auto_root_initializer=_auto_root_initializer,
+        **start_kwargs,
+    )
 
 
 def _bootstrap_from_env(api_key: str) -> None:
@@ -675,11 +739,10 @@ def is_suppressed() -> bool:
 # Auto-root
 #
 # The backend only renders a trace once it contains a *parentless* span of a
-# root-eligible kind (WORKFLOW / CHAIN / AGENT / MCP_TOOL). Direct-provider
-# wrappers (openai, anthropic, bedrock, ...) only ever emit non-root spans
-# (llm / embedding / reranker / tool). So a bare ``client = neatlogs.wrap(...)``
-# call with no surrounding ``@span`` / ``trace()`` produces an orphan span and
-# the trace never renders.
+# root-eligible kind (WORKFLOW / CHAIN / AGENT / MCP_TOOL / LLM). Direct-provider
+# wrappers (openai, anthropic, bedrock, ...) may emit either root-eligible LLM
+# spans or non-root spans (embedding / reranker / tool). A bare non-root call
+# still needs a workflow parent so the trace can finalize.
 #
 # ``get_provider_tracer()`` returns a tracer facade used *only* by those
 # direct-provider wrappers: when a span would otherwise be parentless and is a
@@ -692,13 +755,22 @@ def is_suppressed() -> bool:
 
 # A parentless span of one of these kinds already satisfies the backend's
 # root requirement, so it must NOT be wrapped in another root.
-_ROOT_KINDS = frozenset({"workflow", "chain", "agent", "mcp_tool"})
+_ROOT_KINDS = frozenset({"workflow", "chain", "agent", "mcp_tool", "llm"})
 
 
 def _auto_root_enabled() -> bool:
     """Auto-root is on unless explicitly disabled via NEATLOGS_AUTO_ROOT."""
     val = os.environ.get("NEATLOGS_AUTO_ROOT", "").strip().lower()
     return val not in ("false", "0", "no", "off")
+
+
+def _should_auto_root(kind: str, *, explicit_context: bool = False) -> bool:
+    return (
+        _auto_root_enabled()
+        and str(kind or "").lower() not in _ROOT_KINDS
+        and not explicit_context
+        and not _has_active_recording_parent()
+    )
 
 
 def _resolve_root_workflow_name() -> str:
@@ -860,13 +932,9 @@ class _AutoRootTracer:
         tracer = object.__getattribute__(self, "_tracer")
         attributes = attributes or {}
         kind = str(attributes.get("neatlogs.span.kind", "")).lower()
+        is_parentless = "context" not in kwargs and not _has_active_recording_parent()
 
-        needs_root = (
-            _auto_root_enabled()
-            and kind not in _ROOT_KINDS
-            and "context" not in kwargs  # explicit-context callers opt out
-            and not _has_active_recording_parent()
-        )
+        needs_root = _should_auto_root(kind, explicit_context="context" in kwargs)
         if not needs_root:
             # A root-kind span (or auto-root disabled): still must not inherit a
             # FOREIGN active parent. If only a foreign span is active, detach so
@@ -876,7 +944,18 @@ class _AutoRootTracer:
                 foreign_kwargs = _neatlogs_root_kwargs()
                 if foreign_kwargs:
                     kwargs.update(foreign_kwargs)
-            return tracer.start_span(name=name, attributes=attributes, **kwargs)
+            span = tracer.start_span(name=name, attributes=attributes, **kwargs)
+            if is_parentless and kind in _ROOT_KINDS:
+                try:
+                    from .core.end_user import apply_end_user_attributes
+                    from .core.session import apply_session_attributes
+
+                    apply_wrap_context_attributes(span, is_root=True)
+                    apply_session_attributes(span, None, is_root=True)
+                    apply_end_user_attributes(span, None, None, is_root=True)
+                except Exception:
+                    pass
+            return span
 
         # If only a foreign span is active, start the auto-root in an empty context
         # so it doesn't inherit the foreign (non-neatlogs) parent.

--- a/neatlogs/core/context.py
+++ b/neatlogs/core/context.py
@@ -132,6 +132,9 @@ def trace(
     # in isolated mode.
     from .._wrap_utils import (
         _neatlogs_root_kwargs,
+        _resolve_root_workflow_name,
+        _should_auto_root,
+        apply_wrap_context_attributes,
         attach_as_current,
     )
     from .._wrap_utils import detach as _nl_detach
@@ -167,8 +170,6 @@ def trace(
     from .._wrap_utils import _has_active_recording_parent
 
     is_in_active_trace = _has_active_recording_parent()
-
-    should_create_root_trace = session_id and not is_in_active_trace
 
     template_string = None
     is_prompt_template_obj = False
@@ -238,14 +239,37 @@ def trace(
     is_root = not is_in_active_trace
     ctx_token = attach(ambient_ctx)
     stdout_ctx = _CaptureStdoutContext() if capture_stdout else None
-    span = tracer.start_span(name, context=parent_ctx)
+    span_kind = kind or "CHAIN"
+    auto_root = None
+    auto_root_token = None
+    if is_root and _should_auto_root(span_kind):
+        auto_root = tracer.start_span(
+            _resolve_root_workflow_name(),
+            context=parent_ctx,
+            attributes={"neatlogs.span.kind": "workflow", "neatlogs.auto_root": True},
+        )
+        apply_wrap_context_attributes(auto_root, is_root=True)
+        apply_session_attributes(auto_root, session_id, is_root=True)
+        apply_end_user_attributes(auto_root, end_user_id, end_user_metadata, is_root=True)
+        auto_root_token = attach_as_current(auto_root)
+        parent_ctx = otel_trace.set_span_in_context(auto_root, parent_ctx)
+    try:
+        span = tracer.start_span(name, context=parent_ctx)
+    except Exception:
+        if auto_root_token is not None:
+            _nl_detach(auto_root_token)
+        if auto_root is not None:
+            auto_root.end()
+        detach(ctx_token)
+        raise
     span_token = attach_as_current(span)
     try:
         logger.debug(f"[trace] Creating {'root' if is_root else 'child'} span '{name}'")
         _set_span_attributes(span, kind, template_string, prompt_variables, version, attributes)
         # Session/end-user belong to the trace root only.
-        apply_session_attributes(span, session_id, is_root=is_root)
-        apply_end_user_attributes(span, end_user_id, end_user_metadata, is_root=is_root)
+        span_is_root = is_root and auto_root is None
+        apply_session_attributes(span, session_id, is_root=span_is_root)
+        apply_end_user_attributes(span, end_user_id, end_user_metadata, is_root=span_is_root)
         if mask is not None:
             from .mask import register_mask
 
@@ -262,7 +286,13 @@ def trace(
                 stdout_ctx.__exit__(None, None, None)
     finally:
         _nl_detach(span_token)
-        span.end()
+        try:
+            span.end()
+        finally:
+            if auto_root_token is not None:
+                _nl_detach(auto_root_token)
+            if auto_root is not None:
+                auto_root.end()
         if is_prompt_template_obj:
             PromptContext.clear()
         if is_user_prompt_template_obj:

--- a/neatlogs/decorators/_base.py
+++ b/neatlogs/decorators/_base.py
@@ -211,6 +211,13 @@ def _decorate_span(
         code_attrs = _capture_code_attrs(func)
         merged_attrs = {**code_attrs, **(attributes or {})}
 
+        def _initialize_auto_root(root: Any) -> None:
+            from ..core.end_user import apply_end_user_attributes
+            from ..core.session import apply_session_attributes
+
+            apply_session_attributes(root, session_id, is_root=True)
+            apply_end_user_attributes(root, end_user_id, end_user_metadata, is_root=True)
+
         def _prepare_stream_span(span, args, kwargs, *, is_root: bool):
             from ..core.end_user import apply_end_user_attributes
             from ..core.mask import register_mask
@@ -284,8 +291,20 @@ def _decorate_span(
                 from ..core.log import _CaptureStdoutContext
 
                 is_root = _is_root_span()
-                with neatlogs_span(__name__, span_name, kind=otel_trace.SpanKind.INTERNAL) as span:
-                    bound_inputs = _prepare_stream_span(span, args, kwargs, is_root=is_root)
+                span_context = neatlogs_span(
+                    __name__,
+                    span_name,
+                    kind=otel_trace.SpanKind.INTERNAL,
+                    _auto_root_kind=openinference_kind,
+                    _auto_root_initializer=_initialize_auto_root,
+                )
+                with span_context as span:
+                    bound_inputs = _prepare_stream_span(
+                        span,
+                        args,
+                        kwargs,
+                        is_root=is_root and not span_context.has_auto_root,
+                    )
                     chunks: list[Any] = []
                     stdout_ctx = _CaptureStdoutContext() if capture_stdout else None
                     if stdout_ctx:
@@ -328,8 +347,20 @@ def _decorate_span(
                 from ..core.log import _CaptureStdoutContext
 
                 is_root = _is_root_span()
-                with neatlogs_span(__name__, span_name, kind=otel_trace.SpanKind.INTERNAL) as span:
-                    bound_inputs = _prepare_stream_span(span, args, kwargs, is_root=is_root)
+                span_context = neatlogs_span(
+                    __name__,
+                    span_name,
+                    kind=otel_trace.SpanKind.INTERNAL,
+                    _auto_root_kind=openinference_kind,
+                    _auto_root_initializer=_initialize_auto_root,
+                )
+                with span_context as span:
+                    bound_inputs = _prepare_stream_span(
+                        span,
+                        args,
+                        kwargs,
+                        is_root=is_root and not span_context.has_auto_root,
+                    )
                     chunks: list[Any] = []
                     stdout_ctx = _CaptureStdoutContext() if capture_stdout else None
                     if stdout_ctx:
@@ -375,7 +406,14 @@ def _decorate_span(
                 from ..core.session import apply_session_attributes
 
                 is_root = _is_root_span()
-                with neatlogs_span(__name__, span_name, kind=otel_trace.SpanKind.INTERNAL) as span:
+                span_context = neatlogs_span(
+                    __name__,
+                    span_name,
+                    kind=otel_trace.SpanKind.INTERNAL,
+                    _auto_root_kind=openinference_kind,
+                    _auto_root_initializer=_initialize_auto_root,
+                )
+                with span_context as span:
                     _set_common_span_attrs(
                         span,
                         openinference_kind=openinference_kind,
@@ -386,8 +424,14 @@ def _decorate_span(
                         attributes=merged_attrs,
                     )
                     # Session/end-user belong to the trace root only.
-                    apply_session_attributes(span, session_id, is_root=is_root)
-                    apply_end_user_attributes(span, end_user_id, end_user_metadata, is_root=is_root)
+                    span_is_root = is_root and not span_context.has_auto_root
+                    apply_session_attributes(span, session_id, is_root=span_is_root)
+                    apply_end_user_attributes(
+                        span,
+                        end_user_id,
+                        end_user_metadata,
+                        is_root=span_is_root,
+                    )
                     if mask is not None:
                         span.set_attribute("neatlogs.mask_id", register_mask(mask))
                     if description:
@@ -439,7 +483,14 @@ def _decorate_span(
             from ..core.session import apply_session_attributes
 
             is_root = _is_root_span()
-            with neatlogs_span(__name__, span_name, kind=otel_trace.SpanKind.INTERNAL) as span:
+            span_context = neatlogs_span(
+                __name__,
+                span_name,
+                kind=otel_trace.SpanKind.INTERNAL,
+                _auto_root_kind=openinference_kind,
+                _auto_root_initializer=_initialize_auto_root,
+            )
+            with span_context as span:
                 _set_common_span_attrs(
                     span,
                     openinference_kind=openinference_kind,
@@ -450,8 +501,14 @@ def _decorate_span(
                     attributes=merged_attrs,
                 )
                 # Session/end-user belong to the trace root only.
-                apply_session_attributes(span, session_id, is_root=is_root)
-                apply_end_user_attributes(span, end_user_id, end_user_metadata, is_root=is_root)
+                span_is_root = is_root and not span_context.has_auto_root
+                apply_session_attributes(span, session_id, is_root=span_is_root)
+                apply_end_user_attributes(
+                    span,
+                    end_user_id,
+                    end_user_metadata,
+                    is_root=span_is_root,
+                )
                 if mask is not None:
                     span.set_attribute("neatlogs.mask_id", register_mask(mask))
                 if description:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neatlogs"
-version = "1.4.21"
+version = "1.4.22"
 description = "A Python package for extracting and managing LLM logs to build a collaborative workspace"
 readme = "README.MD"
 license = {text = "MIT"}

--- a/tests/unit/test_code_params_capture.py
+++ b/tests/unit/test_code_params_capture.py
@@ -14,6 +14,7 @@ import pytest
 from opentelemetry import trace
 
 from neatlogs._wrap_utils import set_neatlogs_provider
+from neatlogs.core.context import trace as neatlogs_trace
 from neatlogs.decorators._base import _decorate_span
 from neatlogs.decorators.orchestration import span as neatlogs_span
 
@@ -33,6 +34,10 @@ def _install(tracer_provider):
     set_neatlogs_provider(tracer_provider)
 
 
+def _semantic_span(spans, kind):
+    return next(span for span in spans if span.attributes.get("openinference.span.kind") == kind)
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -48,7 +53,8 @@ def test_semantic_span_kinds_auto_capture_io(kind, tracer_provider, in_memory_sp
 
     assert semantic_stage("evidence") == {"seen": "evidence"}
 
-    [finished] = in_memory_span_exporter.get_finished_spans()
+    spans = in_memory_span_exporter.get_finished_spans()
+    finished = _semantic_span(spans, kind)
     attrs = finished.attributes
     assert attrs["neatlogs.span.kind"] == kind.lower()
     assert "evidence" in attrs["input.value"]
@@ -65,8 +71,7 @@ def test_sync_decorator_sets_code_file_path(tracer_provider, in_memory_span_expo
     my_function()
 
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    attrs = spans[0].attributes
+    attrs = _semantic_span(spans, "CHAIN").attributes
     assert "code.file.path" in attrs
     assert Path(attrs["code.file.path"]).name == Path(__file__).name
 
@@ -81,8 +86,7 @@ def test_sync_decorator_sets_code_function_name(tracer_provider, in_memory_span_
     my_tool_function()
 
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    attrs = spans[0].attributes
+    attrs = _semantic_span(spans, "TOOL").attributes
     assert (
         attrs.get("code.function.name")
         == "test_sync_decorator_sets_code_function_name.<locals>.my_tool_function"
@@ -103,8 +107,7 @@ def test_sync_decorator_sets_code_line_number(tracer_provider, in_memory_span_ex
     my_agent()
 
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    attrs = spans[0].attributes
+    attrs = _semantic_span(spans, "AGENT").attributes
     assert attrs["code.line.number"] == expected_lineno
 
 
@@ -118,8 +121,7 @@ def test_sync_decorator_sets_code_namespace(tracer_provider, in_memory_span_expo
     my_workflow()
 
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    attrs = spans[0].attributes
+    attrs = _semantic_span(spans, "WORKFLOW").attributes
     assert attrs.get("code.namespace") == __name__
 
 
@@ -133,8 +135,7 @@ def test_async_decorator_sets_code_attributes(tracer_provider, in_memory_span_ex
     asyncio.run(my_async_function())
 
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    attrs = spans[0].attributes
+    attrs = _semantic_span(spans, "CHAIN").attributes
     assert "code.file.path" in attrs
     assert "code.function.name" in attrs
     assert "code.line.number" in attrs
@@ -152,8 +153,7 @@ def test_caller_attributes_preserved_alongside_code_attrs(tracer_provider, in_me
     my_tool()
 
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    attrs = spans[0].attributes
+    attrs = _semantic_span(spans, "TOOL").attributes
     assert attrs.get("custom.key") == "custom_value"
     # code attrs are also present
     assert "code.file.path" in attrs
@@ -178,8 +178,7 @@ def test_user_supplied_code_attrs_take_precedence(tracer_provider, in_memory_spa
     my_tool()
 
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    attrs = spans[0].attributes
+    attrs = _semantic_span(spans, "TOOL").attributes
     assert attrs.get("code.file.path") == "user_provided_path.py"
     assert attrs.get("code.function.name") == "user_provided_name"
     assert attrs.get("code.namespace") == "user.provided.namespace"
@@ -234,13 +233,64 @@ def test_stacked_decorator_reports_inner_function_location(
     inner_tool()
 
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    attrs = spans[0].attributes
+    attrs = _semantic_span(spans, "TOOL").attributes
     # File path should be this test file, not functools / some decorator module.
     assert Path(attrs["code.file.path"]).name == Path(__file__).name
     assert attrs["code.function.name"].endswith("inner_tool")
     assert attrs["code.namespace"] == __name__
     assert attrs["code.line.number"] == expected_lineno
+
+
+def test_parentless_tool_gets_one_root_with_identity(tracer_provider, in_memory_span_exporter):
+    _install(tracer_provider)
+
+    @neatlogs_span(kind="TOOL", session_id="session-1")
+    def standalone_tool():
+        return "done"
+
+    assert standalone_tool() == "done"
+    spans = in_memory_span_exporter.get_finished_spans()
+    tool = _semantic_span(spans, "TOOL")
+    root = next(span for span in spans if span.attributes.get("neatlogs.auto_root") is True)
+
+    assert tool.parent.span_id == root.context.span_id
+    assert root.attributes["neatlogs.session.id"] == "session-1"
+    assert "neatlogs.session.id" not in tool.attributes
+
+
+def test_parentless_llm_remains_the_backend_supported_root(
+    tracer_provider, in_memory_span_exporter
+):
+    _install(tracer_provider)
+
+    @_decorate_span(openinference_kind="LLM")
+    def standalone_llm():
+        return "done"
+
+    standalone_llm()
+    spans = in_memory_span_exporter.get_finished_spans()
+
+    assert len(spans) == 1
+    assert spans[0].parent is None
+    assert spans[0].attributes["openinference.span.kind"] == "LLM"
+    assert "neatlogs.auto_root" not in spans[0].attributes
+
+
+def test_parentless_tool_context_gets_one_root_with_identity(
+    tracer_provider, in_memory_span_exporter
+):
+    _install(tracer_provider)
+
+    with neatlogs_trace("standalone.tool", kind="TOOL", session_id="session-2"):
+        pass
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    tool = _semantic_span(spans, "TOOL")
+    root = next(span for span in spans if span.attributes.get("neatlogs.auto_root") is True)
+
+    assert tool.parent.span_id == root.context.span_id
+    assert root.attributes["neatlogs.session.id"] == "session-2"
+    assert "neatlogs.session.id" not in tool.attributes
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_session_identity.py
+++ b/tests/unit/test_session_identity.py
@@ -131,7 +131,7 @@ def test_identify_context_stamps_root(tracer_provider, in_memory_span_exporter):
     assert root.attributes.get(END_USER_ID_KEY) == "ctx_user"
 
 
-def test_wrap_context_stamps_workflow_metadata_on_auto_root(
+def test_wrap_context_stamps_workflow_metadata_on_llm_root(
     tracer_provider, in_memory_span_exporter
 ):
     _install(tracer_provider)
@@ -167,9 +167,10 @@ def test_wrap_context_stamps_workflow_metadata_on_auto_root(
         )
 
     spans = in_memory_span_exporter.get_finished_spans()
-    root = next(s for s in spans if s.attributes.get("neatlogs.auto_root") is True)
+    root = next(s for s in spans if s.parent is None)
 
-    assert root.name == "workflow"
+    assert root.attributes.get("neatlogs.span.kind") == "llm"
+    assert "neatlogs.auto_root" not in root.attributes
     assert "neatlogs.workflow_name" not in root.attributes
     assert root.attributes.get("neatlogs.workflow.workflow_name") == "Copilot chat"
     assert root.attributes.get("neatlogs.workflow.project_id") == "project_123"

--- a/uv.lock
+++ b/uv.lock
@@ -4258,7 +4258,7 @@ wheels = [
 
 [[package]]
 name = "neatlogs"
-version = "1.4.21"
+version = "1.4.22"
 source = { editable = "." }
 dependencies = [
     { name = "agnost" },


### PR DESCRIPTION
## Summary

- keep parentless LLM calls as meaningful roots instead of adding a blank workflow
- give standalone non-root manual spans and decorators exactly one workflow root
- preserve workflow, session, and end-user metadata on the actual root
- bump the SDK patch version to 1.4.22

## Validation

- full unit suite: 450 passed, 1 skipped
- Black and isort checks passed
- sdist and wheel build passed