### PR TITLE
chore: release Python SDK 1.4.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neatlogs"
-version = "1.4.22"
+version = "1.4.23"
 description = "A Python package for extracting and managing LLM logs to build a collaborative workspace"
 readme = "README.MD"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -4258,7 +4258,7 @@ wheels = [
 
 [[package]]
 name = "neatlogs"
-version = "1.4.22"
+version = "1.4.23"
 source = { editable = "." }
 dependencies = [
     { name = "agnost" },


### PR DESCRIPTION
## Summary

- bump the Python SDK version from 1.4.22 to 1.4.23
- keep the project version synchronized in `pyproject.toml` and `uv.lock`
- no dependency versions changed

## Verification

- `uv lock --check`
- Black over complete `neatlogs/` and `tests/`
- isort over complete `neatlogs/` and `tests/`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_asyncio.plugin -q` (`508 passed, 3 skipped`)
- `git diff --check`

## Release

PyPI publication will use clean-built artifacts only after this PR is merged and the merged `main` SHA is reverified.