### PR TITLE
fix: mask returning None drops the span entirely

### DIFF
--- a/neatlogs/core/mask.py
+++ b/neatlogs/core/mask.py
@@ -2,8 +2,9 @@
 PII masking support for Neatlogs spans.
 
 Users supply a callable that receives the full span dict and returns
-the (possibly modified) span dict. The callable is responsible for
-traversing and redacting any sensitive fields.
+the (possibly modified) span dict. Returning None drops the span
+entirely. The callable is responsible for traversing and redacting any
+sensitive fields.
 
 Example::
 
@@ -34,11 +35,12 @@ def register_mask(fn: Callable) -> str:
 def apply_mask(
     span_data: Dict[str, Any],
     global_mask: Optional[Callable],
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """Apply the effective mask callable to *span_data*.
 
     Per-span mask (stored in ``attributes["neatlogs.mask_id"]``) takes
-    precedence over the global mask.  Returns the (possibly modified) dict.
+    precedence over the global mask.  Returns the (possibly modified) dict,
+    or None when the mask dropped the span.
     """
     mask_id = (span_data.get("attributes") or {}).get("neatlogs.mask_id")
     mask_fn: Optional[Callable] = None
@@ -53,7 +55,7 @@ def apply_mask(
         return span_data
 
     result = mask_fn(span_data)
-    return result if result is not None else span_data
+    return result
 
 
 def effective_mask(span_data: Dict[str, Any], global_mask: Optional[Callable]):

--- a/neatlogs/core/masking_exporter.py
+++ b/neatlogs/core/masking_exporter.py
@@ -188,7 +188,9 @@ class _MaskRunner:
                 break
             active.pop(index, None)
             if succeeded and result is None:
-                results[index] = candidate
+                # A mask returning None drops the item entirely, matching the
+                # documented contract in the TypeScript and Go SDKs.
+                results[index] = None
             elif succeeded and isinstance(result, Mapping):
                 results[index] = dict(result)
             elif succeeded:

--- a/neatlogs/init.py
+++ b/neatlogs/init.py
@@ -332,6 +332,7 @@ def init(
                    Default: "INFO".
         mask: Optional callable applied to every span dict before export.
               Receives the full span dict and must return the (possibly modified) dict.
+              Return None to drop the span entirely.
               Use this to redact PII from inputs, outputs, and attributes.
               Per-span masks (set via @span(mask=fn) or with trace(..., mask=fn))
               take precedence over this global mask.

--- a/tests/unit/test_mask_application.py
+++ b/tests/unit/test_mask_application.py
@@ -258,3 +258,38 @@ def test_masking_log_exporter_force_flush_supports_legacy_exporters():
     assert exporter.force_flush() is True
 
     exporter.shutdown()
+
+
+def test_mask_returning_none_drops_the_span():
+    def mask(_snapshot):
+        return None
+
+    provider, inner = _pipeline(mask)
+    span = provider.get_tracer("neatlogs.test").start_span("child")
+    span.set_attribute("openinference.span.kind", "CHAIN")
+    span.set_attribute("input.value", "SECRET")
+    span.end()
+    provider.shutdown()
+
+    assert inner.get_finished_spans() == ()
+
+
+def test_mask_returning_none_drops_the_log():
+    def mask(_snapshot):
+        return None
+
+    provider = LoggerProvider()
+    inner = InMemoryLogRecordExporter()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(MaskingLogExporter(inner, mask)))
+    provider.get_logger("test").emit(body="must-not-export")
+    provider.shutdown()
+
+    assert inner.get_finished_logs() == ()
+
+
+def test_runner_returns_none_when_mask_returns_none():
+    runner = _MaskRunner()
+    try:
+        assert runner.apply(lambda _snapshot: None, {"signal": "span", "attributes": {}}) is None
+    finally:
+        runner.shutdown()


### PR DESCRIPTION
## What
The TypeScript and Go SDKs document that a mask returning null/nil drops the span, and their exporters honor it. The Python exporter treated None as "no change" and exported the original span unmasked - a user porting the documented drop behavior to Python leaks the very data the mask was meant to suppress. Surfaced in the SDK launch readiness thread with a same-input repro across all three published SDKs (ts 1.1.20 drops it, go v0.1.8 drops it, py 1.4.22 ships it in cleartext).

## Fix
_MaskRunner.apply_many now keeps the None result instead of substituting the original candidate. Both export paths (spans and logs) already translate a None result into a dropped item, with diagnostics and the on_dropped callback firing. apply_mask and the init() docstring are aligned with the same contract.

## Tests
3 new regression tests (span drop, log drop, runner-level None) fail on the pre-fix code and pass after. Full unit suite: 502 passed, 4 skipped. Pinned black 26.1.0 + isort 7.0.0 checks clean.