### PR TITLE
Propagate managed prompt identity to provider LLM spans

### DIFF
--- a/neatlogs/config/attribute-mapping.json
+++ b/neatlogs/config/attribute-mapping.json
@@ -313,13 +313,6 @@
             "target": "neatlogs.llm.response_id"
           },
           "prompt_template": {
-            "name": {
-              "sources": [
-                "neatlogs.llm.prompt_template.name",
-                "llm.prompt_template.name"
-              ],
-              "target": "neatlogs.llm.prompt_template.name"
-            },
             "template": {
               "sources": [
                 "neatlogs.prompt.template",

--- a/neatlogs/config/attribute-mapping.json
+++ b/neatlogs/config/attribute-mapping.json
@@ -313,6 +313,13 @@
             "target": "neatlogs.llm.response_id"
           },
           "prompt_template": {
+            "name": {
+              "sources": [
+                "neatlogs.llm.prompt_template.name",
+                "llm.prompt_template.name"
+              ],
+              "target": "neatlogs.llm.prompt_template.name"
+            },
             "template": {
               "sources": [
                 "neatlogs.prompt.template",

--- a/neatlogs/core/context.py
+++ b/neatlogs/core/context.py
@@ -220,6 +220,7 @@ def trace(
             c = set_value("neatlogs.system_prompt_variables", variables_json, context=c)
         if template_string:
             c = set_value("neatlogs.system_prompt_template", template_string, context=c)
+            c = set_value("neatlogs.system_prompt_name", name.strip(), context=c)
         if user_variables_json:
             c = set_value("neatlogs.user_prompt_variables", user_variables_json, context=c)
         if user_template_string:

--- a/neatlogs/core/context.py
+++ b/neatlogs/core/context.py
@@ -220,7 +220,7 @@ def trace(
             c = set_value("neatlogs.system_prompt_variables", variables_json, context=c)
         if template_string:
             c = set_value("neatlogs.system_prompt_template", template_string, context=c)
-            c = set_value("neatlogs.system_prompt_name", name.strip(), context=c)
+            c = set_value("neatlogs.system_prompt_key", name.strip(), context=c)
         if user_variables_json:
             c = set_value("neatlogs.user_prompt_variables", user_variables_json, context=c)
         if user_template_string:

--- a/neatlogs/core/span_processor.py
+++ b/neatlogs/core/span_processor.py
@@ -308,6 +308,7 @@ class NeatlogsSpanProcessor(SpanProcessor):
             ctx = get_current()
             variables_json = get_value("neatlogs.system_prompt_variables", context=ctx)
             template = get_value("neatlogs.system_prompt_template", context=ctx)
+            template_name = get_value("neatlogs.system_prompt_name", context=ctx)
             version_val = get_value("neatlogs.prompt_version", context=ctx)
 
             if not variables_json:
@@ -345,6 +346,8 @@ class NeatlogsSpanProcessor(SpanProcessor):
                 span.set_attribute("llm.prompt_template_variables", variables_json)
             if template:
                 span.set_attribute("llm.prompt_template", template)
+                if template_name:
+                    span.set_attribute("llm.prompt_template.name", template_name)
             if version_val:
                 span.set_attribute("llm.prompt_template.version", version_val)
             if user_template:
@@ -465,6 +468,7 @@ class NeatlogsSpanProcessor(SpanProcessor):
                     "neatlogs.llm.prompt_template",
                     "neatlogs.llm.prompt_template_variables",
                     "neatlogs.llm.prompt_template.version",
+                    "neatlogs.llm.prompt_template.name",
                 ):
                     unified_attrs.pop(k, None)
 

--- a/neatlogs/core/span_processor.py
+++ b/neatlogs/core/span_processor.py
@@ -309,7 +309,7 @@ class NeatlogsSpanProcessor(SpanProcessor):
             ctx = get_current()
             variables_json = get_value("neatlogs.system_prompt_variables", context=ctx)
             template = get_value("neatlogs.system_prompt_template", context=ctx)
-            template_name = get_value("neatlogs.system_prompt_name", context=ctx)
+            prompt_key = get_value("neatlogs.system_prompt_key", context=ctx)
             version_val = get_value("neatlogs.prompt_version", context=ctx)
 
             if not variables_json:
@@ -347,8 +347,11 @@ class NeatlogsSpanProcessor(SpanProcessor):
                 span.set_attribute("llm.prompt_template_variables", variables_json)
             if template:
                 span.set_attribute("llm.prompt_template", template)
-                if template_name:
-                    span.set_attribute("llm.prompt_template.name", template_name)
+                existing_prompt_key = (span.attributes or {}).get("neatlogs.llm.prompt_key") or (
+                    span.attributes or {}
+                ).get("traceloop.prompt.key")
+                if prompt_key and not existing_prompt_key:
+                    span.set_attribute("neatlogs.llm.prompt_key", prompt_key)
             if version_val:
                 span.set_attribute("llm.prompt_template.version", version_val)
             if user_template:
@@ -469,7 +472,7 @@ class NeatlogsSpanProcessor(SpanProcessor):
                     "neatlogs.llm.prompt_template",
                     "neatlogs.llm.prompt_template_variables",
                     "neatlogs.llm.prompt_template.version",
-                    "neatlogs.llm.prompt_template.name",
+                    "neatlogs.llm.prompt_key",
                 ):
                     unified_attrs.pop(k, None)
 

--- a/tests/unit/test_prompt_template_name.py
+++ b/tests/unit/test_prompt_template_name.py
@@ -28,9 +28,7 @@ def pipeline():
 
 
 def llm(tracer, name="chat.completions"):
-    with tracer.start_as_current_span(
-        name, attributes={"openinference.span.kind": "LLM"}
-    ):
+    with tracer.start_as_current_span(name, attributes={"openinference.span.kind": "LLM"}):
         pass
 
 
@@ -66,8 +64,7 @@ def test_nested_context_restores_outer_identity_and_ignores_group_names(pipeline
     llm(tracer, "chat.after")
     names = {s.name: s.attributes.get(KEY) for s in exporter.get_finished_spans()}
     assert {
-        key: names[key]
-        for key in ("chat.group", "chat.inner", "chat.outer", "chat.after")
+        key: names[key] for key in ("chat.group", "chat.inner", "chat.outer", "chat.after")
     } == {
         "chat.group": "outer",
         "chat.inner": "inner",
@@ -97,9 +94,7 @@ def test_canonical_system_keyword_wins_over_legacy_alias(pipeline):
     tracer, exporter = pipeline
     with trace("canonical", system_prompt_template="New", prompt_template="Old"):
         llm(tracer)
-    child = next(
-        s for s in exporter.get_finished_spans() if s.name == "chat.completions"
-    )
+    child = next(s for s in exporter.get_finished_spans() if s.name == "chat.completions")
     assert child.attributes[KEY] == "canonical"
     assert child.attributes["neatlogs.llm.prompt_template"] == "New"
 
@@ -110,9 +105,7 @@ def test_exception_restores_outer_identity(pipeline):
         with pytest.raises(ValueError), trace("inner", system_prompt_template="Inner"):
             raise ValueError("test")
         llm(tracer)
-    child = next(
-        s for s in exporter.get_finished_spans() if s.name == "chat.completions"
-    )
+    child = next(s for s in exporter.get_finished_spans() if s.name == "chat.completions")
     assert child.attributes[KEY] == "outer"
 
 
@@ -123,9 +116,7 @@ def test_new_template_with_empty_name_does_not_borrow_outer_name(pipeline):
         trace("", system_prompt_template="Independent"),
     ):
         llm(tracer)
-    child = next(
-        s for s in exporter.get_finished_spans() if s.name == "chat.completions"
-    )
+    child = next(s for s in exporter.get_finished_spans() if s.name == "chat.completions")
     assert KEY not in child.attributes
     assert child.attributes["neatlogs.llm.prompt_template"] == "Independent"
 
@@ -192,8 +183,6 @@ def test_streaming_child_keeps_identity_for_its_full_lifecycle(pipeline):
     ):
         for chunk in ("first", "second"):
             child.add_event("chunk", {"text": chunk})
-    child = next(
-        s for s in exporter.get_finished_spans() if s.name == "chat.completions.stream"
-    )
+    child = next(s for s in exporter.get_finished_spans() if s.name == "chat.completions.stream")
     assert child.attributes[KEY] == "streaming"
     assert len(child.events) == 2

--- a/tests/unit/test_prompt_template_name.py
+++ b/tests/unit/test_prompt_template_name.py
@@ -11,7 +11,7 @@ from neatlogs._wrap_utils import get_provider_tracer, set_neatlogs_provider
 from neatlogs.core.context import trace
 from neatlogs.core.span_processor import NeatlogsSpanProcessor
 
-KEY = "neatlogs.llm.prompt_template.name"
+KEY = "neatlogs.llm.prompt_key"
 
 
 @pytest.fixture
@@ -27,8 +27,9 @@ def pipeline():
     provider.shutdown()
 
 
-def llm(tracer, name="chat.completions"):
-    with tracer.start_as_current_span(name, attributes={"openinference.span.kind": "LLM"}):
+def llm(tracer, name="chat.completions", attributes=None):
+    span_attributes = {"openinference.span.kind": "LLM", **(attributes or {})}
+    with tracer.start_as_current_span(name, attributes=span_attributes):
         pass
 
 
@@ -97,6 +98,15 @@ def test_canonical_system_keyword_wins_over_legacy_alias(pipeline):
     child = next(s for s in exporter.get_finished_spans() if s.name == "chat.completions")
     assert child.attributes[KEY] == "canonical"
     assert child.attributes["neatlogs.llm.prompt_template"] == "New"
+
+
+@pytest.mark.parametrize("attribute", ["neatlogs.llm.prompt_key", "traceloop.prompt.key"])
+def test_existing_wire_prompt_key_wins_over_trace_name(pipeline, attribute):
+    tracer, exporter = pipeline
+    with trace("wrapper-name", system_prompt_template="Template"):
+        llm(tracer, attributes={attribute: "provider-key"})
+    child = next(s for s in exporter.get_finished_spans() if s.name == "chat.completions")
+    assert child.attributes[KEY] == "provider-key"
 
 
 def test_exception_restores_outer_identity(pipeline):

--- a/tests/unit/test_prompt_template_name.py
+++ b/tests/unit/test_prompt_template_name.py
@@ -1,0 +1,199 @@
+"""Prompt family identity crosses real trace context and normalization boundaries."""
+
+import asyncio
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from neatlogs._wrap_utils import get_provider_tracer, set_neatlogs_provider
+from neatlogs.core.context import trace
+from neatlogs.core.span_processor import NeatlogsSpanProcessor
+
+KEY = "neatlogs.llm.prompt_template.name"
+
+
+@pytest.fixture
+def pipeline():
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(
+        NeatlogsSpanProcessor(emit_completion_markers=False, own_all_spans=True)
+    )
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_neatlogs_provider(provider)
+    yield get_provider_tracer(), exporter
+    provider.shutdown()
+
+
+def llm(tracer, name="chat.completions"):
+    with tracer.start_as_current_span(
+        name, attributes={"openinference.span.kind": "LLM"}
+    ):
+        pass
+
+
+@pytest.mark.parametrize("keyword", ["system_prompt_template", "prompt_template"])
+def test_named_system_template_reaches_normalized_llm_child(pipeline, keyword):
+    tracer, exporter = pipeline
+    with trace("review-document", **{keyword: "Review {{document}}"}):
+        llm(tracer)
+    spans = exporter.get_finished_spans()
+    child = next(s for s in spans if s.name == "chat.completions")
+    assert child.attributes[KEY] == "review-document"
+    assert child.attributes["neatlogs.llm.prompt_template"] == "Review {{document}}"
+    assert all(KEY not in s.attributes for s in spans if s is not child)
+
+
+def test_name_only_and_user_only_trace_do_not_create_system_prompt_identity(pipeline):
+    tracer, exporter = pipeline
+    with trace("group"):
+        llm(tracer)
+    with trace("user-only", user_prompt_template="Question {{question}}"):
+        llm(tracer)
+    assert all(KEY not in span.attributes for span in exporter.get_finished_spans())
+
+
+def test_nested_context_restores_outer_identity_and_ignores_group_names(pipeline):
+    tracer, exporter = pipeline
+    with trace("outer", system_prompt_template="Outer"):
+        with trace("group"):
+            llm(tracer, "chat.group")
+        with trace("inner", system_prompt_template="Inner"):
+            llm(tracer, "chat.inner")
+        llm(tracer, "chat.outer")
+    llm(tracer, "chat.after")
+    names = {s.name: s.attributes.get(KEY) for s in exporter.get_finished_spans()}
+    assert {
+        key: names[key]
+        for key in ("chat.group", "chat.inner", "chat.outer", "chat.after")
+    } == {
+        "chat.group": "outer",
+        "chat.inner": "inner",
+        "chat.outer": "outer",
+        "chat.after": None,
+    }
+
+
+def test_async_tasks_keep_independent_prompt_names(pipeline):
+    tracer, exporter = pipeline
+
+    async def run(name):
+        with trace(name, system_prompt_template="Shared"):
+            await asyncio.sleep(0)
+            llm(tracer, "chat." + name)
+
+    async def both():
+        await asyncio.gather(run("first"), run("second"))
+
+    asyncio.run(both())
+    names = {s.name: s.attributes.get(KEY) for s in exporter.get_finished_spans()}
+    assert names["chat.first"] == "first"
+    assert names["chat.second"] == "second"
+
+
+def test_canonical_system_keyword_wins_over_legacy_alias(pipeline):
+    tracer, exporter = pipeline
+    with trace("canonical", system_prompt_template="New", prompt_template="Old"):
+        llm(tracer)
+    child = next(
+        s for s in exporter.get_finished_spans() if s.name == "chat.completions"
+    )
+    assert child.attributes[KEY] == "canonical"
+    assert child.attributes["neatlogs.llm.prompt_template"] == "New"
+
+
+def test_exception_restores_outer_identity(pipeline):
+    tracer, exporter = pipeline
+    with trace("outer", system_prompt_template="Outer"):
+        with pytest.raises(ValueError), trace("inner", system_prompt_template="Inner"):
+            raise ValueError("test")
+        llm(tracer)
+    child = next(
+        s for s in exporter.get_finished_spans() if s.name == "chat.completions"
+    )
+    assert child.attributes[KEY] == "outer"
+
+
+def test_new_template_with_empty_name_does_not_borrow_outer_name(pipeline):
+    tracer, exporter = pipeline
+    with (
+        trace("outer", system_prompt_template="Outer"),
+        trace("", system_prompt_template="Independent"),
+    ):
+        llm(tracer)
+    child = next(
+        s for s in exporter.get_finished_spans() if s.name == "chat.completions"
+    )
+    assert KEY not in child.attributes
+    assert child.attributes["neatlogs.llm.prompt_template"] == "Independent"
+
+
+def test_template_object_and_auto_root_preserve_prompt_identity(pipeline):
+    from neatlogs import PromptTemplate
+
+    tracer, exporter = pipeline
+    with trace(
+        "named-object",
+        kind="TOOL",
+        system_prompt_template=PromptTemplate("Review {{document}}"),
+    ):
+        llm(tracer)
+    spans = exporter.get_finished_spans()
+    child = next(s for s in spans if s.name == "chat.completions")
+    assert child.attributes[KEY] == "named-object"
+    roots = [s for s in spans if s.attributes.get("neatlogs.auto_root") is True]
+    assert len(roots) == 1
+    wrapper = next(s for s in spans if s.name == "named-object")
+    assert wrapper.parent.span_id == roots[0].context.span_id
+    assert child.parent.span_id == wrapper.context.span_id
+    assert KEY not in roots[0].attributes
+
+
+def test_prompt_identity_trims_name_without_renaming_the_trace_span(pipeline):
+    tracer, exporter = pipeline
+    with trace("  named prompt  ", system_prompt_template="Template"):
+        llm(tracer)
+    spans = exporter.get_finished_spans()
+    child = next(s for s in spans if s.name == "chat.completions")
+    assert child.attributes[KEY] == "named prompt"
+    assert any(s.name == "  named prompt  " for s in spans)
+
+
+def test_thread_contexts_keep_names_separate(pipeline):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    tracer, exporter = pipeline
+    barrier = Barrier(2)
+
+    def run(name):
+        with trace(name, system_prompt_template="Shared"):
+            barrier.wait(timeout=5)
+            llm(tracer, "chat." + name)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(run, name) for name in ("first", "second")]
+        for future in futures:
+            future.result(timeout=10)
+    names = {s.name: s.attributes.get(KEY) for s in exporter.get_finished_spans()}
+    assert names["chat.first"] == "first"
+    assert names["chat.second"] == "second"
+
+
+def test_streaming_child_keeps_identity_for_its_full_lifecycle(pipeline):
+    tracer, exporter = pipeline
+    with (
+        trace("streaming", system_prompt_template="Template"),
+        tracer.start_as_current_span(
+            "chat.completions.stream", attributes={"openinference.span.kind": "LLM"}
+        ) as child,
+    ):
+        for chunk in ("first", "second"):
+            child.add_event("chunk", {"text": chunk})
+    child = next(
+        s for s in exporter.get_finished_spans() if s.name == "chat.completions.stream"
+    )
+    assert child.attributes[KEY] == "streaming"
+    assert len(child.events) == 2


### PR DESCRIPTION
## Summary

`neatlogs.trace(name=..., system_prompt_template=...)` already carries prompt template content, variables, and version to auto-instrumented child LLM spans, but it dropped the stable prompt identity. Generic provider span names then caused the backend to group independent prompt families together.

This change propagates the trimmed prompt-bearing trace name through the existing cross-SDK `neatlogs.llm.prompt_key` contract. It introduces no new public SDK argument or Python-only wire attribute.

## What changed

- Carry the prompt key in the existing OTel prompt context only when a system template is supplied.
- Emit `neatlogs.llm.prompt_key` only on LLM descendants that receive that template.
- Preserve an identity already supplied by the instrumented LLM span through either `neatlogs.llm.prompt_key` or `traceloop.prompt.key`.
- Preserve nested scope restoration, async/thread isolation, exception cleanup, streaming span lifetime, deprecated `prompt_template=` support, and current auto-root behavior.
- Leave general trace scopes, user-template-only scopes, and non-LLM spans without an exported prompt identity.

## Impact

- **SDK users:** no API change; existing instrumentation continues to work.
- **Backend:** companion [neatlogs-app PR #1326](https://github.com/neatlogs/neatlogs-app/pull/1326) consumes the established canonical key and retains fallback behavior for older SDKs.
- **Data:** no schema migration or client-side database identifier.
- **Security/privacy:** only the existing trace scope name is used as prompt identity; prompt content handling is unchanged.
- **Cross-SDK contract:** uses the canonical attribute already shared by Python, TypeScript, and Go.

## Verification

- Full current SDK unit suite: 498 passed, 3 optional skips.
- Prompt identity suite: 14 cases, including existing-key precedence, normalization, nesting, empty names, exceptions, auto-root, async tasks, threads, and streaming.
- Prompt suite passed on Python 3.10, 3.11, 3.12, and 3.13.
- Black and isort checks passed for the changed Python files.
- Source distribution and wheel built successfully.
- Built-wheel prompt-contract smoke passed on Python 3.10 and 3.13.

## Rollout

Merge and deploy the backward-compatible backend consumer first. Release this SDK second, then run the dev-only Google GenAI multi-agent canary before customer adoption. An older backend ignores the additional canonical attribute, while an older SDK continues to use the backend fallback.

Tracks [NL-1776](https://linear.app/neatlogs/issue/NL-1776).
