### PR TITLE
fix: honor NEATLOGS_ENDPOINT in init()

### DIFF
--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -232,6 +232,21 @@ def _serialize_init(func):
     return wrapped
 
 
+def _resolve_init_endpoint(endpoint: Optional[str]) -> str:
+    """Resolve the ingest endpoint: explicit ``endpoint=`` wins, then the
+    NEATLOGS_ENDPOINT env var, then the production default.
+
+    Matches the Go SDK's Config.Endpoint fallback and the doctor/wrapper
+    paths, which already honor NEATLOGS_ENDPOINT.
+    """
+
+    explicit = (endpoint or "").strip()
+    if explicit:
+        return explicit
+    from_env = (os.environ.get("NEATLOGS_ENDPOINT") or "").strip()
+    return from_env or DEFAULT_INGEST_ENDPOINT
+
+
 def _configuration_signature(**values):
     api_key = values.pop("api_key")
     resolved_key = str(api_key).strip() if api_key is not None else ""
@@ -260,7 +275,7 @@ def _configuration_signature(**values):
 @_serialize_init
 def init(
     api_key: Optional[str] = None,
-    endpoint: str = DEFAULT_INGEST_ENDPOINT,
+    endpoint: Optional[str] = None,
     workflow_name: Optional[str] = None,
     user_id: Optional[str] = None,
     tags: Optional[List[str]] = None,
@@ -288,7 +303,9 @@ def init(
 
     Args:
         api_key: Neatlogs API key (or set NEATLOGS_API_KEY env var)
-        endpoint: Neatlogs backend endpoint
+        endpoint: Neatlogs backend endpoint (falls back to the NEATLOGS_ENDPOINT
+                 env var, then https://ingest.neatlogs.com; an explicit value
+                 wins over the env var)
         workflow_name: Logical grouping for traces
         user_id: Operator identifier — whoever is RUNNING the SDK (a developer, a
                  service account, the OS user). Propagates to all spans as a
@@ -365,6 +382,8 @@ def init(
     uploads_enabled_resolved = resolve_uploads_enabled(
         uploads_enabled, os.getenv("NEATLOGS_UPLOADS_ENABLED")
     )
+    endpoint = _resolve_init_endpoint(endpoint)
+
     candidate_signature = _configuration_signature(
         api_key=api_key,
         endpoint=endpoint,

--- a/tests/unit/test_init_endpoint_env.py
+++ b/tests/unit/test_init_endpoint_env.py
@@ -1,0 +1,84 @@
+import pytest
+
+import neatlogs
+from neatlogs.constants import DEFAULT_INGEST_ENDPOINT
+from neatlogs.errors import NeatlogsConfigurationError
+from neatlogs.init import _resolve_init_endpoint
+
+
+@pytest.fixture(autouse=True)
+def _clean_endpoint_env(monkeypatch):
+    monkeypatch.delenv("NEATLOGS_ENDPOINT", raising=False)
+    yield
+
+
+def test_explicit_endpoint_wins_over_env(monkeypatch):
+    monkeypatch.setenv("NEATLOGS_ENDPOINT", "https://dev-cloud.neatlogs.com")
+    assert _resolve_init_endpoint("https://staging.neatlogs.com") == "https://staging.neatlogs.com"
+
+
+def test_env_used_when_no_explicit_endpoint(monkeypatch):
+    monkeypatch.setenv("NEATLOGS_ENDPOINT", "https://dev-cloud.neatlogs.com")
+    assert _resolve_init_endpoint(None) == "https://dev-cloud.neatlogs.com"
+    assert _resolve_init_endpoint("") == "https://dev-cloud.neatlogs.com"
+    assert _resolve_init_endpoint("   ") == "https://dev-cloud.neatlogs.com"
+
+
+def test_default_when_no_explicit_or_env():
+    assert _resolve_init_endpoint(None) == DEFAULT_INGEST_ENDPOINT
+    assert _resolve_init_endpoint("") == DEFAULT_INGEST_ENDPOINT
+
+
+def test_init_with_env_endpoint_is_idempotent_with_explicit_same(monkeypatch):
+    monkeypatch.setenv("NEATLOGS_ENDPOINT", "https://dev-cloud.neatlogs.com")
+    neatlogs.init(
+        api_key="key-a",
+        workflow_name="endpoint-env",
+        disable_export=True,
+        register_shutdown_handlers=False,
+    )
+    # Same effective configuration via explicit endpoint: must not raise.
+    neatlogs.init(
+        api_key="key-a",
+        endpoint="https://dev-cloud.neatlogs.com",
+        workflow_name="endpoint-env",
+        disable_export=True,
+        register_shutdown_handlers=False,
+    )
+    assert neatlogs.shutdown()
+
+
+def test_init_conflicting_endpoint_still_typed_error(monkeypatch):
+    monkeypatch.setenv("NEATLOGS_ENDPOINT", "https://dev-cloud.neatlogs.com")
+    neatlogs.init(
+        api_key="key-a",
+        workflow_name="endpoint-env",
+        disable_export=True,
+        register_shutdown_handlers=False,
+    )
+    with pytest.raises(NeatlogsConfigurationError, match="different configuration"):
+        neatlogs.init(
+            api_key="key-a",
+            endpoint="https://staging.neatlogs.com",
+            workflow_name="endpoint-env",
+            disable_export=True,
+            register_shutdown_handlers=False,
+        )
+    assert neatlogs.shutdown()
+
+
+def test_init_without_env_still_defaults_to_prod():
+    neatlogs.init(
+        api_key="key-a",
+        workflow_name="endpoint-env-default",
+        disable_export=True,
+        register_shutdown_handlers=False,
+    )
+    neatlogs.init(
+        api_key="key-a",
+        endpoint=DEFAULT_INGEST_ENDPOINT,
+        workflow_name="endpoint-env-default",
+        disable_export=True,
+        register_shutdown_handlers=False,
+    )
+    assert neatlogs.shutdown()


### PR DESCRIPTION
## Summary
- resolve the ingest endpoint in `init()` as explicit `endpoint` > `NEATLOGS_ENDPOINT` > production default, matching the Go SDK's `Config.Endpoint` fallback and the doctor/wrapper paths that already honor the env var
- previously `init()` silently ignored `NEATLOGS_ENDPOINT`, so a doctor probe could pass against one backend while the app silently exported to another
- resolution happens before the configuration signature, so idempotent re-init semantics are unchanged

## Validation
- new `tests/unit/test_init_endpoint_env.py` (6 tests: precedence, env fallback, prod default, idempotent re-init, conflicting-config error)
- full unit suite: 499 passed, 4 skipped
- live check: `NEATLOGS_ENDPOINT` pointed at a local capture server and spans arrived there (pre-fix: zero requests, export went to prod)